### PR TITLE
Remove sgd argument from backward callback

### DIFF
--- a/thinc/neural/_classes/affine.py
+++ b/thinc/neural/_classes/affine.py
@@ -31,16 +31,13 @@ class Affine(Model):
         return output
 
     def begin_update(self, input__BI, drop=0.0):
-        input__BI = self.ops.xp.ascontiguousarray(input__BI)
         output__BO = self.predict(input__BI)
 
-        def finish_update(grad__BO, sgd=None):
+        def finish_update(grad__BO):
             grad__BO = self.ops.xp.ascontiguousarray(grad__BO)
             self.ops.gemm(grad__BO, input__BI, trans1=True, out=self.d_W)
             self.d_b += grad__BO.sum(axis=0)
             grad__BI = self.ops.gemm(grad__BO, self.W)
-            if sgd is not None:
-                sgd(self._mem.weights, self._mem.gradient, key=self.id)
             return grad__BI
 
         if drop is not None:

--- a/thinc/neural/_classes/attention.py
+++ b/thinc/neural/_classes/attention.py
@@ -27,13 +27,11 @@ class ParametricAttention(Model):
         attention, bp_attention = self._get_attention(self.Q, Xs, lengths)
         output, bp_output = self._apply_attention(attention, Xs, lengths)
 
-        def attention_bwd(d_output, sgd=None):
+        def attention_bwd(d_output):
             dXs, d_attention = bp_output(d_output)
             dQ, dXs2 = bp_attention(d_attention)
             self.dQ += dQ
             dXs += dXs2
-            if sgd is not None:
-                sgd(self._mem.weights, self._mem.gradient, key=self.id)
             return dXs
 
         return (output, lengths), attention_bwd

--- a/thinc/neural/_classes/convolution.py
+++ b/thinc/neural/_classes/convolution.py
@@ -24,11 +24,8 @@ class ExtractWindow(Model):
 
     def begin_update(self, X__bi, drop=0.0):
         X__bo = self.ops.seq2col(X__bi, self.nW)
-        finish_update = self._get_finish_update()
-        return X__bo, finish_update
-
-    def _get_finish_update(self):
-        def finish_update(gradient, sgd=None):
+        
+        def finish_update(gradient):
             return self.ops.backprop_seq2col(gradient, self.nW)
-
-        return finish_update
+        
+        return X__bo, finish_update

--- a/thinc/neural/_classes/feature_extracter.py
+++ b/thinc/neural/_classes/feature_extracter.py
@@ -22,5 +22,5 @@ class FeatureExtracter(Model):
         return self.ops.asarray(arr, dtype="uint64")
 
 
-def _feature_extracter_bwd(d_features, sgd=None):
+def _feature_extracter_bwd(d_features):
     return d_features

--- a/thinc/neural/_classes/feed_forward.py
+++ b/thinc/neural/_classes/feed_forward.py
@@ -76,11 +76,11 @@ class FeedForward(Model):
             X, inc_layer_grad = layer.begin_update(X, drop=drop)
             callbacks.append(inc_layer_grad)
 
-        def continue_update(gradient, sgd=None):
+        def continue_update(gradient):
             for callback in reversed(callbacks):
                 if gradient is None or callback is None:
                     break
-                gradient = callback(gradient, sgd)
+                gradient = callback(gradient)
             return gradient
 
         return X, continue_update

--- a/thinc/neural/_classes/function_layer.py
+++ b/thinc/neural/_classes/function_layer.py
@@ -104,7 +104,7 @@ class ConcatenationLayer(Model):
         widths = [Y.shape[1] for Y in Ys]
         output = self.ops.xp.hstack(Ys)
 
-        def finish_update_concatenate(d_output, sgd=None):
+        def finish_update_concatenate(d_output):
             layer_grad = None
             start = 0
             for bwd, width in zip(callbacks, widths):
@@ -145,7 +145,7 @@ class AdditionLayer(Model):
         for o in outs:
             out += o
 
-        def backward(d_out, sgd=None):
+        def backward(d_out):
             grads = [bp(d_out, sgd=sgd) for bp in callbacks if bp is not None]
             grads = [g for g in grads if g is not None]
             if grads:

--- a/thinc/neural/_classes/hash_embed.py
+++ b/thinc/neural/_classes/hash_embed.py
@@ -50,7 +50,7 @@ class HashEmbed(Model):
         if mask is not None:
             vectors *= mask
 
