### PR TITLE
new import-include proposal

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-recursive-include include *.h
 include buildbot.json
 include LICENSE
 include README.rst


### PR DESCRIPTION
Please check new idea for getting rid of shipping C headers of dependencies. As far as I can tell with this technique the only drawback is that on first install from a source distribution pip's default wheel building/caching process causes a non-fatal error. This seems better than potentially shipping incompatible headers.
