### PR TITLE
Add Config class

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
         python.version: '3.6'
       Python37Linux:
         imageName: 'ubuntu-16.04'
-        python.version: '3.7.4'
+        python.version: '3.7.5'
       Python37Windows:
         imageName: 'vs2017-win2016'
         python.version: '3.7'

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,115 @@
+# Configuration files
+
+You can describe Thinc models and experiments using a configuration format
+based on Python's built-in `configparser` module. We add a few additional
+conventions to the built-in format, to provide support for non-string values,
+support nested objects, and to integrate with Thinc's *registry system*.
+
+## Example config
+
+
+```
+[some_section]
+key1 = "string value"
+another_key = 1.0
+# Comments, naturally
+third_key = ["values", "are parsed with", "json.loads()"]
+some_other_key =  
+    {
+        "multiline values?": true
+    }
+
+[another_section]
+more_values = "yes!"
+null_values = null
+interpolation = ${some_section:third_key}
+
+# Describe nested sections with a dot notation in the section names.
+[some_section.subsection]
+# This will be moved, producing:
+#   config["some_section"]["subsection"] = {"hi": true, "bye": false}
+hi = true
+bye = false
+```
+
+The config format has two has two main differences from the built-in `configparser`
+module's behaviour:
+
+* JSON-formatted values. Thinc passes all values through `json.loads()` to
+  interpret them. You can use atomic values like strings, floats, integers,
+  or booleans, or you can use complex objects such as lists or maps.
+
+* Structured sections. Thinc uses a dot notation to build nested sections. If
+  you have a section named `[outer_section.subsection]`, Thinc will parse that
+  into a nested structure, placing `subsection` within `outer_section`
+
+## Registry integration
+
+Thinc's registry system lets you map string keys to functions. For instance,
+let's say you want to define a new optimizer. You would define a function that
+constructs it, and add it to the right register, like so:
+
+```python
+
+import thinc
+
+@thinc.registry.optimizers.register("my_cool_optimizer.v1")
+def make_my_optimizer(learn_rate, gamma):
+    return MyCoolOptimizer(learn_rate, gamma)
+
+# Later you can retrieve your function by name:
+create_optimizer = thinc.registry.optimizers.get("my_cool_optimizer.v1")
+```
+
+The registry lets you refer to your function by string name, which is
+often more convenient than passing around the function itself. This is
+especially useful for configuration files: you can provide the name of your
+function and the arguments in the config file, and you'll have everything you
+need to rebuild the object.
+
+Since this is a common workflow, the registry system provides a shortcut for
+it, the `registry.make_from_config()` function. To use it, you just need to
+follow a simple convention in your config file.
+
+If a section contains a key beginning with @, the `registry.make_from_config()`
+function will interpret the rest of that key as the name of the registry. The
+value will be interpreted as the name to lookup. The rest of the section will
+be passed to your function as arguments. Here's a simple example:
+
+```
+[optimizer]
+@optimizers = "my_cool_optimizer.v1"
+learn_rate = 0.001
+gamma = 1e-8
+```
+
+The `registry.make_from_config()` function will fetch your 
+`make_my_optimizer` function from the `optimizers` registry, call it using the
+`learn_rate` and `gamma` arguments, and set the result of the function under
+the key `"optimizer"`.
+
+You can even use the  `registry.make_from_config()` function to build recursive
+structures. Let's say your optimizer supports some sort of fancy visualisation
+plug-in that Thinc has never heard of. All you would need to do is create a new
+registry, named something like `visualizers`, and register a constructor
+function, such as `my_visualizer.v1`. You would also make a new version of your
+optimizer constructor, to pass in the new value. Now you can describe the
+visualizer plugin in your config, so you can use it as an argument to your optimizer:
+
+```
+[optimizer]
+@optimizers = "my_cool_optimizer.v2"
+learn_rate = 0.001
+gamma = 1e-8
+
+[optimizer.visualizer]
+@visualizers = "my_visualizer.v1"
+format = "jpeg"
+host = "localhost"
+port = "8080"
+```
+
+The `optimizer.visualizer` section will be placed under the
+`optimizer` object, using the key `visualizer` (see "structured sections"
+above). The `registry.make_from_config()` function will build the visualizer
+first, so that the result value is ready for the optimizer.

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,20 +19,20 @@ some_other_key =
         "multiline values?": true
     }
 
-[another_section]
-more_values = "yes!"
-null_values = null
-interpolation = ${some_section:third_key}
-
 # Describe nested sections with a dot notation in the section names.
 [some_section.subsection]
 # This will be moved, producing:
 #   config["some_section"]["subsection"] = {"hi": true, "bye": false}
 hi = true
 bye = false
