### PR TITLE
Remove unnecessary "hooks" stuff from Model

### DIFF
--- a/thinc/describe.py
+++ b/thinc/describe.py
@@ -122,15 +122,6 @@ def on_init(*callbacks):
     return wrapped
 
 
-def on_data(*callbacks):
-    def wrapped(cls):
-        cls.on_data_hooks = list(cls.on_data_hooks)
-        cls.on_data_hooks.extend(callbacks)
-        return cls
-
-    return wrapped
-
-
 def input(getter):
     def wrapped(cls):
         cls.describe_input = getter

--- a/thinc/describe.py
+++ b/thinc/describe.py
@@ -111,28 +111,3 @@ def attributes(**specs):
         return cls
 
     return wrapped
-
-
-def on_init(*callbacks):
-    def wrapped(cls):
-        cls.on_init_hooks = list(cls.on_init_hooks)
-        cls.on_init_hooks.extend(callbacks)
-        return cls
-
-    return wrapped
-
-
-def input(getter):
-    def wrapped(cls):
-        cls.describe_input = getter
-        return cls
-
-    return wrapped
-
-
-def output(getter):
-    def wrapped(cls):
-        cls.describe_output = getter
-        return cls
-
-    return wrapped

--- a/thinc/neural/_classes/affine.py
+++ b/thinc/neural/_classes/affine.py
@@ -3,17 +3,6 @@ from ... import describe
 from ...describe import Dimension, Synapses, Biases, Gradient
 
 
