### PR TITLE
use collections.abc when possible

### DIFF
--- a/thinc/check.py
+++ b/thinc/check.py
@@ -1,7 +1,12 @@
 # coding: utf8
 from __future__ import unicode_literals
 
-from collections import Sequence, Sized, Iterable, Callable
+try:
+    # Python >= 3.3
+    from collections.abc import Sequence, Sized, Iterable, Callable
+except ImportError:
+    # Python < 3.3
+    from collections import Sequence, Sized, Iterable, Callable
 from numpy import ndarray
 
 from .compat import integer_types

--- a/thinc/neural/ops.pyx
+++ b/thinc/neural/ops.pyx
@@ -13,7 +13,12 @@ from preshed.maps cimport PreshMap
 import numpy
 from numpy import prod
 from numpy cimport ndarray
-from collections import Sized
+try:
+    # Python >= 3.3
+    from collections.abc import Sized
+except ImportError:
+    # Python < 3.3
+    from collections import Sized
 cimport numpy as np
 
 from ._aligned_alloc import zeros_aligned


### PR DESCRIPTION
Just like #109 , but (hopefully) without bug, and applied to master branch.

Since Python version 3.3, Collections Abstract Base Classes have been moved to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.

(source: https://docs.python.org/3/library/collections.html)

Related to issue #108 