### PR TITLE
Fixed readme gpu_ops import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,8 +213,8 @@ For GPU support, we're grateful to use the work of Chainer's cupy module, which 
     export PATH=$PATH:$CUDA_HOME/bin
     pip install chainer
     python -c "import cupy; assert cupy" # Check it installed
-    pip install thinc
-    python -c "import thinc.neural.gpu_ops" # Check the GPU ops were built
+    pip install thinc_gpu_ops thinc # Or `thinc[cuda]`
+    python -c "import thinc_gpu_ops" # Check the GPU ops were built
 
 The rest of this section describes how to build Thinc from source. If you have
 `Fabric <http://www.fabfile.org>`_ installed, you can use the shortcut:


### PR DESCRIPTION
The README shows to import `thinc.neural.gpu_ops` but this has forked in its own repository [thinc_gpu_ops](https://github.com/explosion/thinc_gpu_ops) and no `gpu_ops` module exists anymore.

```bash
(.thinc) ~ $ pip install thinc_gpu_ops-0.0.3-cp36-cp36m-linux_x86_64.whl cupy-4.5.0-cp36-cp36m-linux_x86_64.whl thinc-6.12.0-cp36-cp36m-linux_x86_64.whl
(.thinc) ~ $ python -c "import cupy; assert cupy" # Check it installed
(.thinc) ~ $ python -c "import thinc_gpu_ops as gpu_ops;" # Check the GPU ops were built
(.thinc) ~ $ 
(.thinc) ~ $ python -c "import thinc.neural.gpu_ops" # Check the GPU ops were built
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'thinc.neural.gpu_ops'
```