### PR TITLE
Use pydantic to fill config defaults. Drop old Pythons

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,21 +9,6 @@ jobs:
 - job: 'Test'
   strategy:
     matrix:
-      Python27Linux:
-        imageName: 'ubuntu-16.04'
-        python.version: '2.7.16'
-      Python27Mac:
-        imageName: 'macos-10.13'
-        python.version: '2.7'
-      Python35Linux:
-        imageName: 'ubuntu-16.04'
-        python.version: '3.5.7'
-      Python35Windows:
-        imageName: 'vs2017-win2016'
-        python.version: '3.5'
-      Python35Mac:
-        imageName: 'macos-10.13'
-        python.version: '3.5'
       Python36Linux:
         imageName: 'ubuntu-16.04'
         python.version: '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ srsly>=0.0.6,<1.1.0
 wasabi>=0.0.9,<1.1.0
 catalogue>=0.0.7,<1.1.0
 # Third-party dependencies
+pydantic>=1.3,<1.4
 numpy>=1.7.0
 plac>=0.9.6,<1.2.0
 tqdm>=4.10.0,<5.0.0

--- a/setup.py
+++ b/setup.py
@@ -227,6 +227,7 @@ def setup_package():
                 "plac>=0.9.6,<1.2.0",
                 "tqdm>=4.10.0,<5.0.0",
                 'pathlib==1.0.1; python_version < "3.4"',
