### PR TITLE
Fix SyntaxError in try-except import cPickle Statement

### DIFF
--- a/thinc/extra/_vendorized/keras_datasets.py
+++ b/thinc/extra/_vendorized/keras_datasets.py
@@ -10,7 +10,7 @@ from .keras_data_utils import get_file
 
 try:
     import cPickle
-else:
+except:
     import pickle as cPickle
 
 


### PR DESCRIPTION
This doesnt follow the correct grammar of python, an 'except' is always
needed before an else in a try-except-else-finally statement.