### PR TITLE
Fix murmur hash for GPU/Windows

### DIFF
--- a/thinc/neural/_murmur3.cu
+++ b/thinc/neural/_murmur3.cu
@@ -12,12 +12,29 @@
  * and modified to work with CUDA.
  */
 // Including stdint.h is a pain in cupy, so just put the declarations in.
-typedef unsigned char                uint8_t;
-typedef unsigned int                uint32_t;
-typedef unsigned long int        uint64_t;
-typedef signed char                int8_t;
-typedef int                        int32_t;
-typedef long int                int64_t;
+// Beware that long int is not 64bit on all platforms!
+// e.g. Windows requires a 'long long' to get to 64 bit.
+
+typedef unsigned char           uint8_t;
+typedef unsigned int            uint32_t;
+typedef signed char             int8_t;
+typedef int                     int32_t;
+
+const unsigned long int test_var = 0;
+const int size = sizeof(test_var);
+
+#if size == 64
+
+typedef unsigned long int      uint64_t;
+typedef long int               int64_t;
+
+#else
+
+typedef unsigned long long      uint64_t;
+typedef long long               int64_t;
+
+#endif
+
 
 //-----------------------------------------------------------------------------
 // Platform-specific functions and macros


### PR DESCRIPTION
Fixes #128 : [`test_hash_gives_distinct_keys[CupyOps]`](https://github.com/explosion/thinc/blob/master/thinc/tests/unit/test_ops.py#L30) stops failing

Fixes https://github.com/explosion/spaCy/issues/4758: no more weird POS & dep tags

Probably fixes https://github.com/explosion/spaCy/issues/4816 (should be tested after merge)

## Description

The murmur hash calculation for Windows (when using GPU/CUDA) was not working properly.

I finally figured out why: `int64_t` was being defined as `long int`. This is correct on LINUX, but not on [Windows](https://docs.microsoft.com/en-us/cpp/c-runtime-library/standard-types?redirectedfrom=MSDN&view=vs-2019).

So I added a bit of code to do some byte-size checking upfront and only then define the correct types. It's a little ugly, but I couldn't get this implemented in a more clean fashion because
- I couldn't find a way to check for platform (`#if defined(_MSC_VER)` e.g. didn't work)
- I couldn't find a way to include the platform-specific header files (which is what you see in most implementations of the murmur hash because of this type incompatibility)
- You're not allowed to redefine a `typedef`

Nonetheless, I think this works :-)

## Example output

This has been the source of many quirks reported with GPU & Windows. I ran some tests myself and this was the output:

### BEFORE PR
#### en_core_web_sm

```
tok.text ['The', 'decrease', 'in', '2008', 'primarily', 'relates', 'to', 'the', 'decrease', 'in', 'cash', 'and', 'cash', 'equivalents', '1', '.', '\n']
tok.pos_ ['PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'PUNCT', 'SPACE']
tok.dep_ ['ROOT', 'pobj', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', 'neg', '']
```


#### en_core_web_md

```
tok.text ['The', 'decrease', 'in', '2008', 'primarily', 'relates', 'to', 'the', 'decrease', 'in', 'cash', 'and', 'cash', 'equivalents', '1', '.', '\n']
tok.pos_ ['ADP', 'NOUN', 'ADP', 'NOUN', 'ADV', 'NOUN', 'VERB', 'ADP', 'NOUN', 'ADP', 'NOUN', 'ADP', 'NOUN', 'ADJ', 'VERB', 'NOUN', 'SPACE']
tok.dep_ ['ROOT', 'pobj', 'prep', 'pobj', 'punct', 'punct', 'conj', 'pcomp', 'pobj', 'prep', 'pobj', 'punct', 'punct', 'punct', 'det', 'pobj', '']
```

### AFTER PR
#### en_core_web_sm

```
tok.text ['The', 'decrease', 'in', '2008', 'primarily', 'relates', 'to', 'the', 'decrease', 'in', 'cash', 'and', 'cash', 'equivalents', '1', '.', '\n']
tok.pos_ ['DET', 'NOUN', 'ADP', 'NUM', 'ADV', 'VERB', 'ADP', 'DET', 'NOUN', 'ADP', 'NOUN', 'CCONJ', 'NOUN', 'NOUN', 'NUM', 'PUNCT', 'SPACE']
tok.dep_ ['det', 'nsubj', 'prep', 'pobj', 'advmod', 'ROOT', 'prep', 'det', 'pobj', 'prep', 'pobj', 'cc', 'compound', 'conj', 'nummod', 'punct', '']
```

#### en_core_web_md

```
tok.text ['The', 'decrease', 'in', '2008', 'primarily', 'relates', 'to', 'the', 'decrease', 'in', 'cash', 'and', 'cash', 'equivalents', '1', '.', '\n']
tok.pos_ ['DET', 'NOUN', 'ADP', 'NUM', 'ADV', 'VERB', 'ADP', 'DET', 'NOUN', 'ADP', 'NOUN', 'CCONJ', 'NOUN', 'NOUN', 'NUM', 'PUNCT', 'SPACE']
tok.dep_ ['det', 'nsubj', 'prep', 'pobj', 'advmod', 'ROOT', 'prep', 'det', 'pobj', 'prep', 'pobj', 'cc', 'compound', 'conj', 'nummod', 'punct', '']
```
I think it's pretty obvious that the after-PR results are preferable :-)
