### PR TITLE
Fix Collections Abstract Base Classes imports for Python 3.8

### DIFF
--- a/thinc/check.py
+++ b/thinc/check.py
@@ -1,4 +1,9 @@
-from collections import defaultdict, Sequence, Sized, Iterable, Callable
+try:
+    # Python >= 3.3
+    from collections.abc import defaultdict, Sequence, Sized, Iterable, Callable
+except ImportError:
+    # Python < 3.3
+    from collections import defaultdict, Sequence, Sized, Iterable, Callable
 import inspect
 import wrapt
 from cytoolz import curry

--- a/thinc/exceptions.py
+++ b/thinc/exceptions.py
@@ -1,6 +1,11 @@
 # coding: utf-8
 from __future__ import unicode_literals
-from collections import Sized
+try:
+    # Python >= 3.3
+    from collections.abc import Sized
+except ImportError:
+    # Python < 3.3
+    from collections import Sized
 
 import traceback
 from termcolor import colored as color

--- a/thinc/neural/ops.pyx
+++ b/thinc/neural/ops.pyx
@@ -15,7 +15,12 @@ import numpy
 from cytoolz import concat
 from numpy import prod
 from numpy cimport ndarray
-from collections import Sized
+try:
+    # Python >= 3.3
+    from collections.abc import Sized
+except ImportError:
+    # Python < 3.3
+    from collections import Sized
 cimport numpy as np
 
 from ..typedefs cimport weight_t


### PR DESCRIPTION
Since Python version 3.3, Collections Abstract Base Classes have been moved to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.

(source: https://docs.python.org/3/library/collections.html)

Related to issue #108 