### PR TITLE
Fix bug: gradient array in feed-forward model is not C-Contiguous

### DIFF
--- a/thinc/neural/_classes/feed_forward.py
+++ b/thinc/neural/_classes/feed_forward.py
@@ -1,6 +1,6 @@
 from .model import Model
 from ... import describe
-
+from numpy import ascontiguousarray
 
 def _run_child_hooks(model, X, y):
     for layer in model._layers:
@@ -39,6 +39,6 @@ class FeedForward(Model):
             for callback in reversed(callbacks):
                 if gradient is None or callback == None:
                     break
-                gradient = callback(gradient, sgd)
+                gradient = callback(ascontiguousarray(gradient), sgd)
             return gradient
         return X, continue_update


### PR DESCRIPTION
I tried to execute the script `thinc/examples/text-pair/glove_mwe_multipool_predict.py`, and I have encountered with an error:

```
/usr/lib/python3.6/site-packages/thinc/neural/_classes/maxout.py in finish_update(dX__bo, sgd)
     54 
     55         def finish_update(dX__bo, sgd=None):
---> 56             dX__bop = self.ops.backprop_maxout(dX__bo, which__bo, self.nP)
     57             self.d_b += dX__bop.sum(axis=0)

/usr/lib/python3.6/site-packages/thinc/neural/ops.pyx in thinc.neural.ops.NumpyOps.backprop_maxout (thinc/neural/ops.cpp:12005)()

/usr/lib/python3.6/site-packages/thinc/neural/ops.cpython-36m-x86_64-linux-gnu.so in View.MemoryView.memoryview_cwrapper (thinc/neural/ops.cpp:30499)()

/usr/lib/python3.6/site-packages/thinc/neural/ops.cpython-36m-x86_64-linux-gnu.so in View.MemoryView.memoryview.__cinit__ (thinc/neural/ops.cpp:26751)()

ValueError: ndarray is not C-contiguous
```
I have fixed this error by making the array given to `finish_update` C-contiguous in the callback function, and it worked for me. Perhaps some folks may also face this problem.