+                "pydantic>=1.3,<1.4"
             ],
             extras_require={
                 "cuda": ["cupy>=5.0.0b4"],
@@ -247,11 +248,6 @@ def setup_package():
                 "Operating System :: MacOS :: MacOS X",
                 "Operating System :: Microsoft :: Windows",
                 "Programming Language :: Cython",
-                "Programming Language :: Python :: 2.6",
-                "Programming Language :: Python :: 2.7",
-                "Programming Language :: Python :: 3.3",
-                "Programming Language :: Python :: 3.4",
-                "Programming Language :: Python :: 3.5",
                 "Programming Language :: Python :: 3.6",
                 "Programming Language :: Python :: 3.7",
                 "Programming Language :: Python :: 3.8",

--- a/thinc/_registry.py
+++ b/thinc/_registry.py
@@ -1,4 +1,6 @@
 import catalogue
+import inspect
+from pydantic import create_model
 
 
 class registry(object):
@@ -17,62 +19,100 @@ class registry(object):
         return func
 
     @classmethod
-    def make_optimizer(name, args, kwargs):
-        func = cls.optimizers.get(name)
-        return func(*args, **kwargs)
-
-    @classmethod
-    def make_schedule(name, args, kwargs):
-        func = cls.schedules.get(name)
-        return func(*args, **kwargs)
-
-    @classmethod
-    def make_initializer(name, args, kwargs):
-        func = cls.initializers.get(name)
-        return func(*args, **kwargs)
-
-    @classmethod
-    def make_layer(cls, name, args, kwargs):
-        func = cls.layers.get(name)
-        return func(*args, **kwargs)
-
-    @classmethod
-    def make_combinator(cls, name, args, kwargs):
-        func = cls.combinators.get(name)
-        return func(*args, **kwargs)
-
-    @classmethod
-    def make_transform(cls, name, args, kwargs):
-        func = cls.transforms.get(name)
-        return func(*args, **kwargs)
-
-    @classmethod
-    def make_from_config(cls, config, id_start="@"):
+    def make_from_config(cls, config):
         """Unpack a config dictionary, creating objects from the registry 
         recursively.
         """
-        id_keys = [key for key in config.keys() if key.startswith(id_start)]
-        if len(id_keys) >= 2:
-            raise ValueError("Multiple registry keys in config: %s" % id_keys)
-        elif len(id_keys) == 0:
-            # Recurse over subdictionaries, filling in values.
-            filled = {}
-            for key, value in config.items():
-                if isinstance(value, dict):
-                    filled[key] = cls.make_from_config(value, id_start=id_start)
-                else:
-                    filled[key] = value
-            return filled
+        # Recurse over subdictionaries, filling in values.
+        filled = {}
+        for key, value in config.items():
+            if isinstance(value, dict):
+                filled[key] = cls.make_from_config(value, id_start=id_start)
+            else:
+                filled[key] = value
+        if cls.is_promise(filled):
+            getter = cls.get_constructor(filled)
+            args, kwargs = cls.parse_args(filled)
+            return getter(*args, **kwargs)
         else:
-            getter = cls.get(id_keys[0].replace(id_start, ""), config[id_keys[0]])
-            args = []
-            kwargs = {}
-            for key, value in config.items():
-                if isinstance(value, dict):
-                    value = cls.make_from_config(value, id_start=id_start)
+            return filled
+
+    @classmethod
+    def fill_and_validate(cls, config, schema):
+        # Build two representations of the config: one where the promises are
+        # preserved, and a second where the promises are represented by their
+        # return types. Use the validation representation to get default
+        # values via PyDantic. The defaults are filled into both representations.
+        filled = {}
+        validation = {}
+        for key, value in config.items():
+            if cls.is_promise(value):
+                promise_schema = cls.make_promise_schema(value)
+                filled[key], _ = cls.fill_and_validate(value, promise_schema)
+                type_ = cls.get_return_type(value)
+                validation[key] = type_.__new__(type_)
+            elif hasattr(value, "items"):
+                field = schema.__fields__[key]
+                filled[key], validation[key] = cls.fill_and_validate(
+                    value, field.type_
+                )
+            else:
+                filled[key] = value
+                validation[key] = value
+        # Now that we've filled in all of the promises, update with defaults
+        # from schema, and validate.
+        validation.update(schema.parse_obj(validation).dict())
+        for key, value in validation.items():
+            if key not in filled:
+                filled[key] = value
+        return filled, validation
+
+    @classmethod
+    def is_promise(cls, obj):
+        if not hasattr(obj, "keys"):
+            return False
+        id_keys = [k for k in obj.keys() if k.startswith("@")]
+        if len(id_keys) != 1:
+            return False
+        else:
+            return True
+
+    @classmethod
+    def get_constructor(cls, obj):
+        id_keys = [k for k in obj.keys() if k.startswith("@")]
+        if len(id_keys) != 1:
+            raise ValueError
+        else:
+            key = id_keys[0]
+            value = obj[key]
+            return cls.get(key[1:], value)
+
+    @classmethod
+    def parse_args(cls, obj):
+        args = []
+        kwargs = {}
+        for key, value in obj.items():
+            if not key.startswith("@"):
                 if isinstance(key, int) or key.isdigit():
                     args.append((int(key), value))
-                elif not key.startswith(id_start):
+                else:
                     kwargs[key] = value
-            args = [value for key, value in sorted(args)]
-            return getter(*args, **kwargs)
+        return [value for key, value in sorted(args)], kwargs
+
+    @classmethod
+    def make_promise_schema(cls, obj):
+        func = cls.get_constructor(obj)
+        # Read the argument annotations and defaults from the function signature
+        sig_args = {}
+        for param in inspect.signature(func).parameters.values():
+            # If no default value is specified assume that it's required
+            if param.default != param.empty:
+                sig_args[param.name] = (param.annotation, param.default)
+            else:
+                sig_args[param.name] = (param.annotation, ...)
+        return create_model("ArgModel", **sig_args)
+
+    @classmethod
+    def get_return_type(cls, obj):
+        func = cls.get_constructor(obj)
+        return inspect.signature(func).return_annotation

--- a/thinc/_registry.py
+++ b/thinc/_registry.py
@@ -30,7 +30,7 @@ class registry(object):
         filled = {}
         for key, value in config.items():
             if isinstance(value, dict):
-                filled[key] = cls.make_from_config(value, id_start=id_start)
+                filled[key] = cls.make_from_config(value)
             else:
                 filled[key] = value
         if cls.is_promise(filled):
@@ -115,8 +115,7 @@ class registry(object):
             else:
                 sig_args[param.name] = (param.annotation, ...)
 
-        return create_model("ArgModel", **sig_args,
-            __config__=_PromiseSchemaConfig)
+        return create_model("ArgModel", **sig_args, __config__=_PromiseSchemaConfig)
 
     @classmethod
     def get_return_type(cls, obj):

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import configparser
 import json
+import io
 from pathlib import Path
 
 
@@ -29,6 +30,32 @@ class Config(dict):
             self.pop(key)
         self.interpret_config(config)
         return self
+
+    def to_str(self):
+        flattened = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation())
+        queue = [(tuple(), self)]
+        for path, node in queue:
+            for key, value in node.items():
+                if hasattr(value, "items"):
+                    queue.append((path + (key,), value))
+                else:
+                    assert path
+                    section_name = ".".join(path)
+                    if not flattened.has_section(section_name):
+                        flattened.add_section(section_name)
+                    flattened.set(section_name, key, json.dumps(value))
+        string_io = io.StringIO()
+        flattened.write(string_io)
+        return string_io.getvalue()
+
+    def to_bytes(self):
+        return self.to_str().encode("utf8")
+
+    def to_disk(self, path):
+        path = Path(path)
+        with path.open("w", encoding="utf8") as file_:
+            file_.write(self.to_str())
 
     def from_bytes(self, byte_string):
         return self.from_str(byte_string.decode("utf8"))

