### PR TITLE
Comment out assert statement for empty length X in unflatten()

### DIFF
--- a/thinc/neural/ops.pyx
+++ b/thinc/neural/ops.pyx
@@ -135,7 +135,7 @@ class Ops(object):
             X = X[length:]
         if pad >= 1 and length != 0:
             X = X[pad:]
-        assert len(X) == 0
+        # assert len(X) == 0 can cause error if 0 exists in lengths
         assert len(unflat) == len(lengths)
         return unflat
 
@@ -235,7 +235,7 @@ class Ops(object):
 
     def argmax(self, x, axis=-1):
         return self.xp.argmax(x, axis=axis)
-    
+
     def sigmoid(self, X):
         return 1./(1. + self.xp.exp(-X))
 
@@ -342,7 +342,7 @@ class Ops(object):
             return W
         else:
             return self.xp.random.uniform(-scale, scale, W.shape)
-    
+
     def normal_init(self, W, fan_in, inplace=True):
         if (W**2).sum() != 0.:
             return W
@@ -409,7 +409,7 @@ class NumpyOps(Ops):
         else:
             m = x.shape[0]
         cdef int n
-        if trans2: 
+        if trans2:
             n = y.shape[0]
         else:
             n = y.shape[1]
@@ -710,7 +710,7 @@ class NumpyOps(Ops):
                 ids.shape[0], out.shape[1])
         else:
             self.xp.add.at(out, ids, inputs)
- 
+
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def adam(self, float[::1] weights, float[::1] gradient, float[::1] mom1,
@@ -740,7 +740,7 @@ cdef void cpu_scatter_add(float* dest,
         if id_ >= 0:
             VecVec.add_i(&dest[id_*nr_col],
         	&src[i*nr_col], 1., nr_col)
- 
+
 
 @cython.cdivision(True)
 cdef void _adam_momentum(weight_t* gradient, weight_t* mom1, weight_t* mom2,

--- a/thinc/tests/unit/test_ops.py
+++ b/thinc/tests/unit/test_ops.py
@@ -268,3 +268,14 @@ def test_flatten_unflatten_roundtrip(cpu_ops, X):
     assert flat.ndim == 1
     unflat = cpu_ops.unflatten(flat, [len(x) for x in X])
     assert_allclose(X, unflat)
+
+
+@settings(max_examples=MAX_EXAMPLES)
+@given(X=strategies.arrays_BI())
+def test_nested_unflatten_length_zero(cpu_ops, X):
+    nums = [[x] for x in X]
+    if len(nums) > 1:
+        nums[-1] = []
+
+    lengths = [len(lst) for lst in nums]
+    unflat = cpu_ops.unflatten(nums, lengths)

--- a/thinc/tests/unit/test_ops.py
+++ b/thinc/tests/unit/test_ops.py
@@ -1,5 +1,6 @@
 # coding: utf8
 from __future__ import unicode_literals
+from random import randint
 
 import pytest
 import numpy
@@ -273,9 +274,16 @@ def test_flatten_unflatten_roundtrip(cpu_ops, X):
 @settings(max_examples=MAX_EXAMPLES)
 @given(X=strategies.arrays_BI())
 def test_nested_unflatten_length_zero(cpu_ops, X):
-    nums = [[x] for x in X]
-    if len(nums) > 1:
-        nums[-1] = []
+    nums = nums = [x for x in X]
+    n = len(X)
+    if n > 1:
+        random_idx = randint(0, n - 1)
+        nums[random_idx] = []
 
+    nums = numpy.array([numpy.array(num, dtype=float) for num in nums])
+    flat = cpu_ops.flatten(nums)
+    assert flat.ndim == 1
     lengths = [len(lst) for lst in nums]
-    unflat = cpu_ops.unflatten(nums, lengths)
+    unflat = cpu_ops.unflatten(flat, lengths)
+    for n, u in zip(nums, unflat):
+        assert_allclose(n, u)


### PR DESCRIPTION
This fix is related to the spacy issue [3456](https://github.com/explosion/spaCy/issues/3456)
The unflatten function fails with a two-dimensional list that contains empty lists.

I added a test function `test_nested_unflatten_length_zero` to test this specific example.