-        def finish_update(delta, sgd=None):
+        def finish_update(delta):
             if mask is not None:
                 delta *= mask
             keys = self.ops.hash(ids, self.seed) % self.nV

--- a/thinc/neural/_classes/maxout.py
+++ b/thinc/neural/_classes/maxout.py
@@ -65,7 +65,7 @@ class Maxout(Model):
         best__bo, which__bo = self.ops.maxout(output__boc)
         best__bo, bp_dropout = self.ops.dropout(best__bo, drop)
 
-        def finish_update(dX__bo, sgd=None):
+        def finish_update(dX__bo):
             dX__bop = self.ops.backprop_maxout(dX__bo, which__bo, self.nP)
             self.d_b += dX__bop.sum(axis=0)
             dX__bop = dX__bop.reshape((dX__bop.shape[0], self.nO * self.nP))
@@ -75,8 +75,6 @@ class Maxout(Model):
             dX__bi = self.ops.gemm(
                 dX__bop, self.W.reshape((self.nO * self.nP, self.nI))
             )
-            if sgd is not None:
-                sgd(self._mem.weights, self._mem.gradient, key=self.id)
             return dX__bi
 
         return best__bo, bp_dropout(finish_update)

--- a/thinc/neural/_classes/mish.py
+++ b/thinc/neural/_classes/mish.py
@@ -41,13 +41,11 @@ class Mish(Model):
         drop *= self.drop_factor
         Y3, bp_dropout = self.ops.dropout(Y2, drop)
 
-        def finish_update(dY2, sgd=None):
+        def finish_update(dY2):
             dY1 = self.ops.backprop_mish(dY2, Y1)
             self.ops.gemm(dY1, X, trans1=True, out=self.d_W)
             self.d_b += dY1.sum(axis=0)
             dX = self.ops.gemm(dY1, self.W)
-            if sgd is not None:
-                sgd(self._mem.weights, self._mem.gradient, key=self.id)
             return dX
 
         return Y3, bp_dropout(finish_update)