--- a/thinc/extra/wrappers.py
+++ b/thinc/extra/wrappers.py
@@ -94,7 +94,7 @@ class PyTorchWrapper(Model):
 
         def backward_pytorch(dy_data, sgd=None):
             d_args, d_kwargs = self.prepare_backward_input(dy_data, y_var)
-            torch.autograd.backward(*d_args, **d_kwargs)
+            torch.autograd.backward(*d_args, **d_kwargs, retain_graph=True)
             if sgd is not None:
                 if self._optimizer is None:
                     self._optimizer = self._create_optimizer(sgd)

--- a/thinc/i2v.py
+++ b/thinc/i2v.py
@@ -1,5 +1,6 @@
 # coding: utf8
 from __future__ import unicode_literals
+from typing import Optional
 
 from .neural._classes.hash_embed import HashEmbed  # noqa: F401
 from .neural._classes.embed import Embed, SimpleEmbed  # noqa: F401
@@ -8,20 +9,20 @@ from ._registry import registry
 
 
 @registry.layers.register("HashEmbed.v1")
-def make_HashEmbed(outputs, rows, column, seed=None):
+def make_HashEmbed(outputs: int, rows: int, column: int, seed: Optional[int]=None):
     return HashEmbed(outputs, rows, seed=seed, column=column)
 
 
 @registry.layers.register("SimpleEmbed.v1")
-def make_SimpleEmbed(outputs, rows, column):
+def make_SimpleEmbed(outputs: int, rows: int, column: int):
     return SimpleEmbed(outputs, rows, column)
 
 
 @registry.layers.register("EmbedAndProject.v1")
-def make_EmbedAndProject(outputs, rows, column):
+def make_EmbedAndProject(outputs: int, rows: int, column: int):
     return Embed(outputs, rows, column)
 
 
 @registry.layers.register("StaticVectors.v1")
-def make_StaticVectors(outputs, spacy_name, column, drop_factor=0.0):
+def make_StaticVectors(outputs: int, spacy_name: str, column: int):
     return StaticVectors(nO=outputs, lang=spacy_name, column=column)

--- a/thinc/misc.py
+++ b/thinc/misc.py
@@ -1,5 +1,6 @@
 # coding: utf8
 from __future__ import unicode_literals
+from typing import Sequence, Optional, Union
 
 from .neural._classes.batchnorm import BatchNorm  # noqa: F401
 from .neural._classes.layernorm import LayerNorm  # noqa: F401
