### PR TITLE
Make Model operators and device ops thread-local

### DIFF
--- a/thinc/check.py
+++ b/thinc/check.py
@@ -130,8 +130,8 @@ def operator_is_defined(op):
             instance = args[0]
         if instance is None:
             raise ExpectedTypeError(instance, ["Model"])
-        if op not in instance._operators:
-            raise UndefinedOperatorError(op, instance, args[0], instance._operators)
+        if op not in instance.THREAD_LOCAL.operators:
+            raise UndefinedOperatorError(op, instance, args[0], instance.THREAD_LOCAL.operators)
         else:
             return wrapped(*args, **kwargs)
 

--- a/thinc/check.py
+++ b/thinc/check.py
@@ -130,8 +130,8 @@ def operator_is_defined(op):
             instance = args[0]
         if instance is None:
             raise ExpectedTypeError(instance, ["Model"])
-        if op not in instance.THREAD_LOCAL.operators:
-            raise UndefinedOperatorError(op, instance, args[0], instance.THREAD_LOCAL.operators)
+        if op not in instance._thread_local.operators:
+            raise UndefinedOperatorError(op, instance, args[0], instance._thread_local.operators)
         else:
             return wrapped(*args, **kwargs)
 

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -47,11 +47,10 @@ class Model(object):
             print(model + other)
             # Raises TypeError --- binding limited to scope of with block.
         """
-        cls._thread_local.old_operator_stack = getattr(cls._thread_local, "old_operator_stack", [])
-        cls._thread_local.old_operator_stack.append(dict(getattr(cls._thread_local, "operators", {})))
+        curr_operators = dict(getattr(cls._thread_local, "operators", {}))
         cls._thread_local.operators = dict(operators)
         yield
-        cls._thread_local.operators = dict(cls._thread_local.old_operator_stack.pop())
+        cls._thread_local.operators = dict(curr_operators)
 
     @classmethod
     @contextlib.contextmanager
@@ -60,13 +59,13 @@ class Model(object):
         if device == cls._thread_local.ops.device:
             yield
         else:
-            cls._thread_local.curr_Ops = getattr(cls._thread_local, "Ops", cls.Ops)
-            cls._thread_local.curr_ops = getattr(cls._thread_local, "ops", cls.ops)
+            curr_Ops = getattr(cls._thread_local, "Ops", cls.Ops)
+            curr_ops = getattr(cls._thread_local, "ops", cls.ops)
             cls._thread_local.Ops = get_ops(device)
             cls._thread_local.ops = cls._thread_local.Ops()
             yield
-            cls._thread_local.Ops = cls._thread_local.curr_Ops
-            cls._thread_local.ops = cls._thread_local.curr_ops
+            cls._thread_local.Ops = curr_Ops
+            cls._thread_local.ops = curr_ops
 
     @property
     def input_shape(self):

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -29,7 +29,7 @@ class Model(object):
     descriptions = []
     on_data_hooks = []
     on_init_hooks = []  # Use this to add layers
-    THREAD_LOCAL = threading.local()
+    _thread_local = threading.local()
 
     @classmethod
     @contextlib.contextmanager
@@ -47,10 +47,10 @@ class Model(object):
             print(model + other)
             # Raises TypeError --- binding limited to scope of with block.
         """
-        cls.THREAD_LOCAL.old_operators = dict(getattr(cls.THREAD_LOCAL, "operators", {}))
-        cls.THREAD_LOCAL.operators = dict(operators)
+        cls._thread_local.old_operators = dict(getattr(cls._thread_local, "operators", {}))
+        cls._thread_local.operators = dict(operators)
         yield
-        cls.THREAD_LOCAL.operators = dict(cls.THREAD_LOCAL.old_operators)
+        cls._thread_local.operators = dict(cls._thread_local.old_operators)
 
     @classmethod
     @contextlib.contextmanager
@@ -238,72 +238,72 @@ class Model(object):
     @check.operator_is_defined("+")
     def __add__(self, other):
         """Apply the function bound to the '+' operator."""
