### PR TITLE
fix unflatten padding when last element is empty

### DIFF
--- a/thinc/neural/ops.pyx
+++ b/thinc/neural/ops.pyx
@@ -133,7 +133,7 @@ class Ops(object):
                 X = X[pad:]
             unflat.append(X[:length])
             X = X[length:]
-        if pad >= 1 and length != 0:
+        if pad >= 1:
             X = X[pad:]
         assert len(X) == 0
         assert len(unflat) == len(lengths)


### PR DESCRIPTION
Attempt to fix spaCy issue https://github.com/explosion/spaCy/issues/3880. The error in that issue is raised by `ops.pyx` on the line  `assert len(X) == 0` (https://github.com/explosion/thinc/blob/master/thinc/neural/ops.pyx#L138), and it happens when the tagger model is run with an empty doc as last element in a call to `nlp.pipe()`.

I think this happens because the `flatten` function adds one additional bit of padding at the end (https://github.com/explosion/thinc/blob/master/thinc/neural/ops.pyx#L119) which is not stripped away when `unflatten` removes the padding only when `length != 0` (https://github.com/explosion/thinc/blob/master/thinc/neural/ops.pyx#L136) for the last variable `length` in `lengths` (accessed outside of its `for` loop).

I don't have a proper way of testing this yet, so I'm definitely not sure about this.