@@ -11,10 +12,10 @@ from ._registry import registry
 
 
 @registry.layers.register("FeatureExtractor.v1")
-def make_FeatureExtractor(attrs):
+def make_FeatureExtractor(attrs: Sequence[Union[int, str]]):
     return FeatureExtracter(attrs)
 
 
 @registry.layers.register("LayerNorm.v1")
-def make_LayerNorm(outputs=None, child=None):
+def make_LayerNorm(outputs: Optional[int]=None, child=None):
     return LayerNorm(nO=outputs, child=child)

--- a/thinc/neural/optimizers.pyx
+++ b/thinc/neural/optimizers.pyx
@@ -7,6 +7,7 @@ from libc.math cimport exp, sqrt
 from libc.stdlib cimport calloc, malloc, free
 import math
 
+from typing import Sequence, Dict
 from collections import defaultdict
 import numpy
 
@@ -36,15 +37,16 @@ ADAM_DEFAULTS = {
 
 
 @registry.optimizers.register("RAdam.v1")
-def create_RAdam(learn_rate=ADAM_DEFAULTS["learn_rate"],
-        L2=ADAM_DEFAULTS["L2"],
-        beta1=ADAM_DEFAULTS["beta1"],
-        beta2=ADAM_DEFAULTS["beta2"],
-        eps=ADAM_DEFAULTS["eps"],
-        max_grad_norm=ADAM_DEFAULTS["max_grad_norm"],
-        L2_is_weight_decay=ADAM_DEFAULTS["L2_is_weight_decay"],
-        use_averages=True,
-        schedules=None,
+def create_RAdam(
+        learn_rate: float=ADAM_DEFAULTS["learn_rate"],
+        L2: float=ADAM_DEFAULTS["L2"],
+        beta1: float=ADAM_DEFAULTS["beta1"],
+        beta2: float=ADAM_DEFAULTS["beta2"],
+        eps: float=ADAM_DEFAULTS["eps"],
+        max_grad_norm: float=ADAM_DEFAULTS["max_grad_norm"],
+        L2_is_weight_decay: bool=ADAM_DEFAULTS["L2_is_weight_decay"],
+        use_averages: bool=True,
+        schedules: Dict[str, Sequence[float]]=None,
         ops=None,
 ):
     ops = _make_ops(ops)
@@ -65,16 +67,17 @@ def create_RAdam(learn_rate=ADAM_DEFAULTS["learn_rate"],
 
 
 @registry.optimizers.register("Adam.v1")
-def create_Adam(learn_rate=ADAM_DEFAULTS["learn_rate"],
-        L2=ADAM_DEFAULTS["L2"],
-        beta1=ADAM_DEFAULTS["beta1"],
-        beta2=ADAM_DEFAULTS["beta2"],
-        eps=ADAM_DEFAULTS["eps"],
-        max_grad_norm=ADAM_DEFAULTS["max_grad_norm"],
-        L2_is_weight_decay=ADAM_DEFAULTS["L2_is_weight_decay"],
-        use_averages=True,
+def create_Adam(
+        learn_rate: float=ADAM_DEFAULTS["learn_rate"],
+        L2: float=ADAM_DEFAULTS["L2"],
+        beta1: float=ADAM_DEFAULTS["beta1"],
+        beta2: float=ADAM_DEFAULTS["beta2"],
+        eps: float=ADAM_DEFAULTS["eps"],
+        max_grad_norm: float=ADAM_DEFAULTS["max_grad_norm"],
+        L2_is_weight_decay: bool=ADAM_DEFAULTS["L2_is_weight_decay"],
+        use_averages: bool=True,
         ops=None,
-        schedules=None
+        schedules: Dict[str, Sequence[float]]=None
 ):
     ops = _make_ops(ops)
     return Optimizer(

--- a/thinc/neural/optimizers.pyx
+++ b/thinc/neural/optimizers.pyx
@@ -61,7 +61,7 @@ def create_RAdam(
         L2_is_weight_decay=True,
         L2=weight_decay,
         schedules=schedules,
-        nesterov=None, lookahead_k=0, lookahead_alpha=0,
+        nesterov=None, lookahead_k=lookahead_k, lookahead_alpha=lookahead_alpha,
         use_averages=True,
         use_radam=True, use_lars=False
     )
@@ -77,7 +77,7 @@ def create_Adam(
         max_grad_norm: float=ADAM_DEFAULTS["max_grad_norm"],
         L2_is_weight_decay: bool=ADAM_DEFAULTS["L2_is_weight_decay"],
         use_averages: bool=True,
-        lookahead_k: int=6,
+        lookahead_k: int=0,
         lookahead_alpha: float=0.5,
         ops=None,
         schedules: Dict[str, Sequence[float]]=None

--- a/thinc/neural/optimizers.pyx
+++ b/thinc/neural/optimizers.pyx
@@ -44,7 +44,7 @@ def create_RAdam(
         eps: float=ADAM_DEFAULTS["eps"],
         weight_decay: float=ADAM_DEFAULTS["L2"],
         max_grad_norm: float=ADAM_DEFAULTS["max_grad_norm"],
-        lookeahead_k: int=6,
+        lookahead_k: int=0,
         lookahead_alpha: float=0.5,
         use_averages: bool=True,
         schedules: Dict[str, Sequence[float]]=None,

--- a/thinc/t2t.py
+++ b/thinc/t2t.py
@@ -30,7 +30,7 @@ def make_TorchBiLSTM(outputs: int, inputs: int, depth: int, dropout: float=0.2):
     return with_square_sequences(PyTorchWrapperRNN(model))
 
 
-@registry.architectures.register("MaxoutWindowEncoder.v1")
+@registry.layers.register("MaxoutWindowEncoder.v1")
 def make_MaxoutWindowEncoder(width: int, depth: int, *, pieces: int, window_size: int):
     from .neural._classes.model import Model
     from .neural._classes.maxout import Maxout
@@ -49,7 +49,7 @@ def make_MaxoutWindowEncoder(width: int, depth: int, *, pieces: int, window_size
     return model
 
 
-@registry.architectures.register("MishWindowEncoder.v1")
+@registry.layers.register("MishWindowEncoder.v1")
 def make_MishWindowEncoder(width: int, depth: int, *, window_size: int):
     from .neural._classes.mish import Mish
     from .neural._classes.model import Model

--- a/thinc/t2t.py
+++ b/thinc/t2t.py
@@ -7,13 +7,62 @@ from .neural._classes.rnn import LSTM, BiLSTM  # noqa: F401
 from .neural._classes.multiheaded_attention import MultiHeadedAttention
 from .neural._classes.multiheaded_attention import prepare_self_attention
 from ._registry import registry
+from .api import layerize, noop, with_square_sequences
+from .extra.wrappers import PyTorchWrapperRNN
 
 
 @registry.layers.register("ExtractWindow.v1")
-def make_ExtractWindow(window_size):
+def make_ExtractWindow(window_size: int):
     return ExtractWindow(nW=window_size)
 
 
 @registry.layers.register("ParametricAttention.v1")
-def make_ParametricAttention(outputs):
+def make_ParametricAttention(outputs: int):
     return ParametricAttention(nO=outputs)
+
+
+@registry.layers.register("TorchBiLSTM.v1")
+def make_TorchBiLSTM(outputs: int, inputs: int, depth: int, dropout: float=0.2):
+    import torch.nn
+    if depth == 0:
+        return layerize(noop())
+    model = torch.nn.LSTM(nI, nO // 2, depth, bidirectional=True, dropout=dropout)
+    return with_square_sequences(PyTorchWrapperRNN(model))
+
+
+@registry.architectures.register("MaxoutWindowEncoder.v1")
+def make_MaxoutWindowEncoder(width: int, depth: int, *, pieces: int, window_size: int):
+    from .neural._classes.model import Model
+    from .neural._classes.maxout import Maxout
+    from .neural._classes.resnet import Residual
+    from .neural._classes.layernorm import LayerNorm
+    from .api import chain, clone
+
+    n_tokens = (window_size * 2) + 1
+    with Model.define_operators({">>": chain, "**": clone}):
+        model = Residual(
+            ExtractWindow(nW=window)
+            >> LayerNorm(Maxout(width, width * n_tokens, pieces=pieces))
+        ) ** depth
+    model.nO = nO
+    model.receptive_field = n_tokens * depth
+    return model
+
+
+@registry.architectures.register("MishWindowEncoder.v1")
+def make_MishWindowEncoder(width: int, depth: int, *, window_size: int):
+    from .neural._classes.mish import Mish
+    from .neural._classes.model import Model
+    from .neural._classes.resnet import Residual
+    from .neural._classes.layernorm import LayerNorm
+    from .api import chain, clone
+
+    n_tokens = (window_size * 2) + 1
+    with Model.define_operators({">>": chain, "**": clone}):
+        model = Residual(
+            ExtractWindow(nW=window)
+            >> LayerNorm(Mish(width, width * n_tokens))
+        ) ** depth
+    model.nO = nO
+    model.receptive_field = n_tokens * depth
+    return model

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from thinc.config import Config
 from thinc.neural.optimizers import Optimizer
+import thinc.rates
 
 
 EXAMPLE_CONFIG = """
@@ -81,6 +82,11 @@ def test_read_config():
 
 
 def test_optimizer_config():
-    cfg = Config().from_bytes(OPTIMIZER_CFG.encode("utf8"))
-    optimizer = Optimizer.from_config(cfg)
+    cfg = Config().from_str(OPTIMIZER_CFG)
+    optimizer = Optimizer.from_config(cfg["optimizer"])
+    assert optimizer.b1 == 0.9
 
+
+def test_config_to_str():
+    cfg = Config().from_str(OPTIMIZER_CFG)
+    assert cfg.to_str().strip() == OPTIMIZER_CFG.strip()

--- a/thinc/tests/unit/test_registry.py
+++ b/thinc/tests/unit/test_registry.py
@@ -1,0 +1,133 @@
+import pytest
+from pydantic import BaseModel
+from pydantic.error_wrappers import ValidationError
+import catalogue
+import thinc._registry
+
+
+class my_registry(thinc._registry.registry):
+    cats = catalogue.create("thinc", "tests", "cats", entry_points=False)
+
+
+class HelloIntsSchema(BaseModel):
+    hello: int
+    world: int
+
+class DefaultsSchema(BaseModel):
+    required: int
+    optional: str = "default value"
+
+
+class ComplexSchema(BaseModel):
+    outer_req: int
+    outer_opt: str = "default value"
+
+    level2_req: HelloIntsSchema
+    level2_opt: DefaultsSchema = DefaultsSchema(required=1)
+    
+
+def test_validate_simple_config():
+    simple_config = {
+        "hello": 1,
+        "world": 2
+    }
+    f, v = my_registry.fill_and_validate(simple_config, HelloIntsSchema)
+    assert f == simple_config
+    assert v == simple_config
+
+
+def test_invalidate_simple_config():
+    invalid_config = {
+        "hello": 1,
+        "world": "hi!"
+    }
+    with pytest.raises(ValidationError):
+        f, v = my_registry.fill_and_validate(invalid_config, HelloIntsSchema)
+
+
+def test_fill_defaults_simple_config():
+    valid_config = {"required": 1}
+    filled, v = my_registry.fill_and_validate(valid_config, DefaultsSchema)
+    assert filled["required"] == 1 
+    assert filled["optional"] == "default value"
+    invalid_config = {"optional": "some value"}
+    with pytest.raises(ValidationError):
+        f, v = my_registry.fill_and_validate(invalid_config, DefaultsSchema)
+
+
+def test_fill_recursive_config():
+    valid_config = {
+        "outer_req": 1,
+        "level2_req": {
+            "hello": 4,
+            "world": 7
+        }
+    }
+    filled, validation = my_registry.fill_and_validate(valid_config, ComplexSchema)
+    assert filled["outer_req"] == 1
+    assert filled["outer_opt"] == "default value"
+    assert filled["level2_req"]["hello"] == 4
+    assert filled["level2_req"]["world"] == 7
+    assert filled["level2_opt"]["required"] == 1
+    assert filled["level2_opt"]["optional"] == "default value"
+ 
+
+@my_registry.cats.register("catsie.v1")
+def catsie_v1(evil: bool, cute: bool=True) -> str:
+    if evil:
+        return "scratch!"
+    else:
+        return "meow"
+
+good_catsie = {
+    "@cats": "catsie.v1",
+    "evil": False,
+    "cute": True
+}
+
+ok_catsie = {
+    "@cats": "catsie.v1",
+    "evil": False,
+    "cute": False
+}
+bad_catsie = {
+    "@cats": "catsie.v1",
+    "evil": True,
+    "cute": True
+}
+
+worst_catsie = {
+    "@cats": "catsie.v1",
+    "evil": True,
+    "cute": False
+}
+
+
+def test_is_promise():
+    assert my_registry.is_promise(good_catsie)
+    assert not my_registry.is_promise({"hello": "world"})
+    assert not my_registry.is_promise(1)
+
+def test_get_constructor():
+    func = my_registry.get_constructor(good_catsie)
+    assert func is catsie_v1
+
+def test_parse_args():
+    args, kwargs = my_registry.parse_args(bad_catsie)
+    assert args == []
+    assert kwargs == {"evil": True, "cute": True}
+
+def test_make_promise_schema():
+    schema = my_registry.make_promise_schema(good_catsie)
+    assert "evil" in schema.__fields__
+    assert "cute" in schema.__fields__
+
+
+def test_validate_promise():
+    config = {
+        "required": 1,
+        "optional": good_catsie
+    }
+    filled, validated = my_registry.fill_and_validate(config, DefaultsSchema)
+    assert filled == config
+    assert validated == {"required": 1, "optional": ""}

--- a/thinc/v2v.py
+++ b/thinc/v2v.py
@@ -1,5 +1,6 @@
 # coding: utf8
 from __future__ import unicode_literals
+from typing import Optional
 
 from .neural._classes.model import Model  # noqa: F401
 from .neural._classes.affine import Affine  # noqa: F401
@@ -12,20 +13,20 @@ from ._registry import registry
 
 
 @registry.layers.register("ReLu.v1")
-def make_ReLu(outputs, inputs=None):
+def make_ReLu(outputs: int, inputs: Optional[int]=None):
     return ReLu(nO=outputs, nI=inputs)
 
 
 @registry.layers.register("Mish.v1")
-def make_Mish(outputs, inputs=None):
+def make_Mish(outputs: int, inputs: Optional[int]=None):
     return Mish(nO=outputs, nI=inputs)
 
 
 @registry.layers.register("Softmax.v1")
-def make_Softmax(outputs, inputs=None):
+def make_Softmax(outputs: Optional[int]=None, inputs: Optional[int]=None):
     return Softmax(nO=outputs, nI=inputs)
 
 
 @registry.layers.register("Maxout.v1")
-def make_Maxout(outputs, pieces, inputs=None):
+def make_Maxout(outputs: int, inputs: Optional[int]=None, *, pieces: int):
     return Maxout(nO=outputs, nI=inputs, pieces=pieces)


### PR DESCRIPTION
* Add pydantic as a dependency
* Implement validation and default filling for the config system
* Add a few type declarations to some registry functions
* Remove Python2.7 and 3.5 from the classifiers and build system