### PR TITLE
Remove PyTorch and numpy calls from multi-headed attention

### DIFF
--- a/examples/attention_tagger.py
+++ b/examples/attention_tagger.py
@@ -167,8 +167,7 @@ def main(
                 >> Maxout(width, pieces=3), pad=0)
             >> PositionEncode(1000, width)
             >> flatten_add_lengths
-            >> MultiHeadedAttention(nM=width, nH=8)
-            >> with_getitem(0, LayerNorm(nO=width))
+            >> Residual(MultiHeadedAttention(nM=width, nH=1))
             >> unflatten
             >> with_flatten(Softmax(nr_tag))
         )

--- a/examples/attention_tagger.py
+++ b/examples/attention_tagger.py
@@ -12,7 +12,7 @@ from spacy.tokens.doc import Doc
 from thinc.i2v import HashEmbed
 from thinc.v2v import Model, Maxout, Softmax
 from thinc.t2t import ExtractWindow
-from thinc.neural._classes.multiheaded_attention import MultiHeadedAttention, SparseAttention, with_pad_and_mask
+from thinc.neural._classes.multiheaded_attention import MultiHeadedAttention
 from thinc.misc import Residual, LayerNorm
 from thinc.api import with_flatten, flatten_add_lengths, unflatten, with_getitem
 

--- a/examples/attention_tagger.py
+++ b/examples/attention_tagger.py
@@ -167,12 +167,10 @@ def main(
                 (lower_case | shape | prefix | suffix)
                 >> Maxout(width, width+(width//2)*3, pieces=3))
             >> PositionEncode(1000, width)
-            >> flatten_add_lengths
             >> Residual(
-                prepare_self_attention(Affine(width*3, width), window=6, nM=width, nH=4)
-                >> MultiHeadedAttention(nM=width, nH=4)
-                >> with_getitem(0, Affine(width, width))) 
-            >> unflatten
+                prepare_self_attention(Affine(width*3, width), nM=width, nH=4)
+                >> MultiHeadedAttention()
+                >> with_flatten(Affine(width, width)))
             >> with_flatten(Softmax(nr_tag, width))
         )
 

--- a/examples/attention_tagger.py
+++ b/examples/attention_tagger.py
@@ -13,8 +13,8 @@ from thinc.i2v import HashEmbed
 from thinc.v2v import Model, Maxout, Softmax
 from thinc.t2t import ExtractWindow
 from thinc.neural._classes.multiheaded_attention import MultiHeadedAttention, SparseAttention, with_pad_and_mask
-from thinc.misc import Residual
-from thinc.api import with_flatten
+from thinc.misc import Residual, LayerNorm
+from thinc.api import with_flatten, flatten_add_lengths, unflatten, with_getitem
 
 from thinc.api import layerize, chain, concatenate, clone, add
 from thinc.neural.util import to_categorical, prefer_gpu
@@ -49,6 +49,18 @@ def FeatureExtracter(lang, attrs=[LOWER, SHAPE, PREFIX, SUFFIX], tokenized=True)
     return layerize(forward)
 
 
+def PositionEncode(L, D):
+    positions = Model.ops.position_encode(L, D)
+    def position_encode_forward(Xs, drop=0.):
+        output = []
+        for x in Xs:
+            output.append(x + positions[:x.shape[0]])
+        def position_encode_backward(dYs, sgd=None):
+            return dYs
+        return output, position_encode_backward
+    return layerize(position_encode_forward)
+
+
 epoch_train_acc = 0.0
 
 
@@ -60,6 +72,7 @@ def track_progress(**context):
     trainer = context["trainer"]
     n_dev = len(dev_y)
     epoch_times = [timer()]
+    losses = context["losses"]
 
     def each_epoch():
         global epoch_train_acc
@@ -75,17 +88,18 @@ def track_progress(**context):
         stats = (
             acc,
             avg_acc,
-            float(epoch_train_acc) / n_train,
+            float(losses[-1]),
             trainer.dropout,
             wps_train,
             wps_run,
         )
         print(
-            "%.3f (%.3f) dev acc, %.3f train acc, %.4f drop, %d wps train, %d wps run"
+            "%.3f (%.3f) dev acc, %.3f train loss, %.4f drop, %d wps train, %d wps run"
             % stats
         )
         epoch_train_acc = 0.0
         epoch_times.append(timer())
+        losses.append(0.)
 
     return each_epoch
 
@@ -122,7 +136,7 @@ def debug(X, drop=0.0):
     L2=("L2 regularization penalty", "option", "L", float),
 )
 def main(
-    width=100,
+    width=128,
     depth=4,
     vector_length=64,
     min_batch_size=1,
@@ -150,10 +164,12 @@ def main(
         model = (
             with_flatten(
                 (lower_case | shape | prefix | suffix)
-                >> Maxout(width, pieces=3), pad=depth)
-            >> with_pad_and_mask(
-                MultiHeadedAttention(nM=width, nH=4)
-            )
+                >> Maxout(width, pieces=3), pad=0)
+            >> PositionEncode(1000, width)
+            >> flatten_add_lengths
+            >> MultiHeadedAttention(nM=width, nH=8)
+            >> with_getitem(0, LayerNorm(nO=width))
+            >> unflatten
             >> with_flatten(Softmax(nr_tag))
         )
 
@@ -162,6 +178,7 @@ def main(
 
     n_train = float(sum(len(x) for x in train_X))
     global epoch_train_acc
+    losses = [0.]
     with model.begin_training(train_X[:5000], train_y[:5000], **cfg) as (
         trainer,
         optimizer,
@@ -169,10 +186,12 @@ def main(
         trainer.each_epoch.append(track_progress(**locals()))
         trainer.batch_size = min_batch_size
         batch_size = float(min_batch_size)
+        trainer.dropout = 0.1
         for X, y in trainer.iterate(train_X, train_y):
             yh, backprop = model.begin_update(X, drop=trainer.dropout)
 
             gradient = [yh[i] - y[i] for i in range(len(yh))]
+            losses[-1] += sum((g**2).sum() for g in gradient)
 
             backprop(gradient, optimizer)
 

--- a/examples/imdb_attention.py
+++ b/examples/imdb_attention.py
@@ -6,7 +6,7 @@ from thinc.i2v import StaticVectors, HashEmbed
 from thinc.v2v import Model, Affine, Maxout, Softmax
 from thinc.t2t import ExtractWindow, ParametricAttention
 from thinc.t2t import MultiHeadedAttention, prepare_self_attention
-from thinc.t2v import Pooling, sum_pool
+from thinc.t2v import Pooling, sum_pool, mean_pool, max_pool
 from thinc.misc import LayerNorm as LN
 from thinc.misc import Residual
 
@@ -48,7 +48,7 @@ def build_model(nr_class, width, depth, conv_depth, vectors_name, **kwargs):
             )
             >> flatten_add_lengths
             >> ParametricAttention(width, hard=False)
-            >> Pooling(sum_pool)
+            >> Pooling(mean_pool)
             >> Residual(LN(Maxout(width)))
         )
 
@@ -61,7 +61,7 @@ def build_model(nr_class, width, depth, conv_depth, vectors_name, **kwargs):
             )
             >> flatten_add_lengths
             >> ParametricAttention(width, hard=False)
-            >> Pooling(sum_pool)
+            >> Pooling(mean_pool)
             >> Residual(LN(Maxout(width))) ** 2
             >> Softmax(nr_class)
         )