-def _set_dimensions_if_needed(model, X, y=None):
-    if model.nI is None:
-        model.nI = X.shape[1]
-    if model.nO is None and y is not None:
-        if len(y.shape) == 2:
-            model.nO = y.shape[1]
-        else:
-            model.nO = int(y.max()) + 1
-
-
-@describe.on_data(_set_dimensions_if_needed)
 @describe.attributes(
     nB=Dimension("Batch size"),
     nI=Dimension("Input size"),

--- a/thinc/neural/_classes/affine.py
+++ b/thinc/neural/_classes/affine.py
@@ -4,7 +4,6 @@ from ...describe import Dimension, Synapses, Biases, Gradient
 
 
 @describe.attributes(
-    nB=Dimension("Batch size"),
     nI=Dimension("Input size"),
     nO=Dimension("Output size"),
     W=Synapses(
@@ -20,14 +19,6 @@ class Affine(Model):
     """Computes the linear transform Y = (W @ X) + b."""
 
     name = "affine"
-
-    @property
-    def input_shape(self):
-        return (self.nB, self.nI)
-
-    @property
-    def output_shape(self):
-        return (self.nB, self.nO)
 
     def __init__(self, nO=None, nI=None, **kwargs):
         Model.__init__(self, **kwargs)

--- a/thinc/neural/_classes/embed.py
+++ b/thinc/neural/_classes/embed.py
@@ -7,14 +7,6 @@ from ...describe import Dimension, Weights, Synapses, Gradient
 from ..util import copy_array
 
 
-def _set_dimensions_if_needed(model, X, y=None):
-    if model.nV is None:
-        max_id = int(X.max()) + 1
-        if max_id >= 10000000:  # pragma: no cover
-            raise ValueError("TODO error --- really want us to make 1m vectors?")
-        model.nV = max_id
-
-
 def _uniform_init(lo, hi):
     def wrapped(W, ops):
         copy_array(W, ops.xp.random.uniform(lo, hi, W.shape))

--- a/thinc/neural/_classes/feed_forward.py
+++ b/thinc/neural/_classes/feed_forward.py
@@ -1,5 +1,4 @@
 from .model import Model
-from ... import describe
 
 
 def _run_child_hooks(model, X, y):
@@ -23,14 +22,6 @@ class FeedForward(Model):
                 self._layers.append(layer)
         Model.__init__(self, **kwargs)
         self.on_data_hooks.append(_run_child_hooks)
-
-    @property
-    def input_shape(self):
-        return self._layers[0].input_shape
-
-    @property
-    def output_shape(self):
-        return self._layers[-1].output_shape
 
     def infer_dimensions(self, X=None, Y=None):
         if Y is not None:

--- a/thinc/neural/_classes/feed_forward.py
+++ b/thinc/neural/_classes/feed_forward.py
@@ -34,10 +34,16 @@ class FeedForward(Model):
         return self._layers[-1].has_dim(name)
 
     def get_dim(self, name):
-        return self._layers[-1].get_dim(name)
+        if name == "nI":
+            return self._layers[0].get_dim(name)
+        else:
+            return self._layers[-1].get_dim(name)
 
     def set_dim(self, name, value):
-        self._layers[-1].set_dim(name, value)
+        if name == "nI":
+            self._layers[0].set_dim(name, value)
+        else:
+            self._layers[-1].set_dim(name, value)
 
     def has_param(self, name):
         return name in self._layers[-1]._params

--- a/thinc/neural/_classes/maxout.py
+++ b/thinc/neural/_classes/maxout.py
@@ -27,8 +27,6 @@ def normal_init(W, ops):
         )
 
 
-@describe.output(("nO",))
-@describe.input(("nI",))
 @describe.attributes(
     nI=Dimension("Size of input"),
     nP=Dimension("Number of pieces"),

--- a/thinc/neural/_classes/maxout.py
+++ b/thinc/neural/_classes/maxout.py
@@ -4,13 +4,6 @@ from ...describe import Dimension, Synapses, Biases, Gradient
 from ..util import get_array_module
 
 
-def _set_dimensions_if_needed(model, X, y=None):
-    if model.nI is None:
-        model.nI = X.shape[1]
-    if model.nO is None and y is not None:  # pragma: no cover
-        model.nO = int(y.max()) + 1
-
-
 def xavier_uniform_init(W, ops):
     if (W ** 2).sum() != 0:
         return
@@ -34,7 +27,6 @@ def normal_init(W, ops):
         )
 
 
-@describe.on_data(_set_dimensions_if_needed)
 @describe.output(("nO",))
 @describe.input(("nI",))
 @describe.attributes(

--- a/thinc/neural/_classes/mish.py
+++ b/thinc/neural/_classes/mish.py
@@ -3,17 +3,6 @@ from .model import Model
 from ...describe import Dimension, Synapses, Biases, Gradient
 
 
-def _set_dimensions_if_needed(model, X, y=None):
-    if model.nI is None:
-        model.nI = X.shape[1]
-    if model.nO is None and y is not None:
-        if len(y.shape) == 2:
-            model.nO = y.shape[1]
-        else:
-            model.nO = int(y.max()) + 1
-
-
-@describe.on_data(_set_dimensions_if_needed)
 @describe.attributes(
     nB=Dimension("Batch size"),
     nI=Dimension("Input size"),

--- a/thinc/neural/_classes/mish.py
+++ b/thinc/neural/_classes/mish.py
@@ -4,7 +4,6 @@ from ...describe import Dimension, Synapses, Biases, Gradient
 
 
 @describe.attributes(
-    nB=Dimension("Batch size"),
     nI=Dimension("Input size"),
     nO=Dimension("Output size"),
     W=Synapses(
@@ -23,14 +22,6 @@ class Mish(Model):
     """
 
     name = "mish"
-
-    @property
-    def input_shape(self):
-        return (self.nB, self.nI)
-
-    @property
-    def output_shape(self):
-        return (self.nB, self.nO)
 
     def __init__(self, nO=None, nI=None, **kwargs):
         Model.__init__(self, **kwargs)

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -80,6 +80,7 @@ class Model(object):
         self.descriptions = dict(self.descriptions)
         self.on_init_hooks = list(self.on_init_hooks)
         self.on_data_hooks = list(self.on_data_hooks)
+        self.on_data_hooks.append(lambda model, X, Y=None: model.infer_dimensions(X, Y))
 
         for attr, install in self.descriptions.items():
             install(attr, self)
@@ -160,11 +161,13 @@ class Model(object):
         for hook in self.on_data_hooks:
             hook(self, train_X, train_y)
 
-    def infer_dimensions(self, X, Y=None):
-        if self.get_dim("nI") is None:
-            self.set_dim("nI",  get_width(X))
-        if self.get_dim("nO") is None and Y is not None:
-            self.set_dim("nO", get_width(Y))
+    def infer_dimensions(self, X=None, Y=None):
+        print("Infer dimensions")
+        if X is not None and self.get_dim("nI") is None:
+            self.set_dim("nI",  util.get_width(X))
+        if Y is not None and self.get_dim("nO") is None:
+            print("Infering nO", Y.shape)
+            self.set_dim("nO", util.get_width(Y))
 
     def begin_update(self, X, drop=0.0):
         raise NotImplementedError

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -16,10 +16,7 @@ class Model(object):
     id = 0
     ops = NumpyOps()
     Ops = NumpyOps
-    drop_factor = 1.0
     descriptions = []
-    on_data_hooks = []
-    on_init_hooks = []  # Use this to add layers
     _thread_local = threading.local()
 
     @classmethod
@@ -70,6 +67,9 @@ class Model(object):
         self.name = self.__class__.name
         self.Ops = self.__class__.Ops
         self.ops = self.Ops()
+        self.drop_factor = 1.0
+        self.on_data_hooks = []
+        self.on_init_hooks = [] 
         kwargs = self._update_defaults(args, kwargs)
         self._mem = Memory(self.ops)
         self._params = {}

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -55,14 +55,6 @@ class Model(object):
             cls.Ops = curr_Ops
             cls.ops = curr_ops
 
-    @property
-    def input_shape(self):
-        raise NotImplementedError
-
-    @property
-    def output_shape(self):
-        raise NotImplementedError
-
     def __init__(self, *args, **kwargs):
         self.name = self.__class__.name
         self.Ops = self.__class__.Ops

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -61,7 +61,6 @@ class Model(object):
         self.ops = self.Ops()
         self.drop_factor = 1.0
         self.on_data_hooks = []
-        self.on_init_hooks = [] 
         kwargs = self._update_defaults(args, kwargs)
         self._mem = Memory(self.ops)
         self._params = {}
@@ -70,14 +69,11 @@ class Model(object):
         if not hasattr(self, "_layers"):
             self._layers = []
         self.descriptions = dict(self.descriptions)
-        self.on_init_hooks = list(self.on_init_hooks)
         self.on_data_hooks = list(self.on_data_hooks)
         self.on_data_hooks.append(lambda model, X, Y=None: model.infer_dimensions(X, Y))
 
         for attr, install in self.descriptions.items():
             install(attr, self)
-        for hook in self.on_init_hooks:
-            hook(self, *args, **kwargs)
         self.set_id()
 
     def __getstate__(self):

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -160,6 +160,12 @@ class Model(object):
         for hook in self.on_data_hooks:
             hook(self, train_X, train_y)
 
+    def infer_dimensions(self, X, Y=None):
+        if self.get_dim("nI") is None:
+            self.set_dim("nI",  get_width(X))
+        if self.get_dim("nO") is None and Y is not None:
+            self.set_dim("nO", get_width(Y))
+
     def begin_update(self, X, drop=0.0):
         raise NotImplementedError
 

--- a/thinc/neural/util.py
+++ b/thinc/neural/util.py
@@ -177,3 +177,25 @@ def is_ragged(seqs):
     return False
 
 
+def get_width(X, dim=-1):
+    """Infer the 'width' of a batch of data, which could be any of:
+    * An n-dimensional array: Use the shape
+    * A tuple (for a ragged array): Use the shape of the first element.
+    * A list of arrays (for sequences): Use the shape of the first element.
+    """
+    if hasattr(X, "shape"):
+        if len(X.shape) == 0:
+            return 0
+        elif len(X.shape) == 1:
+            return int(X.max()) + 1
+        else:
+            return X.shape[dim]
+    elif isinstance(seqs, tuple) and len(seqs) == 2:
+        return get_width(seqs[0], dim=dim)
+    elif hasattr(X, "__len__")
+        if len(X) == 0:
+            return 0
+        else:
+            return get_width(X[0], dim=dim)
+    else:
+        raise ValueError("Cannot get width of object: has neither shape nor length.")

--- a/thinc/neural/util.py
+++ b/thinc/neural/util.py
@@ -192,10 +192,16 @@ def get_width(X, dim=-1):
             return X.shape[dim]
     elif isinstance(seqs, tuple) and len(seqs) == 2:
         return get_width(seqs[0], dim=dim)
-    elif hasattr(X, "__len__")
+    elif hasattr(X, "__len__"):
         if len(X) == 0:
             return 0
         else:
             return get_width(X[0], dim=dim)
     else:
         raise ValueError("Cannot get width of object: has neither shape nor length.")
+
+
+def run_child_hooks(model, X, y):
+    for child in model._layers:
+        for hook in child.on_data_hooks:
+            hook(child, X, y)

--- a/thinc/tests/integration/test_feed_forward.py
+++ b/thinc/tests/integration/test_feed_forward.py
@@ -57,8 +57,8 @@ def test_models_have_shape(model1, model2, nI, nH, nO):
 
 
 def test_model_shape(model, model1, model2, nI, nH, nO):
-    assert model.input_shape == model1.input_shape
-    assert model.output_shape == model2.output_shape
+    assert model.get_dim("nI") == model1.get_dim("nI")
+    assert model.get_dim("nO") == model2.get_dim("nO")
 
 
 def test_predict_and_begin_update_match(model, model1, model2, input_data):

--- a/thinc/tests/unit/test_affine.py
+++ b/thinc/tests/unit/test_affine.py
@@ -48,7 +48,7 @@ def test_Affine_calls_init_hooks(model):
 
 def test_Affine_dimensions_on_data():
     X = MagicMock(shape=(5, 10))
-    y = MagicMock()
+    y = MagicMock(shape=(8,))
     y.max = MagicMock()
     model = Affine()
     model.on_data_hooks = model.on_data_hooks[:1]

--- a/thinc/tests/unit/test_affine.py
+++ b/thinc/tests/unit/test_affine.py
@@ -12,15 +12,7 @@ from ..util import get_model, get_shape
 
 @pytest.fixture
 def model():
-    orig_desc = dict(Affine.descriptions)
-    orig_on_init = list(Affine.on_init_hooks)
-    Affine.descriptions = {
-        name: Mock(desc) for (name, desc) in Affine.descriptions.items()
-    }
-    Affine.on_init_hooks = [Mock(hook) for hook in Affine.on_init_hooks]
     model = Affine()
-    Affine.descriptions = dict(orig_desc)
-    Affine.on_init_hooks = orig_on_init
     return model
 
 
@@ -28,22 +20,23 @@ def test_Affine_default_name(model):
     assert model.name == "affine"
 
 
-def test_Affine_calls_default_descriptions(model):
-    assert len(model.descriptions) == 7
+def test_Affine_calls_default_descriptions():
+    orig_desc = dict(Affine.descriptions)
+    Affine.descriptions = {
+        name: Mock(desc) for (name, desc) in Affine.descriptions.items()
+    }
+    model = Affine()
+ 
+    assert len(model.descriptions) == 6
     for name, desc in model.descriptions.items():
         desc.assert_called()
-    assert "nB" in model.descriptions
     assert "nI" in model.descriptions
     assert "nO" in model.descriptions
     assert "W" in model.descriptions
     assert "b" in model.descriptions
     assert "d_W" in model.descriptions
     assert "d_b" in model.descriptions
-
-
-def test_Affine_calls_init_hooks(model):
-    for hook in model.on_init_hooks:
-        hook.assert_called()
+    Affine.descriptions = orig_desc
 
 
 def test_Affine_dimensions_on_data():

--- a/thinc/tests/unit/test_model.py
+++ b/thinc/tests/unit/test_model.py
@@ -68,17 +68,6 @@ def test_init_installs_via_descriptions():
     assert model2.myattr == "model=%s" % "model2"
 
 
-def test_init_calls_hooks():
-    def mock_init_hook(self, *args, **kwargs):
-        setattr(self, "hooked", (args, kwargs))
-
-    base.Model.on_init_hooks = [mock_init_hook]
-    model = base.Model(0, 1, 2)
-    assert model.hooked == ((0, 1, 2), {})
-    model2 = base.Model(value="something")
-    assert model2.hooked == (tuple(), {"value": "something"})
-
-
 def test_use_device():
     dev_id = id(base.Model.ops)
     with base.Model.use_device(base.Model.ops.device):


### PR DESCRIPTION
The `Model` class supported some weird features with class attributes, using the description system. This PR cleans the unnecessary stuff up.

We no longer have `on_init_hooks`, and `on_data_hooks` is removed as a descriptor -- instead it should just be set in the model `__init__` function.

We also add a `model.infer_dimensions` method, to allow clearer calls if that's what the code is trying to do.