-        return self.THREAD_LOCAL.operators["+"](self, other)
+        return self._thread_local.operators["+"](self, other)
 
     @check.operator_is_defined("-")
     def __sub__(self, other):
         """Apply the function bound to the '-' operator."""
-        return self.THREAD_LOCAL.operators["-"](self, other)
+        return self._thread_local.operators["-"](self, other)
 
     @check.operator_is_defined("*")
     def __mul__(self, other):
         """Apply the function bound to the '*' operator."""
-        return self.THREAD_LOCAL.operators["*"](self, other)
+        return self._thread_local.operators["*"](self, other)
 
     @check.operator_is_defined("@")
     def __matmul__(self, other):
         """Apply the function bound to the '@' operator."""
-        return self.THREAD_LOCAL.operators["@"](self, other)
+        return self._thread_local.operators["@"](self, other)
 
     @check.operator_is_defined("/")
     def __div__(self, other):
         """Apply the function bound to the '/' operator."""
-        return self.THREAD_LOCAL.operators["/"](self, other)
+        return self._thread_local.operators["/"](self, other)
 
     @check.operator_is_defined("/")
     def __truediv__(self, other):  # pragma: no cover
         """Apply the function bound to the '/' operator."""
-        return self.THREAD_LOCAL.operators["/"](self, other)
+        return self._thread_local.operators["/"](self, other)
 
     @check.operator_is_defined("//")
     def __floordiv__(self, other):
         """Apply the function bound to the '//' operator."""
-        return self.THREAD_LOCAL.operators["//"](self, other)
+        return self._thread_local.operators["//"](self, other)
 
     @check.operator_is_defined("%")
     def __mod__(self, other):
         """Apply the function bound to the '%' operator."""
-        return self.THREAD_LOCAL.operators["%"](self, other)
+        return self._thread_local.operators["%"](self, other)
 
     @check.operator_is_defined("**")
     def __pow__(self, other, modulo=None):
         """Apply the function bound to the '**' operator."""
-        return self.THREAD_LOCAL.operators["**"](self, other)
+        return self._thread_local.operators["**"](self, other)
 
     @check.operator_is_defined("<<")
     def __lshift__(self, other):
         """Apply the function bound to the '<<' operator."""
-        return self.THREAD_LOCAL.operators["<<"](self, other)
+        return self._thread_local.operators["<<"](self, other)
 
     @check.operator_is_defined(">>")
     def __rshift__(self, other):
         """Apply the function bound to the '>>' operator."""
-        return self.THREAD_LOCAL.operators[">>"](self, other)
+        return self._thread_local.operators[">>"](self, other)
 
     @check.operator_is_defined("&")
     def __and__(self, other):
         """Apply the function bound to the '&' operator."""
-        return self.THREAD_LOCAL.operators["&"](self, other)
+        return self._thread_local.operators["&"](self, other)
 
     @check.operator_is_defined("^")
     def __xor__(self, other):
         """Apply the function bound to the '^' operator."""
-        return self.THREAD_LOCAL.operators["^"](self, other)
+        return self._thread_local.operators["^"](self, other)
 
     @check.operator_is_defined("|")
     def __or__(self, other):
         """Apply the function bound to the '|' operator."""
-        return self.THREAD_LOCAL.operators["|"](self, other)
+        return self._thread_local.operators["|"](self, other)
 
     def to_bytes(self):
         weights = []

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -17,6 +17,7 @@ from ...check import has_shape, is_sequence, is_float
 
 THREAD_LOCAL = threading.local()
 THREAD_LOCAL.operators = {}
+THREAD_LOCAL.old_operators = {}
 
 
 class Model(object):
@@ -33,6 +34,7 @@ class Model(object):
     on_data_hooks = []
     on_init_hooks = []  # Use this to add layers
     _operators = THREAD_LOCAL.operators
+    _old_operators = THREAD_LOCAL.old_operators
 
     @classmethod
     @contextlib.contextmanager
