### PR TITLE
Add missing space in statement.

### DIFF
--- a/thinc/extra/_vendorized/keras_generic_utils.py
+++ b/thinc/extra/_vendorized/keras_generic_utils.py
@@ -134,7 +134,7 @@ class Progbar(object):
             eta = time_per_unit * (self.target - current)
             info = ''
             if current < self.target:
-                info += ' - ETA: %ds' % eta
+                info += ' - ETA: %ds ' % eta
             else:
                 info += ' - %ds' % (now - self.start)
             for k in self.unique_values:


### PR DESCRIPTION
The lack of space was triggering my OCD (and many others I suppose). 😄 

*Before:*
![screen shot 2018-03-19 at 18 39 44](https://user-images.githubusercontent.com/6146240/37612419-7b6e3cf6-2ba5-11e8-81e4-abb45bf5cbbd.png)

*After:*
![screen shot 2018-03-19 at 18 37 50](https://user-images.githubusercontent.com/6146240/37612416-7995f16c-2ba5-11e8-8f27-32f16429ccc7.png)

I know it's a small thing, but anyway, here it is. :)