--- a/thinc/neural/_classes/model.py
+++ b/thinc/neural/_classes/model.py
@@ -183,6 +183,20 @@ class Model(object):
         """
         raise NotImplementedError
 
+    def finish_update(self, optimizer):
+        """Update parameters with current gradients.
+        
+        optimizer (Callable[array, array, key=None]):
+            The optimizer. The function is called with each parameter and
+            gradient of the model.
+        """
+        optimizer(self._mem.weights, self._mem.gradient, key=self.id)
+        seen = set([self.id])
+        for node in self.walk():
+            if node.id not in seen:
+                node.finish_update(optimizer)
+                seen.add(node.id)
+
     def predict(self, X):
         y, _ = self.begin_update(X, drop=None)
         return y

--- a/thinc/neural/_classes/relu.py
+++ b/thinc/neural/_classes/relu.py
@@ -11,9 +11,9 @@ class ReLu(Affine):
         output__BO, finish_affine = Affine.begin_update(self, input__BI, drop=0.0)
         output__BO = self.ops.relu(output__BO)
 
-        def finish_update(gradient, sgd=None):
+        def finish_update(gradient):
             gradient = self.ops.backprop_relu(gradient, output__BO)
-            return finish_affine(gradient, sgd)
+            return finish_affine(gradient)
 
         dropped, bp_dropout = self.ops.dropout(output__BO, drop, inplace=False)
         return dropped, bp_dropout(finish_update)

--- a/thinc/neural/_classes/resnet.py
+++ b/thinc/neural/_classes/resnet.py
@@ -34,8 +34,8 @@ class Residual(Model):
         else:
             output = X + y
 
-        def residual_bwd(d_output, sgd=None):
-            dX = bp_y(d_output, sgd)
+        def residual_bwd(d_output):
+            dX = bp_y(d_output)
             if isinstance(d_output, list) or isinstance(d_output, tuple):
                 return [d_output[i] + dX[i] for i in range(len(d_output))]
             else:

--- a/thinc/tests/integration/test_affine_learns.py
+++ b/thinc/tests/integration/test_affine_learns.py
@@ -83,7 +83,9 @@ def test_update():
     assert_allclose(scores[0, 0], scores[0, 1])
     # Tell it the answer was 'f'
     gradient = np.asarray([[-1.0, 0.0]], dtype="f")
-    finish_update(gradient, sgd)
+    finish_update(gradient)
+    for key, (W, dW) in model.get_gradients().items():
+        sgd(W, dW, key=key)
 
     assert model.b[0] == 1.0
     assert model.b[1] == 0.0
@@ -97,7 +99,9 @@ def test_update():
     scores, finish_update = model.begin_update(tf)
     # Tell it the answer was 'T'
     gradient = np.asarray([[0.0, -1.0]], dtype="f")
-    finish_update(gradient, sgd)
+    finish_update(gradient)
+    for key, (W, dW) in model.get_gradients().items():
+        sgd(W, dW, key=key)
 
     assert model.b[0] == 1.0
     assert model.b[1] == 1.0

--- a/thinc/tests/unit/test_affine.py
+++ b/thinc/tests/unit/test_affine.py
@@ -99,7 +99,9 @@ def test_finish_update_calls_optimizer_with_weights(W_b_input):
         assert data.shape[0] == (nr_out * nr_in) + nr_out, data.shape[0]
 
     grad_BO = numpy.ones((nr_batch, nr_out), dtype="f")
-    grad_BI = finish_update(grad_BO, sgd)  # noqa: F841
+    grad_BI = finish_update(grad_BO)  # noqa: F841
+    for key, (W, dW) in model.get_gradients().items():
+        sgd(W, dW, key=key)
     assert seen_keys == {model.id}
 
 

--- a/thinc/tests/unit/test_pytorch_wrapper.py
+++ b/thinc/tests/unit/test_pytorch_wrapper.py
@@ -13,12 +13,14 @@ def check_learns_zero_output(model, sgd, X, Y):
     """Check we can learn to output a zero vector"""
     Yh, get_dX = model.begin_update(X)
     dYh = (Yh - Y) / Yh.shape[0]
-    dX = get_dX(dYh, sgd=sgd)
+    dX = get_dX(dYh)
+    model.finish_update(sgd)
     prev = numpy.abs(Yh.sum())
     for i in range(100):
         Yh, get_dX = model.begin_update(X)
         total = numpy.abs(Yh.sum())
-        dX = get_dX(Yh - Y, sgd=sgd)  # noqa: F841
+        dX = get_dX(Yh - Y)  # noqa: F841
+        model.finish_update(sgd)
         assert total < prev
         prev = total
 
@@ -45,6 +47,7 @@ def test_wrapper(nN=2, nI=3, nO=4):
     Yh, get_dX = model.begin_update(X)
     assert Yh.shape == (nN, nO)
     dYh = (Yh - Y) / Yh.shape[0]
-    dX = get_dX(dYh, sgd=sgd)
+    dX = get_dX(dYh)
+    model.finish_update(sgd)
     assert dX.shape == (nN, nI)
     check_learns_zero_output(model, sgd, X, Y)

--- a/thinc/tests/unit/test_rnn.py
+++ b/thinc/tests/unit/test_rnn.py
@@ -99,9 +99,11 @@ def test_LSTM_learns():
     Yhs, bp_Yhs = model.begin_update([X])
     loss1 = ((Yhs[0] - Y) ** 2).sum()
     Yhs, bp_Yhs = model.begin_update([X])
-    dXs = bp_Yhs([Yhs[0] - Y], sgd=sgd)
+    dXs = bp_Yhs([Yhs[0] - Y])
+    for key, (W, dW) in model.get_gradients().items():
+        sgd(W, dW, key=key)
     Yhs, bp_Yhs = model.begin_update([X])
-    dXs = bp_Yhs([Yhs[0] - Y], sgd=sgd)  # noqa: F841
+    dXs = bp_Yhs([Yhs[0] - Y])  # noqa: F841
     loss2 = ((Yhs[0] - Y) ** 2).sum()
     assert loss1 > loss2, (loss1, loss2)
 


### PR DESCRIPTION
This is a pretty pervasive breaking change. Previously we had the following in our models:

    Y, backward = model.begin_update(X)
    dX = backward(dY, sgd=optimizer)

After this PR, we'll have this instead:

    Y, backward = model.begin_update(X)
    dX = backward(dY)
    model.finish_update(sgd)

There are a number of reasons why the old way was bad. One is that we were changing the weights in the middle of the backward pass, which could introduce some nasty problems, especially when you had architectures with the same model instance twice. It also made it harder to divide up sub-batches, and just generally complicated the design (it made the signatures really ugly, for instance).