@@ -50,11 +52,11 @@ class Model(object):
             print(model + other)
             # Raises TypeError --- binding limited to scope of with block.
         """
-        old_ops = dict(cls._operators)
+        cls._old_operators = dict(cls._operators)
         for op, func in operators.items():
             cls._operators[op] = func
         yield
-        cls._operators = old_ops
+        cls._operators = cls._old_operators
 
     @classmethod
     @contextlib.contextmanager

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -15,10 +15,6 @@ from ..util import get_ops, copy_array
 from ... import check
 from ...check import has_shape, is_sequence, is_float
 
-THREAD_LOCAL = threading.local()
-THREAD_LOCAL.operators = {}
-THREAD_LOCAL.old_operators = {}
-
 
 class Model(object):
     """Model base class."""
@@ -33,8 +29,7 @@ class Model(object):
     descriptions = []
     on_data_hooks = []
     on_init_hooks = []  # Use this to add layers
-    _operators = THREAD_LOCAL.operators
-    _old_operators = THREAD_LOCAL.old_operators
+    THREAD_LOCAL = threading.local()
 
     @classmethod
     @contextlib.contextmanager
@@ -52,11 +47,10 @@ class Model(object):
             print(model + other)
             # Raises TypeError --- binding limited to scope of with block.
         """
-        cls._old_operators = dict(cls._operators)
-        for op, func in operators.items():
-            cls._operators[op] = func
+        cls.THREAD_LOCAL.old_operators = dict(getattr(cls.THREAD_LOCAL, "operators", {}))
+        cls.THREAD_LOCAL.operators = dict(operators)
         yield
-        cls._operators = cls._old_operators
+        cls.THREAD_LOCAL.operators = dict(cls.THREAD_LOCAL.old_operators)
 
     @classmethod
     @contextlib.contextmanager
@@ -244,72 +238,72 @@ class Model(object):
     @check.operator_is_defined("+")
     def __add__(self, other):
         """Apply the function bound to the '+' operator."""
-        return self._operators["+"](self, other)
+        return self.THREAD_LOCAL.operators["+"](self, other)
 
     @check.operator_is_defined("-")
     def __sub__(self, other):
         """Apply the function bound to the '-' operator."""
-        return self._operators["-"](self, other)
+        return self.THREAD_LOCAL.operators["-"](self, other)
 
     @check.operator_is_defined("*")
     def __mul__(self, other):
         """Apply the function bound to the '*' operator."""
-        return self._operators["*"](self, other)
+        return self.THREAD_LOCAL.operators["*"](self, other)
 
     @check.operator_is_defined("@")
     def __matmul__(self, other):
         """Apply the function bound to the '@' operator."""
-        return self._operators["@"](self, other)
+        return self.THREAD_LOCAL.operators["@"](self, other)
 
     @check.operator_is_defined("/")
     def __div__(self, other):
         """Apply the function bound to the '/' operator."""
-        return self._operators["/"](self, other)
+        return self.THREAD_LOCAL.operators["/"](self, other)
 
     @check.operator_is_defined("/")
     def __truediv__(self, other):  # pragma: no cover
         """Apply the function bound to the '/' operator."""
-        return self._operators["/"](self, other)
+        return self.THREAD_LOCAL.operators["/"](self, other)
 
     @check.operator_is_defined("//")
     def __floordiv__(self, other):
         """Apply the function bound to the '//' operator."""
-        return self._operators["//"](self, other)
+        return self.THREAD_LOCAL.operators["//"](self, other)
 
     @check.operator_is_defined("%")
     def __mod__(self, other):
         """Apply the function bound to the '%' operator."""
-        return self._operators["%"](self, other)
+        return self.THREAD_LOCAL.operators["%"](self, other)
 
     @check.operator_is_defined("**")
     def __pow__(self, other, modulo=None):
         """Apply the function bound to the '**' operator."""
-        return self._operators["**"](self, other)
+        return self.THREAD_LOCAL.operators["**"](self, other)
 
     @check.operator_is_defined("<<")
     def __lshift__(self, other):
         """Apply the function bound to the '<<' operator."""
