### PR TITLE
CuPy package for CUDA 10.1 is `cupy-cuda101`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,7 @@ def setup_package():
                 "cuda91": ["cupy-cuda91>=5.0.0b4"],
                 "cuda92": ["cupy-cuda92>=5.0.0b4"],
                 "cuda100": ["cupy-cuda100>=5.0.0b4"],
-                "cuda110": ["cupy-cuda110>=5.0.0b4"],
+                "cuda101": ["cupy-cuda101>=5.0.0b4"],
             },
             classifiers=[
                 "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Currently `cupy-cuda110` does not exist.
https://docs-cupy.chainer.org/en/latest/install.html#install-cupy
https://pypi.org/project/cupy-cuda101/