--- a/examples/imdb_attention.py
+++ b/examples/imdb_attention.py
@@ -1,0 +1,140 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+import tqdm
+from thinc.i2v import StaticVectors, HashEmbed
+from thinc.v2v import Model, Affine, Maxout, Softmax
+from thinc.t2t import ExtractWindow, ParametricAttention
+from thinc.t2t import MultiHeadedAttention, prepare_self_attention
+from thinc.t2v import Pooling, sum_pool
+from thinc.misc import LayerNorm as LN
+from thinc.misc import Residual
+
+from thinc.extra import datasets
+from thinc.extra.load_nlp import register_vectors
+from thinc.neural.util import to_categorical
+from thinc.api import layerize, chain, concatenate, clone
+from thinc.api import foreach, with_flatten, flatten_add_lengths, with_getitem
+from thinc.misc import FeatureExtracter
+import spacy
+from spacy.attrs import ORTH, LOWER, SHAPE, PREFIX, SUFFIX, ID
+
+from thinc.neural.ops import CupyOps
+from spacy.util import compounding
+
+
+@layerize
+def get_sents(docs, drop=0.0):
+    sents = [list(doc.sents) for doc in docs]
+    return sents, None
+
+
+def build_model(nr_class, width, depth, conv_depth, vectors_name, **kwargs):
+    with Model.define_operators({"|": concatenate, ">>": chain, "**": clone}):
+        embed = (
+            HashEmbed(width, 5000, column=1)
+            | StaticVectors(vectors_name, width, column=5)
+            | HashEmbed(width // 2, 750, column=2)
+            | HashEmbed(width // 2, 750, column=3)
+            | HashEmbed(width // 2, 750, column=4)
+        ) >> LN(Maxout(width))
+
+        sent2vec = (
+            with_flatten(embed)
+            >> Residual(
+                prepare_self_attention(Affine(width*3, width), nM=width, nH=4)
+                >> MultiHeadedAttention(nM=width, nH=4)
+                >> with_flatten(Affine(width, width))
+            )
+            >> flatten_add_lengths
+            >> ParametricAttention(width, hard=False)
+            >> Pooling(sum_pool)
+            >> Residual(LN(Maxout(width)))
+        )
+
+        model = (
+            foreach(sent2vec, drop_factor=2.0)
+            >> Residual(
+                prepare_self_attention(Affine(width*3, width), nM=width, nH=4)
+                >> MultiHeadedAttention(nM=width, nH=4)
+                >> with_flatten(Affine(width, width))
+            )
+            >> flatten_add_lengths
+            >> ParametricAttention(width, hard=False)
+            >> Pooling(sum_pool)
+            >> Residual(LN(Maxout(width))) ** depth
+            >> Softmax(nr_class)
+        )
+    model.lsuv = False
+    return model
+
+
+def main(use_gpu=False, nb_epoch=100):
+    if use_gpu:
+        Model.ops = CupyOps()
+        Model.Ops = CupyOps
+    train, test = datasets.imdb(limit=2000)
+    print("Load data")
+    train_X, train_y = zip(*train)
+    test_X, test_y = zip(*test)
+    train_y = Model.ops.asarray(to_categorical(train_y, nb_classes=2))
+    test_y = Model.ops.asarray(to_categorical(test_y, nb_classes=2))
+
+    nlp = spacy.load("en_vectors_web_lg")
+    nlp.add_pipe(nlp.create_pipe("sentencizer"), first=True)
+    register_vectors(Model.ops, nlp.vocab.vectors.name, nlp.vocab.vectors.data)
+
+    preprocessor = FeatureExtracter([ORTH, LOWER, PREFIX, SUFFIX, SHAPE, ID])
+    train_X = [preprocessor(list(doc.sents)) for doc in tqdm.tqdm(nlp.pipe(train_X))]
+    test_X = [preprocessor(list(doc.sents)) for doc in tqdm.tqdm(nlp.pipe(test_X))]
+
+    dev_X = train_X[-1000:]
+    dev_y = train_y[-1000:]
+    train_X = train_X[:-1000]
+    train_y = train_y[:-1000]
+    print("Parse data")
+    n_sent = sum([len(list(sents)) for sents in train_X])
+    print("%d sentences" % n_sent)
+
+    model = build_model(
+        2, vectors_name=nlp.vocab.vectors.name, width=128, conv_depth=2, depth=2, train_X=train_X, train_y=train_y
+    )
+    with model.begin_training(train_X[:100], train_y[:100]) as (trainer, optimizer):
+        epoch_loss = [0.0]
+
+        def report_progress():
+            with model.use_params(optimizer.averages):
+                print(
+                    epoch_loss[-1],
+                    epoch_var[-1],
+                    model.evaluate(dev_X, dev_y),
+                    trainer.dropout,
+                )
+            epoch_loss.append(0.0)
+            epoch_var.append(0.0)
+
+        trainer.each_epoch.append(report_progress)
+        batch_sizes = compounding(64, 64, 1.01)
+        trainer.dropout = 0.3
+        trainer.batch_size = int(next(batch_sizes))
+        trainer.dropout_decay = 0.0
+        trainer.nb_epoch = nb_epoch
+        # optimizer.alpha = 0.1
+        # optimizer.max_grad_norm = 10.0
+        # optimizer.b1 = 0.0
+        # optimizer.b2 = 0.0
+        epoch_var = [0.0]
+        for X, y in trainer.iterate(train_X, train_y):
+            yh, backprop = model.begin_update(X, drop=trainer.dropout)
+            losses = ((yh - y) ** 2.0).sum(axis=1) / y.shape[0]
+            epoch_var[-1] += losses.var()
+            loss = losses.mean()
+            backprop((yh - y) / yh.shape[0], optimizer)
+            epoch_loss[-1] += loss
+            trainer.batch_size = int(next(batch_sizes))
+        with model.use_params(optimizer.averages):
+            print("Avg dev.: %.3f" % model.evaluate(dev_X, dev_y))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/imdb_cnn.py
+++ b/examples/imdb_cnn.py
@@ -11,15 +11,15 @@ from thinc.misc import LayerNorm as LN
 from thinc.misc import Residual
 
 from thinc.extra import datasets
-from thinc.neural.util import to_categorical
+from thinc.neural.util import to_categorical, require_gpu
 from thinc.extra.load_nlp import register_vectors
 from thinc.api import layerize, chain, concatenate, clone
 from thinc.api import foreach, flatten_add_lengths, with_getitem
 from thinc.misc import FeatureExtracter
 import spacy
 from spacy.attrs import ORTH, LOWER, SHAPE, PREFIX, SUFFIX, ID
+from spacy.util import fix_random_seed
 
-from thinc.neural.ops import CupyOps
 from spacy.util import compounding
 
 
@@ -70,9 +70,9 @@ def build_model(nr_class, width, depth, conv_depth, vectors_name, **kwargs):
 
 
 def main(use_gpu=False, nb_epoch=100):
+    fix_random_seed(0)
     if use_gpu:
-        Model.ops = CupyOps()
-        Model.Ops = CupyOps
+        require_gpu()
     train, test = datasets.imdb(limit=2000)
     print("Load data")
     train_X, train_y = zip(*train)

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -471,3 +471,50 @@ def foreach_sentence(layer, drop_factor=1.0):
 
     model = wrap(sentence_fwd, layer)
     return model
+
+
+# This stuff was developed for the multi-headed attention.
+
+def with_pad_and_mask(layer):
+    def create_model_input_forward(Xs, drop=0.):
+        nX = model.ops.asarray([x.shape[0] for x in Xs], dtype='i')
+        nL = nX.max()
+        X, unpad_X = pad_sequences(model.ops, Xs, pad_to=nL)
+        X_mask = _get_mask(X, nX)
+        Y, bp_Y = layer.begin_update((X.astype("float32"), X_mask, None), drop=drop)
+        def create_model_input_backward(dYs, sgd=None):
+            dY, _ = pad_sequences(model.ops, dYs, pad_to=nL)
+            dX = bp_Y(dY, sgd=sgd)
+            return unpad_X(dX)
+        return unpad_X(Y), create_model_input_backward
+    model = layerize(create_model_input_forward)
+    return model
+
+
+def pad_sequences(ops, seqs_in, pad_to=None):
+    lengths = ops.asarray([len(seq) for seq in seqs_in], dtype='i')
+    nB = len(seqs_in)
+    if pad_to is None:
+        pad_to = lengths.max()
+    arr = ops.allocate((nB, int(pad_to)) + seqs_in[0].shape[1:], dtype=seqs_in[0].dtype)
+    for arr_i, seq in enumerate(seqs_in):
+        arr[arr_i, :seq.shape[0]] = ops.asarray(seq)
+    
+    def unpad(padded):
+        unpadded = [None] * len(lengths)
+        for i in range(padded.shape[0]):
+            unpadded[i] = padded[i, :lengths[i]]
+        return unpadded
+    return arr, unpad
+
+
+def _get_mask(X, nX):
+    nB = X.shape[0]
+    nL = X.shape[1]
+    X_mask = Model.ops.allocate((nB, nL, nL))
+    for i, length in enumerate(nX):
+        X_mask[i, :, :length] = 1.0
+    return X_mask
+
+
+

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -403,9 +403,13 @@ def foreach(layer, drop_factor=1.0):
         lengths = []
         for doc in docs:
             doc_sents = [sent for sent in doc if len(sent)]
-            subset = [
-                s for s in doc_sents if numpy.random.random() >= drop * drop_factor
-            ]
+            assert len(doc_sents)
+            if drop:
+                subset = [
+                    s for s in doc_sents if numpy.random.random() >= drop * drop_factor
+                ]
+            else:
+                subset = list(doc_sents)
             if subset:
                 sents.extend(subset)
                 lengths.append(len(subset))
@@ -413,6 +417,7 @@ def foreach(layer, drop_factor=1.0):
                 numpy.random.shuffle(doc_sents)
                 sents.append(doc_sents[0])
                 lengths.append(1)
+        assert len(sents)
         flat, bp_flat = layer.begin_update(sents, drop=0.0)
         output = layer.ops.unflatten(flat, lengths)
 

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -43,6 +43,17 @@ def flatten_add_lengths(seqs, pad=0, drop=0.0):
     X = ops.flatten(seqs, pad=pad)
     return (X, lengths), finish_update
 
+@layerize
+def unflatten(X_lengths, drop=0.):
+    ops = Model.ops
+    X, lengths = X_lengths
+    Xs = ops.unflatten(X, lengths)
+
+    def backprop_unflatten(dXs, sgd=None):
+        dX = ops.flatten(dXs, pad=0)
+        return dX
+
+    return Xs, backprop_unflatten
 
 def remap_ids(ops=None, column=0):
     id_map = {0: 0}

--- a/thinc/extra/load_nlp.py
+++ b/thinc/extra/load_nlp.py
@@ -14,6 +14,10 @@ def get_spacy(lang, **kwargs):
         SPACY_MODELS[lang] = spacy.load(lang, **kwargs)
     return SPACY_MODELS[lang]
 
+def register_vectors(ops, lang, data):
+    key = (ops.device, lang)
+    VECTORS[key] = data
+
 
 def get_vectors(ops, lang):
     global VECTORS

--- a/thinc/neural/_classes/layernorm.py
+++ b/thinc/neural/_classes/layernorm.py
@@ -19,9 +19,9 @@ def _init_to_one(W, ops):
 
 
 def _run_child_hooks(model, X, y=None):
-    for hook in model.child.on_data_hooks:
-        hook(model.child, X, y)
-    # model.nO = model.child.nO
+    if model.child:
+        for hook in model.child.on_data_hooks:
+            hook(model.child, X, y)
 
 
 @describe.on_data(_run_child_hooks)
@@ -81,8 +81,10 @@ class LayerNorm(Model):
             drop *= getattr(
                 self.child, "drop_factor", self.ops.asarray([1.0], dtype="f")
             )
+
         y, bp_dropout = self.ops.dropout(y, drop)
         assert y.dtype == "float32"
+
         return y, bp_dropout(finish_update)
 
     def _begin_update_scale_shift(self, input__BI):

--- a/thinc/neural/_classes/multiheaded_attention.py
+++ b/thinc/neural/_classes/multiheaded_attention.py
@@ -9,214 +9,7 @@ import copy
 import math
 
 
-class SparseAttention(Model):
-    """This class implements multiheaded attention in steps, factorizing
-    the attention matrix."""
-
-    def __init__(self, nM=300, nH=6):
-        self.nH = nH
-        self.nM = nM  # model size: the length of the embeddings
-        self.nD = nM // nH
-        self.get_queries = Affine(nM, nM)
-        self.get_keys = Affine(nM, nM)
-        self.get_values = Affine(nM, nM)
-        self.get_output = Affine(nM, nM)
-        self._layers = [
-            self.get_queries,
-            self.get_keys,
-            self.get_values,
-            self.get_output,
-        ]
-
-    def begin_update(self, input, drop=0.1):
-        if len(input) == 3:
-            x0, mask, sentX = input
-            sentY = sentX
-            y0 = x0
-            self_attention = True
-        else:
-            self_attention = False
-            x0, y0, mask, sentX, sentY = input
-        """ Shapes """
-        # x0: nB, nL, nM
-        # q0: nB, nL, nM
-        # k0: nB, nL, nM
-        # v0: nB, nL, nM
-        # q1: nB, nH, nL, nD
-        # k1: nB, nH, nL, nD
-        # v1: nB, nH, nL, nD
-        nB, nL, nD, nH = x0.shape[0], x0.shape[1], self.nD, self.nH
-        q0, get_dx0 = self.get_queries.begin_update(x0)
-        q1 = q0.reshape(nB, -1, self.nH, self.nD).transpose(0, 2, 1, 3)
-        k0, get_dy0_1 = self.get_keys.begin_update(y0)
-        k1 = k0.reshape(nB, -1, self.nH, self.nD).transpose(0, 2, 1, 3)
-        v0, get_dy0_2 = self.get_values.begin_update(y0)
-        v1 = v0.reshape(nB, -1, self.nH, self.nD).transpose(0, 2, 1, 3)
-        mask1 = mask.astype(Model.ops.xp.uint8) & self.mask_floor(nB, nL)
-        mask2 = mask.astype(Model.ops.xp.uint8) & self.mask_repetitive(nB, nL)
-        q2, get_dq1_dk1_dv1 = self.attn(
-            q1, k1, v1, mask=mask1, sentX=sentX, sentY=sentY, self_attn=self_attention
-        )
-        x1, get_dq2_dk1_dv1 = self.attn(
-            q1, k1, v1, mask=mask2, sentX=sentX, sentY=sentY, self_attn=self_attention
-        )
-
-        x2 = x1.transpose(0, 2, 1, 3).reshape((nB, nL, nH * nD))
-        x3, get_dx2 = self.get_output.begin_update(x2)
-
-        def finish_update(dx3, sgd=None):
-            dx2 = get_dx2(dx3, sgd=sgd)
-            dx1 = dx2.reshape((nB, nL, nH, nD)).transpose(0, 2, 1, 3)
-            dq2, dk11, dv11 = get_dq2_dk1_dv1(dx1)
-            dq1, dk12, dv12 = get_dq1_dk1_dv1(dq2)
-            dk1 = dk11 + dk12
-            dv1 = dv11 + dv12
-            nM = nH * nD
-            dq0 = dq1.transpose(0, 2, 1, 3).reshape((nB, nL, nM))
-            dk0 = dk1.transpose(0, 2, 1, 3).reshape((nB, nL, nM))
-            dv0 = dv1.transpose(0, 2, 1, 3).reshape((nB, nL, nM))
-            dy0 = get_dy0_2(dv0, sgd=sgd) + get_dy0_1(dk0, sgd=sgd)
-            dx0 = get_dx0(dq0, sgd=sgd)
-            if self_attention:
-                return dx0 + dy0
-            else:
-                return (dx0, dy0)
-
-        return x3, finish_update
-
-    def attn(self, Q, K, V, mask=None, sentX=None, sentY=None, self_attn=True):
-        """
-        Compute attention on (query, key, value) triplets.
-        The similarity of the (Q, K) pairs are used to
-        compute an attention matrix, which is used to rescale
-        V.
-        """
-        S0, bp_scaled_dp = self._scaled_dot_prod(Q, K)
-        S1, bp_mask = self._mask(S0, mask)
-        S2, bp_softmax = self._softmax(S1)
-        S3, bp_apply_attn = self._apply_attn(S2, V)
-
-        def backprop_attn(dS3):
-            """ Attention three inputs, one output """
-            dS2, dV = bp_apply_attn(dS3)
-            dS1 = bp_softmax(dS2)
-            dS0 = bp_mask(dS1)
-            dQ, dK = bp_scaled_dp(dS0)
-            return dQ, dK, dV
-
-        return S3, backprop_attn
-
-    def _scaled_dot_prod(self, Q0, K0):
-        # Q0: nB, nH, nL, nD
-        # K0: nB, nH, nL, nD
-        nB, nH, nL, nD = Q0.shape
-        # Q1: nB*nH, nL, nD
-        Q1 = Q0.reshape((nB * nH, nL, nD))
-        # K1: (nB*nH, nD, nL)
-        K1 = K0.transpose(0, 1, 3, 2).reshape((nB * nH, nD, nL))
-        # K2: (nB*nH, nD, nL)
-        K2 = (K1 / self.ops.xp.sqrt(self.nM)).astype("float32")
-        # S0: (nB*nH, nL, nL)
-        S0 = self.ops.matmul(self.ops.xp.ascontiguousarray(Q1), self.ops.xp.ascontiguousarray(K2))
-
-        # S1 shape: (nB, nH, nL, nL)
-        S1 = S0.reshape((nB, nH, nL, nL))
-
-        def backprop_attn1(dS1):
-            dS0 = self.ops.xp.ascontiguousarray(dS1.reshape((nB * nH, nL, nL)))
-            dQ1 = self.ops.matmul(dS0, self.ops.xp.ascontiguousarray(K2.transpose(0, 2, 1)))
-            dK2 = self.ops.matmul(self.ops.xp.ascontiguousarray(Q1.transpose(0, 2, 1)), dS0)
-            dK1 = (dK2 / self.ops.xp.sqrt(self.nM)).astype("float32")
-            dK0 = dK1.reshape((nB, nH, nD, nL)).transpose(0, 1, 3, 2)
-            dQ0 = dQ1.reshape((nB, nH, nL, nD))
-            return dQ0, dK0
-
-        return S1, backprop_attn1
-    
-    def _softmax(self, X, drop=0.):
-        Y = self.ops.softmax(X, axis=-1)
-        def backprop_softmax(dY, sgd=None):
-            return self.ops.backprop_softmax(Y, dY, axis=-1)
-        return Y, backprop_softmax
-
-    def _mask(self, S0, mask):
-        mask = self.ops.asarray(mask, dtype='f')
-        S1 = S0.transpose(1, 0, 2, 3)
-        S2 = S1 - (1 - mask) * (1e9)
-        S3 = S2.transpose(1, 0, 2, 3)
-        def backprop_attn2(dS3):
-            dS2 = dS3.transpose(1, 0, 2, 3)
-            dS1 = dS2 * mask
-            dS0 = dS1.transpose(1, 0, 2, 3)
-            return dS0
-        return S3, backprop_attn2
-
-    def _apply_attn(self, S0, V0):
-        """ Multiplication with values """
-        # S0: (nB, nH, nL, nL)
-        # VO: (nB, nH, nL, nD)
-        # S1: (nB*nH, nL, nL)
-        # V1:  (nB*nH, nL, nD)
-        # S2: (nB*nH, nL, nD)
-        # S3: (nB, nH, nL, nD)
-        nB, nH, nL, nL = S0.shape
-        nD = V0.shape[-1]
-        V1 = self.ops.xp.ascontiguousarray(V0.reshape((nB * nH, nL, nD)))
-        S1 = self.ops.xp.ascontiguousarray(S0.reshape((nB * nH, nL, nL)))
-        S2 = self.ops.matmul(S1, V1)
-
-        S3 = S2.reshape((nB, nH, nL, nD))
-
-        def backprop_attn4(dS3):
-            dS2 = self.ops.xp.ascontiguousarray(dS3.reshape((nB * nH, nL, nD)))
-            # (nB*nH, nL, nD) @ (nB*nH, nL, nD).T --> (nB*nH, nL, nL)
-            dS1 = self.ops.matmul(dS2, self.ops.xp.ascontiguousarray(V1.transpose(0, 2, 1)))
-            # (nB*nH, nL, nL).T @ (nB*nH, nL, nD) --> (nB*nH, nL, nD)
-            dV1 = self.ops.matmul(self.ops.xp.ascontiguousarray(S1.transpose(0, 2, 1)), dS2)
-            dS0 = dS1.reshape((nB, nH, nL, nL))
-            dV0 = dV1.reshape((nB, nH, nL, nD))
-            return dS0, dV0
-
-        return S3, backprop_attn4
-
-    def mask_floor(self, nB, nL):
-        stride = math.ceil(math.sqrt(nL))
-        floor_mask = (
-            Model.ops.xp.expand_dims(Model.ops.xp.eye(nL), axis=0)
-            .repeat(nB, axis=0)
-            .astype(Model.ops.xp.uint8)
-        )
-        for i in range(nL):
-            lower = max(0, i - (i % stride))
-            higher = i + 1
-            floor_mask[:, i, lower:higher] = 1
-        return floor_mask
-
-    def mask_repetitive(self, nB, nL, c=1, mode="left"):
-        """ Every stride tokens, mask one (independent of row) """
-        stride = math.ceil(math.sqrt(nL))
-        repetitive_mask = (
-            Model.ops.xp.expand_dims(Model.ops.xp.eye(nL), axis=0)
-            .repeat(nB, axis=0)
-            .astype(Model.ops.xp.uint8)
-        )
-        for j in range(nL):
-            if (j % stride) >= (stride - c):
-                if mode == "left":
-                    repetitive_mask[:, j:, j] = 1
-        return repetitive_mask
-
-
 class MultiHeadedAttention(Model):
-    """This class implements multiheaded attention. It can be used for self
-    attention or outer attention, depending on our needs. There is no left
-    and right context width. We attend to the whole sentence and we take
-    care of the masks to adjust appropriately. There are no actual different
-    weight matrices for each head, but a bigger weight matrix for all heads.
-    Going to bigger dimensions is the key to get the multiple heads.
-    For the time being; key, query and value matrices are supposed to have the
-    same length.
-    """
     def __init__(self, nM=300, nH=6):
         Model.__init__(self)
         self.nH = nH
@@ -229,25 +22,49 @@ class MultiHeadedAttention(Model):
             self.get_output,
         ]
 
-    def begin_update(self, X_lengths, drop=0.0):
+    def begin_update(self, inputs, drop=0.0):
+        (Qs, Ks, Vs), get_d_inputs = self.handle_inputs(inputs, drop=drop)
+        Y, get_dQs_dKs_dVs = self.attend((Qs, Ks, Vs), drop=drop)
+        outputs, get_dY = self.handle_outputs(Y, inputs)
+
+        def backprop_self_attn(d_outputs, sgd=None):
+            dY = get_dY(d_outputs, sgd=sgd)
+            dQs, dKs, dVs = get_dQs_dKs_dVs(dY, sgd=sgd)
+            d_inputs = get_d_inputs((dQs, dKs, dVs), sgd=sgd)
+            return d_inputs
+        
+        return outputs, backprop_self_attn
+
+    def handle_inputs(self, X_lengths, drop=0.0):
         X, lengths = X_lengths
         QKV, get_dX = self.get_queries_keys_values.begin_update(X, drop=drop)
         Qs, Ks, Vs = self._split_seqs(QKV, lengths)
-        Xattns, get_dQs_dKs_dVs = self._attend_seqs(Qs, Ks, Vs)
-        assert Xattns[0].shape == (lengths[0], X.shape[1]), (Xattns[0].shape, X.shape[1])
-        Xattn = self.ops.flatten(Xattns)
-        assert Xattn.shape == X.shape
-        Y, get_dXattn = self.get_output.begin_update(Xattn, drop=drop)
 
-        def backprop_self_attn(dY, sgd=None):
-            dXattn = get_dXattn(dY, sgd=sgd)
-            dXattns = self.ops.unflatten(dXattn, lengths)
-            dQs, dKs, dVs = get_dQs_dKs_dVs(dXattns, sgd=sgd)
+        def backprop_handle_inputs(dQs_dKs_dVs, sgd=None):
+            dQs, dKs, dVs = dQs_dKs_dVs
             dQKV = self._join_seqs(dQs, dKs, dVs)
             dX = get_dX(dQKV, sgd=sgd)
             return dX
-        
-        return (Y, lengths), backprop_self_attn
+        return (Qs, Ks, Vs), backprop_handle_inputs
+
+    def handle_outputs(self, Y, X_lengths):
+        X, lengths = X_lengths
+        return (Y, lengths), lambda dY, sgd=None: dY
+
+    def attend(self, Qs_Ks_Vs, drop=0.0):
+        Qs, Ks, Vs = Qs_Ks_Vs
+        Xattns, get_dQs_dKs_dVs = self._attend_seqs(Qs, Ks, Vs)
+        Xattn = self.ops.flatten(Xattns)
+        Y, get_dXattn = self.get_output.begin_update(Xattn, drop=drop)
+        lengths = self.ops.asarray([len(x) for x in Xattns], dtype='i')
+
+        def backprop_attend(dY, sgd=None):
+            dXattn = get_dXattn(dY, sgd=sgd)
+            dXattns = self.ops.unflatten(dXattn, lengths)
+            dQs, dKs, dVs = get_dQs_dKs_dVs(dXattns, sgd=sgd)
+            return dQs, dKs, dVs
+
+        return Y, backprop_attend
 
     def _split_seqs(self, QKV, lengths):
         Qs = []

--- a/thinc/neural/_classes/multiheaded_attention.py
+++ b/thinc/neural/_classes/multiheaded_attention.py
@@ -15,7 +15,6 @@ def prepare_self_attention(affine, window=None, nM=300, nH=6):
         get_mask = window_mask(window)
     else:
         get_mask = None
-    affine.W *= 2
     def qkv_sa_forward(Xs, drop=0.0):
         X = affine.ops.flatten(Xs)
         lengths = affine.ops.asarray([len(x) for x in Xs], dtype='i')

--- a/thinc/neural/_classes/multiheaded_attention.py
+++ b/thinc/neural/_classes/multiheaded_attention.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals, print_function
 from .model import Model
 from .affine import Affine
 from ...api import with_reshape, layerize
+from ..util import get_array_module
 import numpy as np
 import copy
 import math
@@ -274,108 +275,148 @@ class MultiHeadedAttention(Model):
     def begin_update(self, X_lengths, drop=0.0):
         X, lengths = X_lengths
         QKV, get_dX = self.get_queries_keys_values.begin_update(X, drop=drop)
-        Xattn, get_dQKV = self.attn(QKV, lengths)
+        Qs, Ks, Vs = self._split_seqs(QKV, lengths)
+        Xattns, get_dQs_dKs_dVs = self._attend_seqs(Qs, Ks, Vs)
+        assert Xattns[0].shape == (lengths[0], X.shape[1]), (Xattns[0].shape, X.shape[1])
+        Xattn = self.ops.flatten(Xattns)
+        assert Xattn.shape == X.shape
         Y, get_dXattn = self.get_output.begin_update(Xattn, drop=drop)
 
         def backprop_self_attn(dY, sgd=None):
             dXattn = get_dXattn(dY, sgd=sgd)
-            dQKV = get_dQKV(dXattn, sgd=sgd)
+            dXattns = self.ops.unflatten(dXattn, lengths)
+            dQs, dKs, dVs = get_dQs_dKs_dVs(dXattns, sgd=sgd)
+            dQKV = self._join_seqs(dQs, dKs, dVs)
             dX = get_dX(dQKV, sgd=sgd)
             return dX
         
         return (Y, lengths), backprop_self_attn
 
-    def attn(self, QKV, lengths):
+    def _split_seqs(self, QKV, lengths):
+        Qs = []
+        Ks = []
+        Vs = []
+        i = 0
+        for length in lengths:
+            qkv = QKV[i:i+length]
+            qkv = qkv.reshape((length, 3, self.nM))
+            queries = self.ops.xp.ascontiguousarray(qkv[:, 0])
+            keys = self.ops.xp.ascontiguousarray(qkv[:, 1])
+            values = self.ops.xp.ascontiguousarray(qkv[:, 2])
+            Qs.append(queries.reshape((-1, self.nH, self.nD)))
+            Ks.append(keys.reshape((-1, self.nH, self.nD)))
+            Vs.append(values.reshape((-1, self.nH, self.nD)))
+            i += length
+        return Qs, Ks, Vs
+
+    def _join_seqs(self, Qs, Ks, Vs):
+        Q = self.ops.xp.vstack(Qs).reshape((-1, self.nH*self.nD))
+        K = self.ops.xp.vstack(Ks).reshape((-1, self.nH*self.nD))
+        V = self.ops.xp.vstack(Vs).reshape((-1, self.nH*self.nD))
+        return self.ops.xp.hstack((Q, K, V))
+
+    def _attend_seqs(self, Qs, Ks, Vs):
+        outputs = []
+        backprops = []
+        for Q, K, V in zip(Qs, Ks, Vs):
+            output, backprop = self._attend(Q, K, V)
+            outputs.append(output)
+            backprops.append(backprop)
+
+        def backprop_attend_seqs(d_outputs, sgd=None):
+            dQs = []
+            dKs = []
+            dVs = []
+            for d_output, backprop in zip(d_outputs, backprops):
+                dQ, dK, dV = backprop(d_output, sgd=sgd)
+                dQs.append(dQ)
+                dKs.append(dK)
+                dVs.append(dV)
+            return dQs, dKs, dVs
+        return outputs, backprop_attend_seqs
+
+    def _attend(self, Q, K, V):
         """
-        Compute attention on (query, key, value) triplets.
+        Compute attention on a (query, key, value) triplet.
         The similarity of the (Q, K) pairs are used to
         compute an attention matrix, which is used to rescale
         V.
         """
-        outputs = []
-        backprops = []
-        i = 0
-        for length in lengths:
-            Q = QKV[i:i+length, :self.nM]
-            K = QKV[i:i+length, self.nM:self.nM*2]
-            V = QKV[i:i+length, -self.nM:]
-            S0, bp_scaled_dp = self._scaled_dot_prod(Q, K)
-            S1, bp_softmax = self._softmax(S0)
-            S2, bp_apply_attn = self._apply_attn(S1, V)
-            backprops.append((bp_scaled_dp, bp_softmax, bp_apply_attn))
-            outputs.append(S2)
-            i += length
+        attn, get_dQ_dK = self._get_attn_weights(Q, K)
+        output, get_d_attn_dV = self._apply_attn(attn, V)
 
-        def backprop_attn(d_outputs, sgd=None):
-            """ Attention three inputs, one output """
-            i = 0
-            d_inputs = []
-            for length, (bp_scaled_dp, bp_softmax, bp_apply_attn) in zip(lengths, backprops):
-                dS2 = d_outputs[i:i+length]
-                dS1, dV = bp_apply_attn(dS2)
-                dS0 = bp_softmax(dS1)
-                dQ, dK = bp_scaled_dp(dS0)
-                assert dQ.shape == dK.shape == dV.shape
-                dQKV = self.ops.xp.hstack((dQ, dK, dV))
-                d_inputs.append(dQKV)
-                i += length
-            d_inputs = self.ops.xp.vstack(d_inputs)
-            return d_inputs.reshape(QKV.shape)
-        return self.ops.xp.vstack(outputs), backprop_attn
+        def backprop_attend(d_output, sgd=None):
+            d_attn, dV = get_d_attn_dV(d_output)
+            dQ, dK = get_dQ_dK(d_attn)
+            return (dQ, dK, dV)
 
-    def _scaled_dot_prod(self, Q0, K0):
-        Q0 = Q0.reshape((-1, self.nH, self.nD)).transpose((1, 0, 2))
-        K0 = K0.reshape((-1, self.nH, self.nD)).transpose((1, 0, 2))
-        # Q0: nH, nL, nD
-        # K0: nH, nL, nD
-        nH, nL, nD = Q0.shape
-        # Q1: nH, nL, nD
-        Q1 = Q0.reshape((nH, nL, nD))
-        # K1: (nH, nD, nL)
-        K1 = K0.transpose(0, 2, 1).reshape((nH, nD, nL))
-        # K2: (nH, nD, nL)
-        K2 = (K1 / self.ops.xp.sqrt(self.nM)).astype("float32")
-        # S0: (nH, nL, nL)
-        S0 = self.ops.matmul(self.ops.xp.ascontiguousarray(Q1), self.ops.xp.ascontiguousarray(K2))
+        return output, backprop_attend
 
-        def backprop_attn1(dS0, sgd=None):
-            dQ1 = self.ops.matmul(dS0, self.ops.xp.ascontiguousarray(K2.transpose(0, 2, 1)))
-            dK2 = self.ops.matmul(self.ops.xp.ascontiguousarray(Q1.transpose(0, 2, 1)), dS0)
-            dK1 = (dK2 / self.ops.xp.sqrt(self.nM)).astype("float32")
-            dK0 = dK1.reshape((nH, nD, nL)).transpose(2, 0, 1)
-            dQ0 = dQ1.reshape((nH, nL, nD)).transpose((1, 0, 2))
+    def _get_attn_weights(self, Q0, K0):
+        nQ, nK, nH, nD = (Q0.shape[0], K0.shape[0], self.nH, self.nD)
+        assert Q0.shape == (nQ, nH, nD)
+        assert K0.shape == (nK, nH, nD)
+        sqrtM = self.ops.xp.sqrt(self.nM).astype("f")
+        Q1 = _trans(Q0, 1, 0, 2)
+        assert Q1.shape == (nH, nQ, nD)
+        K1 = _trans(K0, 1, 2, 0)
+        assert K1.shape == (nH, nD, nK)
+        K1 /= sqrtM
+        attn0 = self.ops.matmul(Q1, K1)
+        assert attn0.shape == (nH, nQ, nK)
+        attn1 = self.ops.softmax(attn0, axis=-1)
+        assert attn1.shape == (nH, nQ, nK)
+
+        def backprop_attn1(d_attn1, sgd=None):
+            assert d_attn1.shape == (nH, nQ, nK)
+            d_attn0 = self.ops.backprop_softmax(attn1, d_attn1, axis=-1)
+            assert d_attn0.shape == (nH, nQ, nK)
+            dQ1 = self.ops.matmul(d_attn0, _trans(K1, 0, 2, 1))
+            assert dQ1.shape == (nH, nQ, nD)
+            dK1 = self.ops.matmul(_trans(Q1, 0, 2, 1), d_attn0)
+            assert dK1.shape == (nH, nD, nK)
+            dK0 = _trans(dK1, 2, 0, 1)
+            dK0 /= sqrtM
+            assert dK0.shape == (nK, nH, nD)
+            dQ0 = _trans(dQ1, 1, 0, 2)
+            assert dQ0.shape == (nQ, nH, nD)
             return dQ0, dK0
 
-        return S0, backprop_attn1
+        return attn1, backprop_attn1
 
-    def _softmax(self, X, drop=0.):
-        Y = self.ops.softmax(X, axis=-1)
-        def backprop_softmax(dY, sgd=None):
-            return self.ops.backprop_softmax(Y, dY, axis=-1)
-        return Y, backprop_softmax
-
-    def _apply_attn(self, S0, V0):
+    def _apply_attn(self, attn, V0):
         """ Multiplication with values """
-        # S0: (nH, nL, nL)
-        # VO: (nL, nH, nD)
-        # S1: (nH, nL, nD)
-        # V1:  (nH, nL, nD)
-        # S2: (nL, nH*nD)
-        nH, nL, nL = S0.shape
-        V0 = V0.reshape((nL, nH, -1))
-        nD = V0.shape[-1]
-        V1 = V0.transpose((1, 0, 2))
-        S1 = self.ops.matmul(self.ops.xp.ascontiguousarray(S0), self.ops.xp.ascontiguousarray(V1))
-        S2 = S1.transpose((1, 0, 2)).reshape((-1, self.nH*self.nD))
+        nH, nQ, nV = attn.shape
+        nD = self.nD
+        assert V0.shape == (nV, nH, nD)
+        V1 = _trans(V0, 1, 0, 2)
+        assert V1.shape == (nH, nV, nD)
+        # (nH, nQ, nV) @ (nH, nV, nD) = (nH, nQ, nD)
+        S0 = self.ops.matmul(attn, V1)
+        assert S0.shape == (nH, nQ, nD)
+        S1 = _trans(S0, 1, 0, 2)
+        assert S1.shape == (nQ, nH, nD)
+        S2 = S1.reshape((nQ, nH*nD))
 
-        def backprop_attn4(dS2):
-            dS1 = dS2.reshape((-1, self.nH, self.nD)).transpose((1, 0, 2))
-            dS1 = self.ops.xp.ascontiguousarray(dS1)
-            # (nH, nL, nD) @ (nH, nL, nD).T --> (nH, nL, nL)
-            dS0 = self.ops.matmul(dS1, self.ops.xp.ascontiguousarray(V1.transpose(0, 2, 1)))
-            # (nH, nL, nL).T @ (nH, nL, nD) --> (nH, nL, nD)
-            dV1 = self.ops.matmul(self.ops.xp.ascontiguousarray(S0.transpose(0, 2, 1)), dS1)
-            dV0 = dV1.reshape((nH, nL, nD)).transpose((1, 0, 2))
-            return dS0, dV0
+        def backprop_apply_attn(dS2):
+            assert dS2.shape == (nQ, nH*nD)
+            dS1 = dS2.reshape((nQ, nH, nD))
+            dS0 = dS1.transpose((1, 0, 2))
+            assert dS0.shape == (nH, nQ, nD)
+            dS0 = self.ops.xp.ascontiguousarray(dS0)
+            # (nH, nQ, nD) @ (nH, nD, nV) --> (nH, nQ, nV)
+            d_attn = self.ops.matmul(dS0, _trans(V1, 0, 2, 1))
+            assert d_attn.shape == (nH, nQ, nV)
+            # (nH, nV, nQ) @ (nH, nQ, nD) --> (nH, nV, nD)
+            dV1 = self.ops.matmul(_trans(attn, 0, 2, 1), dS0)
+            assert dV1.shape == (nH, nV, nD)
+            dV0 = dV1.transpose((1, 0, 2))
+            assert dV0.shape == (nV, nH, nD)
+            return d_attn, dV0
 
-        return S2, backprop_attn4
+        return S2, backprop_apply_attn
+
+def _trans(X, *order):
+    """Transpose and make contiguous"""
+    xp = get_array_module(X)
+    return xp.ascontiguousarray(X.transpose(order))

--- a/thinc/neural/_classes/multiheaded_attention.py
+++ b/thinc/neural/_classes/multiheaded_attention.py
@@ -10,6 +10,25 @@ import math
 
 
 class MultiHeadedAttention(Model):
+    """Multi-headed attention. Subclasses can control the specifics by subclassing:
+
+    * handle_inputs:
+        Takes the inputs, and must return a tuple (queries, keys, values). Each
+        of the elements of the tuple should be a list of arrays. The lists need
+        to be the same lengths. The keys and values arrays have to be the same
+        shape. The handle_inputs function needs to also return a callback,
+        to do the backward pass.
+    * handle_outputs:
+        Performs output transforms. This makes it easier for subclasses to work
+        on lists, padded batches, etc.
+    * attend:
+        Takes a triple (queries, keys, values) and returns a single array with
+        the concatenated outputs, after applying the attention. Normally this
+        will involve computing an attention matrix using (queries, keys), and then
+        applying the attention matrix to values.
+
+    The defaults for all these things are currently configured for self-attention.
+    """
     def __init__(self, nM=300, nH=6):
         Model.__init__(self)
         self.nH = nH

--- a/thinc/neural/_classes/multiheaded_attention.py
+++ b/thinc/neural/_classes/multiheaded_attention.py
@@ -273,9 +273,9 @@ class MultiHeadedAttention(Model):
 
     def begin_update(self, X_lengths, drop=0.0):
         X, lengths = X_lengths
-        QKV, get_dX = self.get_queries_keys_values.begin_update(X)
+        QKV, get_dX = self.get_queries_keys_values.begin_update(X, drop=drop)
         Xattn, get_dQKV = self.attn(QKV, lengths)
-        Y, get_dXattn = self.get_output.begin_update(Xattn)
+        Y, get_dXattn = self.get_output.begin_update(Xattn, drop=drop)
 
         def backprop_self_attn(dY, sgd=None):
             dXattn = get_dXattn(dY, sgd=sgd)

--- a/thinc/neural/_classes/resnet.py
+++ b/thinc/neural/_classes/resnet.py
@@ -19,8 +19,11 @@ class Residual(Model):
 
     def begin_update(self, X, drop=0.0):
         y, bp_y = self._layers[0].begin_update(X, drop=drop)
-        if isinstance(X, list) or isinstance(X, tuple):
+        if isinstance(X, list):
             output = [X[i] + y[i] for i in range(len(X))]
+        elif isinstance(X, tuple) and isinstance(y, tuple) and len(X) == 2:
+            # Handle case where we have (data, lengths) tuple
+            output = (X[0] + y[0], X[1])
         else:
             output = X + y
 

--- a/thinc/neural/_classes/resnet.py
+++ b/thinc/neural/_classes/resnet.py
@@ -14,6 +14,8 @@ class Residual(Model):
         Y = self._layers[0](X)
         if isinstance(X, list) or isinstance(X, tuple):
             return [X[i] + Y[i] for i in range(len(X))]
+        elif isinstance(X, tuple) and isinstance(Y, tuple) and len(X) == 2:
+            return (X[0] + Y[0], X[1])
         else:
             return X + Y
 

--- a/thinc/neural/_classes/resnet.py
+++ b/thinc/neural/_classes/resnet.py
@@ -10,12 +10,14 @@ class Residual(Model):
         self._layers.append(layer)
         self.on_data_hooks.append(on_data)
 
-    def __call__(self, X):
+    def predict(self, X):
         Y = self._layers[0](X)
         if isinstance(X, list) or isinstance(X, tuple):
             return [X[i] + Y[i] for i in range(len(X))]
         elif isinstance(X, tuple) and isinstance(Y, tuple) and len(X) == 2:
-            return (X[0] + Y[0], X[1])
+            assert X[1].sum() == Y[1].sum()
+            assert Y[1].sum() == Y[0].shape[0], (Y[1].sum(), Y[0].shape[0])
+            return (X[0] + Y[0], Y[1])
         else:
             return X + Y
 
@@ -25,7 +27,9 @@ class Residual(Model):
             output = [X[i] + y[i] for i in range(len(X))]
         elif isinstance(X, tuple) and isinstance(y, tuple) and len(X) == 2:
             # Handle case where we have (data, lengths) tuple
-            output = (X[0] + y[0], X[1])
+            assert X[1].sum() == y[1].sum()
+            assert y[1].sum() == y[0].shape[0], (y[1].sum(), y[0].shape[0])
+            output = (X[0] + y[0], y[1])
         else:
             output = X + y
 

--- a/thinc/neural/ops.pyx
+++ b/thinc/neural/ops.pyx
@@ -246,9 +246,6 @@ class Ops(object):
         return 1-y**2
 
     def softmax(self, x, inplace=False, axis=-1):
-        if x.ndim >= 3:
-            raise NotImplementedError(
-                "Softmax currently only supports 2d. ndim=%d" % x.ndim)
         shape = x.shape
         maxes = self.xp.max(x, axis=axis, keepdims=True)
         shifted = x - maxes
@@ -274,6 +271,11 @@ class Ops(object):
             return Xs
         else:
             return new_x
+
+    def backprop_softmax(self, Y, dY, axis=-1):
+        dX = Y * dY
+        dX -= Y * dX.sum(axis=axis, keepdims=True)
+        return dX
 
     def backprop_softmax_sequences(self, dy, y, lengths):
         dx = y * dy

--- a/thinc/neural/ops.pyx
+++ b/thinc/neural/ops.pyx
@@ -403,6 +403,21 @@ class NumpyOps(Ops):
         VecVec.add_i(<float*>x.data,
             <float*>y.data, scale, x.shape[0])
 
+    def matmul(self, float[:, :, ::1] x, float[:, :, ::1] y, out=None):
+        assert x.shape[0] == y.shape[0]
+        assert x.shape[2] == y.shape[1]
+        cdef np.ndarray out_array
+        if out is None:
+            out_array = self.allocate((x.shape[0], x.shape[1], y.shape[2]))
+        else:
+            out_array = self.xp.asarray(out)
+        assert out_array.shape[0] == x.shape[0]
+        assert out_array.shape[1] == x.shape[1]
+        assert out_array.shape[2] == y.shape[2]
+        for i in range(x.shape[0]):
+            blis.py.gemm(x[i], y[i], out=out_array[i])
+        return out_array
+
     def gemm(self, float[:, ::1] x, float[:, ::1] y, trans1=False, trans2=False,
              out=None):
         cdef int m

--- a/thinc/neural/ops.pyx
+++ b/thinc/neural/ops.pyx
@@ -33,7 +33,8 @@ cdef extern from "math.h":
     float sqrtf(float x) nogil
     float expf(float x) nogil
     float tanhf(float x) nogil
-
+    float sinf(float x) nogil
+    float cosf(float x) nogil
 
 try:
     import cupy
@@ -746,6 +747,34 @@ class NumpyOps(Ops):
         for i in range(keys_.shape[0]-n):
             output[i] = hash64(&keys[i], n*sizeof(keys[0]), 0)
         return output_
+
+    def position_encode(self, int N, int D, int period=10000, out=None):
+        cdef np.ndarray out_
+        if out is None:
+            out_ = self.allocate((N, D))
+        else:
+            out_ = out
+        assert out_.shape[0] == N
+        assert out_.shape[1] == D
+        cpu_position_encode(<float*>out_.data, period, N, D)
+        return out_ 
+    
+cdef void cpu_position_encode(float* output, float period, int N, int D) nogil:
+    cdef float pos, d
+    cdef int j
+    cdef float dimensions = D
+    for i in range(N):
+        pos = i
+        j = 0
+        d = 0
+        while (j+1) < D:
+            d = j
+            output[j]   = sinf(pos / period ** (2 * d / dimensions))
+            output[j+1] = cosf(pos / period ** (2 * d / dimensions))
+            j += 2
+        if j < D:
+            output[j]   = sinf(pos / period ** (2 * d / dimensions))
+        output += D
 
 
 cdef void cpu_scatter_add(float* dest,

--- a/thinc/neural/ops.pyx
+++ b/thinc/neural/ops.pyx
@@ -813,6 +813,9 @@ class CupyOps(Ops):
     device = 'gpu'
     xp = cupy
 
+    def matmul(self, x, y, out=None):
+        return self.xp.matmul(x, y, out=out)
+
     def gemm(self, x, y, out=None, trans1=False, trans2=False):
         if trans1:
             x = x.T

--- a/thinc/t2t.py
+++ b/thinc/t2t.py
@@ -4,3 +4,5 @@ from __future__ import unicode_literals
 from .neural._classes.convolution import ExtractWindow  # noqa: F401
 from .neural._classes.attention import ParametricAttention  # noqa: F401
 from .neural._classes.rnn import LSTM, BiLSTM  # noqa: F401
+from .neural._classes.multiheaded_attention import MultiHeadedAttention
+from .neural._classes.multiheaded_attention import prepare_self_attention


### PR DESCRIPTION
* Implement backprop of softmax
* Replace PyTorch mask with our mask function
* Add matmul op, to remove calls to numpy.matmul

The layer would mostly be usable in spaCy now, although the padding is problematic if the sequences are long. The implementation is about 2-3x faster than the previous, on CPU.