### PR TITLE
Fix termcolor dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ def setup_package():
                 'plac>=0.9.6,<1.0.0',
                 'six>=1.10.0,<2.0.0',
                 'dill',
+                'termcolor',
                 'pathlib>=1.0.0,<2.0.0'
             ],
             classifiers=[


### PR DESCRIPTION
This bug is hidden because `termcolor` is listed in `requirements.txt`, used by travis, but not listed in `setup.py`. See below the `ImportError` on a fresh `pip install thinc`:

```
$ python

In [4]: import thinc.check
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-4-e97ab0d72623> in <module>()
----> 1 import thinc.check

/Users/rolando/miniconda3/envs/tmp-test/lib/python3.5/site-packages/thinc/check.py in <module>()
      5 from numpy import ndarray
      6
----> 7 from .exceptions import UndefinedOperatorError, DifferentLengthError
      8 from .exceptions import ExpectedTypeError, ShapeMismatchError
      9 from .exceptions import OutsideRangeError

/Users/rolando/miniconda3/envs/tmp-test/lib/python3.5/site-packages/thinc/exceptions.py in <module>()
      4
      5 import traceback
----> 6 from termcolor import colored as color
      7
      8

ImportError: No module named 'termcolor'
```