-        return self._operators["<<"](self, other)
+        return self.THREAD_LOCAL.operators["<<"](self, other)
 
     @check.operator_is_defined(">>")
     def __rshift__(self, other):
         """Apply the function bound to the '>>' operator."""
-        return self._operators[">>"](self, other)
+        return self.THREAD_LOCAL.operators[">>"](self, other)
 
     @check.operator_is_defined("&")
     def __and__(self, other):
         """Apply the function bound to the '&' operator."""
-        return self._operators["&"](self, other)
+        return self.THREAD_LOCAL.operators["&"](self, other)
 
     @check.operator_is_defined("^")
     def __xor__(self, other):
         """Apply the function bound to the '^' operator."""
-        return self._operators["^"](self, other)
+        return self.THREAD_LOCAL.operators["^"](self, other)
 
     @check.operator_is_defined("|")
     def __or__(self, other):
         """Apply the function bound to the '|' operator."""
-        return self._operators["|"](self, other)
+        return self.THREAD_LOCAL.operators["|"](self, other)
 
     def to_bytes(self):
         weights = []

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -47,10 +47,11 @@ class Model(object):
             print(model + other)
             # Raises TypeError --- binding limited to scope of with block.
         """
-        cls._thread_local.old_operators = dict(getattr(cls._thread_local, "operators", {}))
+        cls._thread_local.old_operator_stack = getattr(cls._thread_local, "old_operator_stack", [])
+        cls._thread_local.old_operator_stack.append(dict(getattr(cls._thread_local, "operators", {})))
         cls._thread_local.operators = dict(operators)
         yield
-        cls._thread_local.operators = dict(cls._thread_local.old_operators)
+        cls._thread_local.operators = dict(cls._thread_local.old_operator_stack.pop())
 
     @classmethod
     @contextlib.contextmanager

--- a/thinc/tests/unit/test_model.py
+++ b/thinc/tests/unit/test_model.py
@@ -84,12 +84,12 @@ def test_init_calls_hooks():
 
 
 def test_use_device():
-    dev_id = id(base.Model.ops)
-    with base.Model.use_device(base.Model.ops.device):
-        assert id(base.Model.ops) == dev_id
+    dev_id = id(base.Model._thread_local.ops)
+    with base.Model.use_device(base.Model._thread_local.ops.device):
+        assert id(base.Model._thread_local.ops) == dev_id
     with base.Model.use_device("gpu"):
-        assert id(base.Model.ops) != dev_id
-    assert id(base.Model.ops) == dev_id
+        assert id(base.Model._thread_local.ops) != dev_id
+    assert id(base.Model._thread_local.ops) == dev_id
 
 
 def test_bind_plus():

--- a/thinc/tests/unit/test_model.py
+++ b/thinc/tests/unit/test_model.py
@@ -141,6 +141,24 @@ def _overload_plus(operator, sleep):
     assert value == "ab"
 
 
+def test_nested_operator_contexts():
+    operator = "+"
+    m1 = base.Model(name="a")
+    m2 = base.Model(name="b")
+    with base.Model.define_operators({"+": lambda a, b: a.name + b.name}):
+        value = m1 + m2
+        with pytest.raises(TypeError):
+            value = m1 * m2
+        with base.Model.define_operators({"*": lambda a, b: a.name + b.name}):
+            with pytest.raises(TypeError):
+                value = m1 + m2
+            value = m1 * m2
+        value = m1 + m2
+        with pytest.raises(TypeError):
+            value = m1 * m2
+    assert value == "ab"
+
+
 @pytest.mark.parametrize("op", "+ - * @ / // % ** << >> & ^ |".split())
 def test_all_operators(op):
     m1 = base.Model(name="a")


### PR DESCRIPTION
Make old/saved Model operators thread-local, too. Doesn't seem like a particularly great solution, but seems to least temporarily fix https://github.com/explosion/spaCy/issues/4349. I think better solutions would require a fairly major restructuring of `Model`.