+
+[another_section]
+more_values = "yes!"
+null_values = null
+interpolation = ${some_section:third_key}
 ```
 
-The config format has two has two main differences from the built-in `configparser`
+The config format has two main differences from the built-in `configparser`
 module's behaviour:
 
 * JSON-formatted values. Thinc passes all values through `json.loads()` to

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ preshed>=1.0.1,<3.1.0
 blis>=0.4.0,<0.5.0
 srsly>=0.0.6,<1.1.0
 wasabi>=0.0.9,<1.1.0
+catalogue>=0.0.7,<1.1.0
 # Third-party dependencies
 numpy>=1.7.0
 plac>=0.9.6,<1.2.0

--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,7 @@ def setup_package():
                 "blis>=0.4.0,<0.5.0",
                 "wasabi>=0.0.9,<1.1.0",
                 "srsly>=0.0.6,<1.1.0",
+                "catalogue>=0.0.7,<1.1.0",
                 # Third-party dependencies
                 "numpy>=1.7.0",
                 "plac>=0.9.6,<1.2.0",

--- a/thinc/__init__.py
+++ b/thinc/__init__.py
@@ -5,3 +5,4 @@ from __future__ import unicode_literals
 import numpy  # noqa: F401
 
 from .about import __name__, __version__  # noqa: F401
+from ._registry import registry

--- a/thinc/_registry.py
+++ b/thinc/_registry.py
@@ -3,12 +3,8 @@ import catalogue
 
 class registry(object):
     optimizers = catalogue.create("thinc", "optimizers", entry_points=True)
-    rates = catalogue.create("thinc", "rates", entry_points=True)
-    
+    schedules = catalogue.create("thinc", "schedules", entry_points=True)
     layers = catalogue.create("thinc", "layers", entry_points=True)
-    initializers = catalogue.create("thinc", "initializers", entry_points=True)
-    combinators = catalogue.create("thinc", "combinators", entry_points=True)
-    transforms = catalogue.create("thinc", "transforms", entry_points=True)
 
     @classmethod
     def get(cls, name, key):

--- a/thinc/_registry.py
+++ b/thinc/_registry.py
@@ -1,0 +1,75 @@
+import catalogue
+
+
+class registry(object):
+    optimizers = catalogue.create("thinc", "optimizers", entry_points=True)
+    rates = catalogue.create("thinc", "rates", entry_points=True)
+    
+    layers = catalogue.create("thinc", "layers", entry_points=True)
+    initializers = catalogue.create("thinc", "initializers", entry_points=True)
+    combinators = catalogue.create("thinc", "combinators", entry_points=True)
+    transforms = catalogue.create("thinc", "transforms", entry_points=True)
+
+    @classmethod
+    def get(cls, name, key):
+        if not hasattr(cls, name):
+            raise ValueError("Unknown registry: %s" % name)
+        reg = getattr(cls, name)
+        func = reg.get(name)
+        if func is None:
+            raise ValueError("Could not find %s in %s" % (name, key))
+        return func
+
+    @classmethod
+    def make_optimizer(name, args, kwargs):
+        func = cls.optimizers.get(name)
+        return func(*args, **kwargs)
+
+    @classmethod
+    def make_schedule(name, args, kwargs):
+        func = cls.schedules.get(name)
+        return func(*args, **kwargs)
+
+    @classmethod
+    def make_initializer(name, args, kwargs):
+        func = cls.initializers.get(name)
+        return func(*args, **kwargs)
+
+    @classmethod
+    def make_layer(cls, name, args, kwargs):
+        func = cls.layers.get(name)
+        return func(*args, **kwargs)
+
+    @classmethod
+    def make_combinator(cls, name, args, kwargs):
+        func = cls.combinators.get(name)
+        return func(*args, **kwargs)
+
+    @classmethod
+    def make_transform(cls, name, args, kwargs):
+        func = cls.transforms.get(name)
+        return func(*args, **kwargs)
+
+    @classmethod
+    def make_from_config(cls, config, id_start="@"):
+        """Unpack a config dictionary, creating objects from the registry 
+        recursively.
+        """
+        id_keys = [key for key in config.keys() if key.startswith(id_start)]
+        if len(id_keys) >= 2:
+            raise ValueError("Multiple registry keys in config: %s" % id_keys)
+        elif len(id_keys) == 0:
+            return config
+        else:
+            getter = cls.get(id_keys[0].replace(id_start, ""), config[id_keys[0]])
+            args = []
+            kwargs = {}
+            for key, value in config.items():
+                if isinstance(value, dict):
+                    value = cls.make_from_config(value, id_start=id_start)
+                if isinstance(key, int) or key.isdigit():
+                    args.append((int(key), value))
+                elif not key.startswith(id_start):
+                    kwargs[key] = value
+            args = [value for key, value in sorted(args)]
+            return getter(*args, **kwargs)

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import configparser
+import json
 from pathlib import Path
 
 
@@ -18,15 +19,7 @@ class Config(dict):
             for part in parts:
                 node = node.setdefault(part, {})
             for key, value in values.items():
-                if is_float(value):
-                    node[key] = config.getfloat(section, key)
-                elif is_int(value):
-                    node[key] = config.getint(section, key)
-                elif is_bool(value):
-                    node[key] = config.getboolean(section, key)
-                else:
-                    value = strip_quotes(config.get(section, key))
-                    node[key] = value
+                node[key] = json.loads(config.get(section, key))
 
     def from_str(self, text):
         config = configparser.ConfigParser(
@@ -44,32 +37,3 @@ class Config(dict):
         with Path(path).open("r", encoding="utf8") as file_:
             text = file_.read()
         return self.from_str(text)
-
-
-def is_int(value):
-    try:
-        int(value)
-        return True
-    except ValueError:
-        return False
-
-def is_float(value):
-    try:
-        float(value)
-        return True
-    except ValueError:
-        return False
-
-def is_bool(value):
-    return value.lower() in ["true", "false"]
-
-
-def strip_quotes(value):
-    if len(value) < 3:
-        return value
-    elif value.startswith('"') and value.endswith('"'):
-        return value[1:-1]
-    elif value.startswith("'") and value.endswith("'"):
-        return value[1:-1]
-    else:
-        return value

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import configparser
 from pathlib import Path
 

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -28,8 +28,7 @@ class Config(dict):
                     value = strip_quotes(config.get(section, key))
                     node[key] = value
 
-    def from_bytes(self, byte_string):
-        text = byte_string.decode("utf8")
+    def from_str(self, text):
         config = configparser.ConfigParser(
             interpolation=configparser.ExtendedInterpolation())
         config.read_string(text)
@@ -38,10 +37,13 @@ class Config(dict):
         self.interpret_config(config)
         return self
 
+    def from_bytes(self, byte_string):
+        return self.from_str(byte_string.decode("utf8"))
+
     def from_disk(self, path):
-        with Path(path).open("rb", encoding="utf8") as file_:
-            data = file_.read()
-        return self.from_bytes(data)
+        with Path(path).open("r", encoding="utf8") as file_:
+            text = file_.read()
+        return self.from_str(text)
 
 
 def is_int(value):

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -1,0 +1,71 @@
+import configparser
+from pathlib import Path
+
+
+class Config(dict):
+    def __init__(self, data=None):
+        dict.__init__(self)
+        if data is None:
+            data = {}
+        self.update(data)
+
+    def interpret_config(self, config):
+        for section, values in config.items():
+            parts = section.split(".")
+            node = self
+            for part in parts:
+                node = node.setdefault(part, {})
+            for key, value in values.items():
+                if is_float(value):
+                    node[key] = config.getfloat(section, key)
+                elif is_int(value):
+                    node[key] = config.getint(section, key)
+                elif is_bool(value):
+                    node[key] = config.getboolean(section, key)
+                else:
+                    value = strip_quotes(config.get(section, key))
+                    node[key] = value
+
+    def from_bytes(self, byte_string):
+        text = byte_string.decode("utf8")
+        config = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation())
+        config.read_string(text)
+        for key in list(self.keys()):
+            self.pop(key)
+        self.interpret_config(config)
+        return self
+
+    def from_disk(self, path):
+        with Path(path).open("rb", encoding="utf8") as file_:
+            data = file_.read()
+        return self.from_bytes(data)
+
+
+def is_int(value):
+    try:
+        int(value)
+        return True
+    except ValueError:
+        return False
+
+def is_float(value):
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+def is_bool(value):
+    return value.lower() in ["true", "false"]
+
+
+def strip_quotes(value):
+    if len(value) < 3:
+        return value
+    elif value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    elif value.startswith("'") and value.endswith("'"):
+        return value[1:-1]
+    else:
+        return value

--- a/thinc/i2v.py
+++ b/thinc/i2v.py
@@ -2,5 +2,26 @@
 from __future__ import unicode_literals
 
 from .neural._classes.hash_embed import HashEmbed  # noqa: F401
-from .neural._classes.embed import Embed  # noqa: F401
+from .neural._classes.embed import Embed, SimpleEmbed  # noqa: F401
 from .neural._classes.static_vectors import StaticVectors  # noqa: F401
+from ._registry import registry
+
+
+@registry.layers.register("HashEmbed.v1")
+def make_HashEmbed(outputs, rows, column, seed=None):
+    return HashEmbed(outputs, rows, seed=seed, column=column)
+
+
+@registry.layers.register("SimpleEmbed.v1")
+def make_SimpleEmbed(outputs, rows, column):
+    return SimpleEmbed(outputs, rows, column)
+
+
+@registry.layers.register("EmbedAndProject.v1")
+def make_EmbedAndProject(outputs, rows, column):
+    return Embed(outputs, rows, column)
+
+
+@registry.layers.register("StaticVectors.v1")
+def make_StaticVectors(outputs, spacy_name, column, drop_factor=0.0):
+    return StaticVectors(nO=outputs, lang=spacy_name, column=column)

--- a/thinc/misc.py
+++ b/thinc/misc.py
@@ -7,3 +7,14 @@ from .neural._classes.resnet import Residual  # noqa: F401
 from .neural._classes.feature_extracter import FeatureExtracter  # noqa: F401
 from .neural._classes.function_layer import FunctionLayer  # noqa: F401
 from .neural._classes.feed_forward import FeedForward  # noqa: F401
+from ._registry import registry
+
+
+@registry.layers.register("FeatureExtractor.v1")
+def make_FeatureExtractor(attrs):
+    return FeatureExtracter(attrs)
+
+
+@registry.layers.register("LayerNorm.v1")
+def make_LayerNorm(outputs=None, child=None):
+    return LayerNorm(nO=outputs, child=child)

--- a/thinc/neural/optimizers.pyx
+++ b/thinc/neural/optimizers.pyx
@@ -13,26 +13,93 @@ import numpy
 from ..typedefs cimport weight_t
 from .ops import NumpyOps, CupyOps, add_gradient_noise
 from .util import get_array_module
+from .._registry import registry
 
 
-def linear_decay(rate, decay, nr_upd):
-    return rate * 1./(1. + decay * nr_upd)
+SGD_DEFAULTS = {
+    "L2": 1e-4,
+    "max_grad_norm": 10,
+    "L2_is_weight_decay": False
+}
 
 
-def anneal(rate, decay, decay_steps, nr_upd):
-    if decay == 0.0:
-        return rate
-    else:
-        return rate * decay ** (nr_upd / decay_steps)
+ADAM_DEFAULTS = {
+    "L2": SGD_DEFAULTS["L2"],
+    "beta1": 0.9,
+    "beta2": 0.999,
+    "eps": 1e-08,
+    "max_grad_norm": SGD_DEFAULTS["max_grad_norm"],
+    "L2_is_weight_decay": SGD_DEFAULTS["L2_is_weight_decay"]
+}
 
-def Adam(*args, **kwargs):
-    return Optimizer(*args, **kwargs)
+
+@registry.optimizers.register("thinc.RAdam.v1")
+def RAdam(learn_rate,
+        ops=None,
+        L2=ADAM_DEFAULTS["L2"],
+        beta1=ADAM_DEFAULTS["beta1"],
+        beta2=ADAM_DEFAULTS["beta2"],
+        eps=ADAM_DEFAULTS["eps"],
+        max_grad_norm=ADAM_DEFAULTS["max_grad_norm"],
+        L2_is_weight_decay=ADAM_DEFAULTS["L2_is_weight_decay"],
+        schedules=None
+):
+    ops = _make_ops(ops)
+    return Optimizer(
+        ops,
+        learn_rate,
+        L2=L2,
+        beta1=beta1,
+        beta2=beta2,
+        eps=eps,
+        max_grad_norm=max_grad_norm,
+        L2_is_weight_decay=L2_is_weight_decay,
+        schedules=schedules,
+        nesterov=None, lookahead_k=0, lookahead_alpha=0,
+        use_radam=True, use_lars=False
+    )
 
 
-def SGD(*args, **kwargs):
-    kwargs.setdefault('beta1', 0.)
-    kwargs.setdefault('beta2', 0.)
-    return Optimizer(*args, **kwargs)
+@registry.optimizers.register("thinc.Adam.v1")
+def Adam(learn_rate,
+        ops=None,
+        L2=ADAM_DEFAULTS["L2"],
+        beta1=ADAM_DEFAULTS["beta1"],
+        beta2=ADAM_DEFAULTS["beta2"],
+        eps=ADAM_DEFAULTS["eps"],
+        max_grad_norm=ADAM_DEFAULTS["max_grad_norm"],
+        L2_is_weight_decay=ADAM_DEFAULTS["L2_is_weight_decay"],
+        schedules=None
+):
+    ops = _make_ops(ops)
+    return Optimizer(
+        ops,
+        learn_rate,
+        L2=L2,
+        beta1=beta1,
+        beta2=beta2,
+        eps=eps,
+        max_grad_norm=max_grad_norm,
+        L2_is_weight_decay=L2_is_weight_decay,
+        schedules=schedules,
+        decay=0.0, decay_steps=0, b1_decay=0, b2_decay=0, 
+        nesterov=None, lookahead_k=0, lookahead_alpha=0,
+        use_radam=False, use_lars=False
+    )
+
+
+@registry.optimizers.register("thinc.SGD.v1")
+def SGD(learn_rate,
+        ops=None,
+        L2=SGD_DEFAULTS["L2"],
+        max_grad_norm=SGD_DEFAULTS["max_grad_norm"],
+        L2_is_weight_decay=SGD_DEFAULTS["L2_is_weight_decay"],
+        schedules=None
+):
+    ops = _make_ops(ops)
+    return Optimizer(ops, learn_rate,
+        L2=L2, max_grad_norm=max_grad_norm, L2_is_weight_decay=L2_is_weight_decay,
+        schedules=schedules, beta1=0.0, beta2=0.0)
 
 
 class Optimizer(object):
@@ -46,12 +113,19 @@ class Optimizer(object):
     * beta1=0.0, beta2=0.2: RMS prop
     * b1=0.999, b2=0.9: Adam
     '''
-    def __init__(self, ops, lr, L2=1e-4, beta1=0.90, beta2=0.999, eps=1e-08, decay=0.0,
-                 decay_steps=5000,
-                 b1_decay=0.0, b2_decay=0.0, max_grad_norm=10., gradient_noise=0.0,
-                 nesterov=True, L2_is_weight_decay=False, lookahead_k=0,
-                 lookahead_alpha=0.5, use_radam=False, use_lars=False):
+    @classmethod
+    def from_config(cls, config):
+        return registry.unpack_config(config)
+
+    def __init__(self, ops, lr, L2=1e-4, beta1=0.90, beta2=0.999, eps=1e-08, 
+                 max_grad_norm=10., gradient_noise=0.0, nesterov=True,
+                 L2_is_weight_decay=False, lookahead_k=0, lookahead_alpha=0.5,
+                 use_radam=False, use_lars=False, schedule=None, **_):
         self.ops = ops
+        if schedule is None:
+            self.schedule = {}
+        else:
+            self.schedule = dict(schedule)
         self.mom1 = {}
         self.mom2 = {}
         self.slow_weights = {} # For lookahead
@@ -62,21 +136,23 @@ class Optimizer(object):
         self.alpha = lr
         self.b1 = beta1
         self.b2 = beta2
-        self.b1_decay = b1_decay
-        self.b2_decay = b1_decay
         self.gradient_noise = gradient_noise
         self.eps = eps
-        self.decay = decay
         self.L2 = L2
         self.nesterov = nesterov
-        self.decay_steps = decay_steps
         self.L2_is_weight_decay = L2_is_weight_decay
         self.lookahead_k = lookahead_k
         self.lookahead_alpha = lookahead_alpha
         self.use_radam = use_radam
+        # Deprecated
         self.use_lars = use_lars
+        self.decay = 0.0
+        self.decay_steps = 0
         self.lars_min = 0
         self.lars_max = 10
+        self.b1_decay = 0.0
+        self.b2_decay = 0.0
+
 
     def to_gpu(self):
         self.ops = CupyOps()
@@ -90,6 +166,18 @@ class Optimizer(object):
             for key, value in params.items():
                 if hasattr(value, 'get'):
                     params[key] = value.get()
+
+    def step_schedules(self):
+        for key, schedule in self.schedules.items():
+            setattr(self, key, next(schedule))
+
+    @property
+    def learn_rate(self):
+        return self.alpha
+
+    @learn_rate.setter
+    def learn_rate(self, learn_rate):
+        self.alpha = learn_rate
 
     def lr(self, nr_upd):
         alpha = anneal(self.alpha, self.decay, self.decay_steps, nr_upd)
@@ -229,3 +317,25 @@ class Optimizer(object):
         gradient.fill(0)
 
 
+def _make_ops(ops):
+    if ops == "CupyOps":
+        return CupyOps()
+    elif ops == "NumpyOps":
+        return NumpyOps()
+    elif ops is None:
+        from ._classes.model import Model
+        return Model.ops
+    else:
+        return ops
+
+
+# These are deprecated
+def linear_decay(rate, decay, nr_upd):
+    return rate * 1./(1. + decay * nr_upd)
+
+
+def anneal(rate, decay, decay_steps, nr_upd):
+    if decay == 0.0:
+        return rate
+    else:
+        return rate * decay ** (nr_upd / decay_steps)

--- a/thinc/t2t.py
+++ b/thinc/t2t.py
@@ -6,3 +6,14 @@ from .neural._classes.attention import ParametricAttention  # noqa: F401
 from .neural._classes.rnn import LSTM, BiLSTM  # noqa: F401
 from .neural._classes.multiheaded_attention import MultiHeadedAttention
 from .neural._classes.multiheaded_attention import prepare_self_attention
+from ._registry import registry
+
+
+@registry.layers.register("ExtractWindow.v1")
+def make_ExtractWindow(window_size):
+    return ExtractWindow(nW=window_size)
+
+
+@registry.layers.register("ParametricAttention.v1")
+def make_ParametricAttention(outputs):
+    return ParametricAttention(nO=outputs)

--- a/thinc/t2v.py
+++ b/thinc/t2v.py
@@ -2,3 +2,24 @@
 from __future__ import unicode_literals
 
 from .neural.pooling import Pooling, max_pool, mean_pool, sum_pool  # noqa: F401
+from ._registry import registry
+
+
+@registry.layers.register("MeanPooling.v1")
+def make_MeanPooling_v1():
+    return Pooling(mean_pool)
+
+
+@registry.layers.register("SumPooling.v1")
+def make_SumPooling_v1():
+    return Pooling(sum_pool)
+
+
+@registry.layers.register("MaxPooling.v1")
+def make_MaxPooling_v1():
+    return Pooling(max_pool)
+
+
+@registry.layers.register("MeanMaxPooling.v1")
+def make_MeanMaxPooling_v1():
+    return Pooling(mean_pool, max_pool)

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -8,13 +8,13 @@ EXAMPLE_CONFIG = """
 [DEFAULT]
 
 [optimizer]
-@optimizers: thinc.Adam.v1
+@optimizers = "thinc.Adam.v1"
 beta1 = 0.9
 beta2 = 0.999
 use_averages = true
 
 [optimizer.learn_rate]
-@schedules: thinc.warmup_linear_rate.v1
+@schedules = "thinc.warmup_linear_rate.v1"
 start = 0.1
 steps = 10000
 
@@ -25,48 +25,48 @@ name = "parser"
 factory = "parser"
 
 [pipeline.parser.model]
-@layers: spacy.ParserModel.v1
+@layers = "spacy.ParserModel.v1"
 hidden_depth = 1
 hidden_width = 64
 token_vector_width = 128
 
 [pipeline.parser.model.tok2vec]
-@layers: spacy.Tok2Vec.v1
+@layers = "spacy.Tok2Vec.v1"
 width = ${pipeline.parser.model:token_vector_width}
 
 [pipeline.parser.model.tok2vec.embed]
-@layers: spacy.MultiFeatureHashEmbed.v1
+@layers = "spacy.MultiFeatureHashEmbed.v1"
 width = ${pipeline.parser.model.tok2vec:width}
 
 [pipeline.parser.model.tok2vec.embed.hidden]
-@layers: thinc.MLP.v1
+@layers = "thinc.MLP.v1"
 depth = 1
 pieces = 3
 layer_norm = true
 outputs = ${pipeline.parser.model.tok2vec.embed:width}
 
 [pipeline.parser.model.tok2vec.encode]
-@layers: spacy.MaxoutWindowEncoder.v1
+@layers = "spacy.MaxoutWindowEncoder.v1"
 depth = 4
 pieces = 3
 window_size = 1
 
 [pipeline.parser.model.lower]
-@: spacy.ParserLower.v1
+@layers = "spacy.ParserLower.v1"
 
 [pipeline.parser.model.upper]
-@layers: thinc.Affine.v1
+@layers = "thinc.Affine.v1"
 """
 
 OPTIMIZER_CFG = """
 [optimizer]
-@optimizers: thinc.Adam.v1
+@optimizers = "thinc.Adam.v1"
 beta1 = 0.9
 beta2 = 0.999
 use_averages = true
 
 [optimizer.schedules.learn_rate]
-@schedules: thinc.warmup_linear_rate.v1
+@schedules = "thinc.warmup_linear_rate.v1"
 start = 0.1
 steps = 10000
 """

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1,0 +1,66 @@
+import json
+from thinc.config import Config
+
+
+EXAMPLE_CONFIG = """
+[DEFAULT]
+
+[optimizer]
+@: thinc.optimizers.Adam.v1
+beta1 = 0.9
+beta2 = 0.999
+use_averages = true
+
+[optimizer.learn_rate]
+@: thinc.rates.warmup_linear_rate.v1
+start = 0.1
+steps = 10000
+
+[pipeline]
+
+[pipeline.parser]
+name = "parser"
+factory = "parser"
+
+[pipeline.parser.model]
+@: spacy.parser.v1
+hidden_depth = 1
+hidden_width = 64
+token_vector_width = 128
+
+[pipeline.parser.model.tok2vec]
+@: spacy.Tok2Vec.v1
+width = ${pipeline.parser.model:token_vector_width}
+
+[pipeline.parser.model.tok2vec.embed]
+@: spacy.MultiFeatureHashEmbed.v1
+width = ${pipeline.parser.model.tok2vec:width}
+
+[pipeline.parser.model.tok2vec.embed.hidden]
+@: thinc.v2v.MLP.v1
+depth = 1
+pieces = 3
+layer_norm = true
+outputs = ${pipeline.parser.model.tok2vec.embed:width}
+
+[pipeline.parser.model.tok2vec.encode]
+@: spacy.MaxoutWindowEncoder.v1
+depth = 4
+pieces = 3
+window_size = 1
+
+[pipeline.parser.model.lower]
+@: spacy.ParserLower.v1
+
+[pipeline.parser.model.upper]
+@: thinc.v2v.Affine.v1
+"""
+
+
+def test_read_config():
+    byte_string = EXAMPLE_CONFIG.encode("utf8")
+    cfg = Config().from_bytes(byte_string)
+    assert cfg["optimizer"]["learn_rate"]["start"] == 0.1
+    assert cfg["pipeline"]["parser"]["factory"] == "parser"
+    assert cfg["pipeline"]["parser"]["model"]["tok2vec"]["width"] == 128
+    print(json.dumps(cfg, indent=2))

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from thinc.config import Config
+from thinc.neural.optimizers import Optimizer
 
 
 EXAMPLE_CONFIG = """
@@ -57,6 +58,18 @@ window_size = 1
 @layers: thinc.Affine.v1
 """
 
+OPTIMIZER_CFG = """
+[optimizer]
+@optimizers: thinc.Adam.v1
+beta1 = 0.9
+beta2 = 0.999
+use_averages = true
+
+[optimizer.schedules.learn_rate]
+@schedules: thinc.warmup_linear_rate.v1
+start = 0.1
+steps = 10000
+"""
 
 def test_read_config():
     byte_string = EXAMPLE_CONFIG.encode("utf8")
@@ -64,3 +77,9 @@ def test_read_config():
     assert cfg["optimizer"]["learn_rate"]["start"] == 0.1
     assert cfg["pipeline"]["parser"]["factory"] == "parser"
     assert cfg["pipeline"]["parser"]["model"]["tok2vec"]["width"] == 128
+
+
+def test_optimizer_config():
+    cfg = Config().from_bytes(OPTIMIZER_CFG.encode("utf8"))
+    optimizer = Optimizer.from_config(cfg)
+

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -7,13 +7,13 @@ EXAMPLE_CONFIG = """
 [DEFAULT]
 
 [optimizer]
-@: thinc.optimizers.Adam.v1
+@optimizers: thinc.Adam.v1
 beta1 = 0.9
 beta2 = 0.999
 use_averages = true
 
 [optimizer.learn_rate]
-@: thinc.rates.warmup_linear_rate.v1
+@schedules: thinc.warmup_linear_rate.v1
 start = 0.1
 steps = 10000
 
@@ -24,28 +24,28 @@ name = "parser"
 factory = "parser"
 
 [pipeline.parser.model]
-@: spacy.parser.v1
+@layers: spacy.ParserModel.v1
 hidden_depth = 1
 hidden_width = 64
 token_vector_width = 128
 
 [pipeline.parser.model.tok2vec]
-@: spacy.Tok2Vec.v1
+@layers: spacy.Tok2Vec.v1
 width = ${pipeline.parser.model:token_vector_width}
 
 [pipeline.parser.model.tok2vec.embed]
-@: spacy.MultiFeatureHashEmbed.v1
+@layers: spacy.MultiFeatureHashEmbed.v1
 width = ${pipeline.parser.model.tok2vec:width}
 
 [pipeline.parser.model.tok2vec.embed.hidden]
-@: thinc.v2v.MLP.v1
+@layers: thinc.MLP.v1
 depth = 1
 pieces = 3
 layer_norm = true
 outputs = ${pipeline.parser.model.tok2vec.embed:width}
 
 [pipeline.parser.model.tok2vec.encode]
-@: spacy.MaxoutWindowEncoder.v1
+@layers: spacy.MaxoutWindowEncoder.v1
 depth = 4
 pieces = 3
 window_size = 1
@@ -54,7 +54,7 @@ window_size = 1
 @: spacy.ParserLower.v1
 
 [pipeline.parser.model.upper]
-@: thinc.v2v.Affine.v1
+@layers: thinc.Affine.v1
 """
 
 

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1,4 +1,5 @@
-import json
+from __future__ import unicode_literals
+
 from thinc.config import Config
 
 
@@ -63,4 +64,3 @@ def test_read_config():
     assert cfg["optimizer"]["learn_rate"]["start"] == 0.1
     assert cfg["pipeline"]["parser"]["factory"] == "parser"
     assert cfg["pipeline"]["parser"]["model"]["tok2vec"]["width"] == 128
-    print(json.dumps(cfg, indent=2))

--- a/thinc/v2v.py
+++ b/thinc/v2v.py
@@ -8,3 +8,24 @@ from .neural._classes.maxout import Maxout  # noqa: F401
 from .neural._classes.softmax import Softmax  # noqa: F401
 from .neural._classes.selu import SELU  # noqa: F401
 from .neural._classes.mish import Mish  # noqa: F401
+from ._registry import registry
+
+
+@registry.layers.register("ReLu.v1")
+def make_ReLu(outputs, inputs=None):
+    return ReLu(nO=outputs, nI=inputs)
+
+
+@registry.layers.register("Mish.v1")
+def make_Mish(outputs, inputs=None):
+    return Mish(nO=outputs, nI=inputs)
+
+
+@registry.layers.register("Softmax.v1")
+def make_Softmax(outputs, inputs=None):
+    return Softmax(nO=outputs, nI=inputs)
+
+
+@registry.layers.register("Maxout.v1")
+def make_Maxout(outputs, pieces, inputs=None):
+    return Maxout(nO=outputs, nI=inputs, pieces=pieces)


### PR DESCRIPTION
With the move to use [catalogue](https://github.com/explosion/catalogue) for extended configuration in spaCy, we need a solution for configuration management. It makes sense for the solution to live in Thinc, because Thinc's optimizers, layers etc should all work with the config management.

I looked closely at all of the options for config management. The config files will get pretty big, so we shouldn't just use JSON. YAML is terrible. XML would work but it'll involve a fair bit of code. TOML and HCL don't have first-part support in Python, and they're a bit less common.

I'm proposing a solution based on Python's configparser module, with a couple of small conventions. 

Configparser's format is an ini-like format that maps into a two-level dict:

```
[outer key 1]
inner key 1a = 1
inner key 1b = 2

[outer key 2]
inner key 2a = 3
inner key 2b = 4
```

Produces:

```
{
  "outer key 1": {
    "inner key 1a": "1",
    "inner key 1b": "2"
  },
  "outer key 2": {
    "outer key 2a": "3",
    "outer key 2b": "4"
  }
}
```

Our configs need nested values. I propose we do these via convention, transforming sections like `parser.model` so that they become `config["parser"]["model"]`. This actually works out pretty nicely: the file is just a long list of leaf-data, with the structure handled in the titles. It's also pretty easy to read and write the data this way.

I've also added some simple value interpretation logic, so that floats, ints and booleans come back as the correct values. The configparser supports unquoted strings in the values, which I think is pretty sloppy...I think we probably want to raise on those. That would also allow us to add some extra syntax for paths.

The other bit of convention I've introduced is using `@` to denote that a section refers to a catalogue entry. The configparser format supports both `:` and `=` as delimiters. I'm proposing using `:` only for the `@` key.

Finally, configparser also supports variable interpolation. You can refer to a different value in the config by writing `${other_section:other_key}`. If you're referring to a value within the same section, you don't need to write the section name.
