### PR TITLE
Introduce 'shims' package, fix PyTorchWrapper

### DIFF
--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -11,7 +11,7 @@ except ImportError:
 from .ops import Ops
 from .numpy_ops import NumpyOps
 from . import _custom_kernels
-from ..util import copy_array, get_array_module
+from ..util import get_array_module
 
 
 class CupyOps(Ops):

--- a/thinc/layers/pytorchwrapper.py
+++ b/thinc/layers/pytorchwrapper.py
@@ -1,197 +1,31 @@
-import contextlib
+from typing import Callable, Tuple, Any
 from ..model import Model
-
-try:
-    import cupy
-except ImportError:
-    cupy = None
-
-try:
-    import torch.autograd
-    import torch.optim
-    import torch
-    import torch.utils.dlpack
-    from torch.nn import Module as PyTorchModule
-except ImportError:
-    has_torch = False
+from ..shims import PyTorchShim
+from ..util import xp2torch, torch2xp
+from ..types import Array
 
 
-def PyTorchWrapper(pytorch_model):
+def PyTorchWrapper(pytorch_model: Any) -> Model:
     """Wrap a PyTorch model, so that it has the same API as Thinc models.
     To optimize the model, you'll need to create a PyTorch optimizer and call
     optimizer.step() after each batch --- see examples/wrap_pytorch.py
     """
-    return PyTorchModel("pytorch", forward, init=init, attrs={"_model": model})
+    return Model("pytorch", forward, shims=[PyTorchShim(pytorch_model)])
 
 
-def forward(model, x_data, is_train):
+def forward(model: Model, X: Array, is_train: bool) -> Tuple[Array, Callable]:
     """Return the output of the wrapped PyTorch model for the given input,
     along with a callback to handle the backward pass.
     """
-    pytorch_model = model.get_attr("_model")
-    if is_train:
-        pytorch_model.train()
-        fwd_args, fwd_kwargs = model.prepare_input(x_data, is_update=True)
-        y_var = pytorch_model(*fwd_args, **fwd_kwargs)
-    else:
-        pytorch_model.eval()
-        x_args, x_kwargs = model.prepare_input(x_data, is_update=False)
-        with torch.no_grad():
-            y_var = pytorch_model(*x_args, **x_kwargs)
-        self._model.train()
-        return model.prepare_output(y_var)
+    pytorch_model = model.shims[0]
 
-    y = model.prepare_output(y_var)
+    X_torch = xp2torch(X, requires_grad=is_train)
+    Y_torch, torch_backprop = pytorch_model((X_torch,), {}, is_train)
+    Y = torch2xp(Y_torch)
 
-    def backward_pytorch(dy_data):
-        d_args, d_kwargs = model.prepare_backward_input(dy_data, y_var)
-        torch.autograd.backward(*d_args, **d_kwargs, retain_graph=True)
-        return model.prepare_backward_output(fwd_args, fwd_kwargs)
+    def backprop(dY):
+        dY_torch = xp2torch(dY, requires_grad=is_train)
+        dX_torch = torch_backprop((Y_torch,), {"grad_tensors": dY_torch})
+        return torch2xp(dX_torch[0].grad)
 
-    return y, backward_pytorch
- 
-
-class PyTorchModel(Model):
-    def prepare_input(self, x_data, is_update=True):
-        if isinstance(x_data, (list, tuple)):
-            x_var = [
-                torch.autograd.Variable(xp2torch(x), requires_grad=is_update)
-                for x in x_data
-            ]
-            return tuple(x_var), {}
-        else:
-            x_var = torch.autograd.Variable(xp2torch(x_data), requires_grad=is_update)
-            return (x_var,), {}
-
-    def prepare_output(self, y_var):
-        if isinstance(y_var, (list, tuple)):
-            return tuple([torch2xp(y) for y in y_var])
-        else:
-            return torch2xp(y_var)
-
-    def prepare_backward_input(self, dy_data, y_var):
-        if isinstance(dy_data, (list, tuple)):
-            dy_var = [xp2torch(dy) for dy in dy_data]
-            return y_var, {"grad_tensors": dy_var}
-        else:
-            dy_var = xp2torch(dy_data)
-            return (y_var,), {"grad_tensors": (dy_var,)}
-
-    def prepare_backward_output(self, x_args, x_kwargs):
-        x_var = x_args[0]
-        return torch2xp(x_var.grad)
-
-    def predict(self, x_data):
-        pass
-
-    def finish_update(self, optimizer):
-        if not self._optimizer:
-            self._optimizer = self._create_optimizer(optimizer)
-        if getattr(optimizer, "max_grad_norm", None):
-            torch.nn.utils.clip_grad_norm_(
-                self._model.parameters(), optimizer.max_grad_norm)
-        self._optimizer.step()
-        self._optimizer.zero_grad()
-
-    def _create_optimizer(self, sgd):
-        params = self._model.parameters()
-        if sgd.b1 != 0 and sgd.b2 != 0:
-            optimizer = torch.optim.Adam(params, lr=sgd.alpha, betas=(sgd.b1, sgd.b2))
-        elif sgd.b2 == 0:
-            optimizer = torch.optim.SGD(params, lr=sgd.alpha, momentum=sgd.b1)
-        else:
-            raise NotImplementedError
-        return optimizer
-
-    @contextlib.contextmanager
-    def use_params(self, params):
-        key_prefix = f"pytorch_{self.id}_"
-        state_dict = {}
-        for k, v in params.items():
-            if hasattr(k, "startswith") and k.startswith(key_prefix):
-                state_dict[k.replace(key_prefix, "")] = xp2torch(v)
-        if state_dict:
-            backup = {k: v.clone() for k, v in self._model.state_dict().items()}
-            self._model.load_state_dict(state_dict)
-            yield
-            self._model.load_state_dict(backup)
-        else:
-            yield
-
-    def _update_pytorch_averages(self, sgd, *, init_steps=1):
-        if getattr(sgd, "averages", None) is None:
-            return
-        # Collect parameters if we don't have them
-        for name, param in self._model.state_dict().items():
-            key = f"pytorch_{self.id}_{name}"
-            sgd.nr_update[key] += 1
-            xp_param = torch2xp(param)
-            if key in sgd.averages:
-                self.ops.update_averages(
-                    sgd.averages[key], xp_param, sgd.nr_update[key]
-                )
-            else:
-                sgd.averages[key] = xp_param.copy()
-                sgd.nr_update[key] = init_steps
-
-    def to_disk(self, path):
-        torch.save(self._model.state_dict(), str(path))
-
-    def from_disk(self, path):
-        if self.ops.device == "cpu":
-            map_location = "cpu"
-        else:
-            device_id = torch.cuda.current_device()
-            map_location = "cuda:%d" % device_id
-        self._model.load_state_dict(torch.load(path, map_location=map_location))
-        self._model.to(map_location)
-
-    def to_bytes(self):
-        filelike = BytesIO()
-        torch.save(self._model.state_dict(), filelike)
-        filelike.seek(0)
-        return filelike.getvalue()
-
-    def from_bytes(self, data):
-        filelike = BytesIO(data)
-        filelike.seek(0)
-        if self.ops.device == "cpu":
-            map_location = "cpu"
-        else:
-            device_id = torch.cuda.current_device()
-            map_location = "cuda:%d" % device_id
-        self._model.load_state_dict(torch.load(filelike, map_location=map_location))
-        self._model.to(map_location)
-
-    def to_gpu(self, device_num):
-        self._model.cuda(device_num)
-
-    def to_cpu(self):
-        self._model.cpu()
-
-
-#class PyTorchWrapperRNN(PyTorchWrapper):
-#    """Wrap a PyTorch RNN model"""
-#
-#    def prepare_input(self, inputs, is_update=False):
-#        if isinstance(inputs, tuple):
-#            x_data, h_0 = inputs
-#        else:
-#            x_data = inputs
-#            h_0 = None
-#        x_var = torch.autograd.Variable(xp2torch(x_data), requires_grad=is_update)
-#        return (x_var, h_0), {}
-#
-#    def prepare_output(self, torch_outputs):
-#        y_var, h_n = torch_outputs
-#        return torch2xp(y_var), h_n
-#
-#    def prepare_backward_input(self, dy_data, y_var):
-#        dy, _ = dy_data
-#        dy_var = xp2torch(dy)
-#        y_var, _ = y_var
-#        return (y_var,), {"grad_tensors": (dy_var,)}
-#
-#    def prepare_backward_output(self, x_args, x_kwargs):
-#        x_var, _ = x_args
-#        return torch2xp(x_var.grad)
+    return Y, backprop

--- a/thinc/layers/residual.py
+++ b/thinc/layers/residual.py
@@ -21,7 +21,7 @@ def Residual(layer: Model) -> Model:
         layers=[layer],
         dims={
             "nO": layer.get_dim("nO") if layer.has_dim("nO") else None,
-            "nI": layer.get_dim("nI") if layer.has_dim("nI") else None
+            "nI": layer.get_dim("nI") if layer.has_dim("nI") else None,
         },
     )
 

--- a/thinc/shims/__init__.py
+++ b/thinc/shims/__init__.py
@@ -1,0 +1,2 @@
+from .shim import Shim
+from .pytorch import PyTorchShim

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -1,0 +1,192 @@
+import contextlib
+from io import BytesIO
+from ..util import torch2xp, xp2torch
+
+from .shim import Shim
+
+try:
+    import cupy
+except ImportError:
+    cupy = None
+
+try:
+    import torch.autograd
+    import torch.optim
+    import torch
+    from torch.nn import Module as PyTorchModule
+except ImportError:
+    has_torch = False
+
+
+class PyTorchShim(Shim):
+    """Interface between a PyTorch model and a Thinc Model. This container is
+    *not* a Thinc Model subclass itself.
+    """
+
+    def __call__(self, args, kwargs, is_train):
+        if is_train:
+            return self.begin_update(args, kwargs)
+        else:
+            return self.predict(args, kwargs), lambda args, kwargs: (args, kwargs)
+
+    def predict(self, args, kwargs):
+        self._model.eval()
+        with torch.no_grad():
+            y_var = self._model(*args, **kwargs)
+        self._model.train()
+        return y_var, lambda d_args, d_kwargs: d_args
+
+    def begin_update(self, args, kwargs):
+        self._model.train()
+        output = self._model(*args, **kwargs)
+
+        def backprop(d_args, d_kwargs):
+            torch.autograd.backward(*d_args, **d_kwargs)
+            return args
+
+        return output, backprop
+
+    def finish_update(self, optimizer):
+        if not self._optimizer:
+            self._optimizer = self._create_optimizer(optimizer)
+        if getattr(optimizer, "max_grad_norm", None):
+            torch.nn.utils.clip_grad_norm_(
+                self._model.parameters(), optimizer.max_grad_norm
+            )
+        self._optimizer.step()
+        self._optimizer.zero_grad()
+        self._update_pytorch_averages(optimizer)
+
+    def _create_optimizer(self, sgd):
+        params = self._model.parameters()
+        if sgd.b1 != 0 and sgd.b2 != 0:
+            optimizer = torch.optim.Adam(params, lr=sgd.alpha, betas=(sgd.b1, sgd.b2))
+        elif sgd.b2 == 0:
+            optimizer = torch.optim.SGD(params, lr=sgd.alpha, momentum=sgd.b1)
+        else:
+            raise NotImplementedError
+        return optimizer
+
+    @contextlib.contextmanager
+    def use_params(self, params):
+        key_prefix = f"pytorch_{self.id}_"
+        state_dict = {}
+        for k, v in params.items():
+            if hasattr(k, "startswith") and k.startswith(key_prefix):
+                state_dict[k.replace(key_prefix, "")] = xp2torch(v)
+        if state_dict:
+            backup = {k: v.clone() for k, v in self._model.state_dict().items()}
+            self._model.load_state_dict(state_dict)
+            yield
+            self._model.load_state_dict(backup)
+        else:
+            yield
+
+    def _update_pytorch_averages(self, sgd, *, init_steps=1):
+        if getattr(sgd, "averages", None) is None:
+            return
+        # Collect parameters if we don't have them
+        for name, param in self._model.state_dict().items():
+            key = f"pytorch_{self.id}_{name}"
+            sgd.nr_update[key] += 1
+            xp_param = torch2xp(param)
+            if key in sgd.averages:
+                sgd.ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
+            else:
+                sgd.averages[key] = xp_param.copy()
+                sgd.nr_update[key] = init_steps
+
+    def to_gpu(self, device_num):
+        self._model.cuda(device_num)
+
+    def to_cpu(self):
+        self._model.cpu()
+
+    def to_disk(self, path):
+        torch.save(self._model.state_dict(), str(path))
+
+    def from_disk(self, path):
+        if self.ops.device == "cpu":
+            map_location = "cpu"
+        else:
+            device_id = torch.cuda.current_device()
+            map_location = "cuda:%d" % device_id
+        self._model.load_state_dict(torch.load(path, map_location=map_location))
+        self._model.to(map_location)
+        return self
+
+    def to_bytes(self):
+        filelike = BytesIO()
+        torch.save(self._model.state_dict(), filelike)
+        filelike.seek(0)
+        return filelike.getvalue()
+
+    def from_bytes(self, data):
+        filelike = BytesIO(data)
+        filelike.seek(0)
+        if self.ops.device == "cpu":
+            map_location = "cpu"
+        else:
+            device_id = torch.cuda.current_device()
+            map_location = "cuda:%d" % device_id
+        self._model.load_state_dict(torch.load(filelike, map_location=map_location))
+        self._model.to(map_location)
+        return self
+
+
+"""
+class PyTorchWrapperRNN(PyTorchShim):
+    # Wrap a PyTorch RNN model
+
+    def prepare_input(self, inputs, is_update=False):
+        if isinstance(inputs, tuple):
+            x_data, h_0 = inputs
+        else:
+            x_data = inputs
+            h_0 = None
+        x_var = torch.autograd.Variable(xp2torch(x_data), requires_grad=is_update)
+        return (x_var, h_0), {}
+
+    def prepare_output(self, torch_outputs):
+        y_var, h_n = torch_outputs
+        return torch2xp(y_var), h_n
+
+    def prepare_backward_input(self, dy_data, y_var):
+        dy, _ = dy_data
+        dy_var = xp2torch(dy)
+        y_var, _ = y_var
+        return (y_var,), {"grad_tensors": (dy_var,)}
+
+    def prepare_backward_output(self, x_args, x_kwargs):
+        x_var, _ = x_args
+        return torch2xp(x_var.grad)
+
+    def prepare_input(self, x_data, is_update=True):
+        if isinstance(x_data, (list, tuple)):
+            x_var = [
+                torch.autograd.Variable(xp2torch(x), requires_grad=is_update)
+                for x in x_data
+            ]
+            return tuple(x_var), {}
+        else:
+            x_var = torch.autograd.Variable(xp2torch(x_data), requires_grad=is_update)
+            return (x_var,), {}
+
+    def prepare_output(self, y_var):
+        if isinstance(y_var, (list, tuple)):
+            return tuple([torch2xp(y) for y in y_var])
+        else:
+            return torch2xp(y_var)
+
+    def prepare_backward_input(self, dy_data, y_var):
+        if isinstance(dy_data, (list, tuple)):
+            dy_var = [xp2torch(dy) for dy in dy_data]
+            return y_var, {"grad_tensors": dy_var}
+        else:
+            dy_var = xp2torch(dy_data)
+            return (y_var,), {"grad_tensors": (dy_var,)}
+
+    def prepare_backward_output(self, x_args, x_kwargs):
+        x_var = x_args[0]
+        return torch2xp(x_var.grad)
+"""

--- a/thinc/shims/shim.py
+++ b/thinc/shims/shim.py
@@ -1,0 +1,70 @@
+from typing import Any, Optional, List, Tuple, Callable, Dict
+import contextlib
+from pathlib import Path
+
+
+class Shim:
+    """Define a basic interface for external models. Users can create subclasses
+    of 'shim' to wrap external libraries. We provide shims for PyTorch.
+
+    The Thinc Model class treats Shim objects as a sort of special type of
+    sublayer: it knows they're not actual Thinc Model instances, but it also
+    knows to talk to the shim instances when doing things like using transferring
+    between devices, loading in parameters, optimization. It also knows Shim
+    objects need to be serialized and deserialized with to/from bytes/disk,
+    rather than expecting that they'll be msgpack-serializable.
+    """
+
+    global_id = 0
+
+    _model: Any
+    _optimizer: Optional[Any]
+
+    def __init__(self, model: Any):
+        Shim.global_id += 1
+        self.id = Shim.global_id
+        self._model = model
+        self._optimizer = None
+
+    def __call__(
+        self, args: List, kwargs: Dict, is_train: bool
+    ) -> Tuple[Any, Callable[[Any], Any]]:
+        raise NotImplementedError
+
+    def predict(self, args: List, kwargs: Dict) -> Any:
+        Y, backprop = self(args, kwargs, is_train=False)
+        return Y
+
+    def begin_update(
+        self, args: List, kwargs: Dict
+    ) -> Tuple[Any, Callable[[Any], Any]]:
+        return self(args, kwargs, is_train=True)
+
+    def finish_update(self, optimizer):
+        raise NotImplementedError
+
+    @contextlib.contextmanager
+    def use_params(self, params):
+        raise NotImplementedError
+
+    def to_gpu(self, device_num):
+        raise NotImplementedError
+
+    def to_cpu(self):
+        raise NotImplementedError
+
+    def to_disk(self, path):
+        bytes_data = self.to_bytes()
+        with Path(path).open("wb") as file_:
+            file_.write(bytes_data)
+
+    def from_disk(self, path) -> "Shim":
+        with Path(path).open("rb") as file_:
+            bytes_data = file_.read()
+        return self.from_bytes(bytes_data)
+
+    def to_bytes(self):
+        raise NotImplementedError
+
+    def from_bytes(self, data) -> "Shim":
+        raise NotImplementedError

--- a/thinc/tests/integration/test_basic_tagger.py
+++ b/thinc/tests/integration/test_basic_tagger.py
@@ -9,7 +9,6 @@ from thinc.layers.hashembed import HashEmbed
 from thinc.layers.extractwindow import ExtractWindow
 from thinc.layers.chain import chain
 from thinc.layers.with_flatten import with_flatten
-from thinc.loss import categorical_crossentropy
 from thinc.optimizers import Adam
 import ml_datasets
 

--- a/thinc/tests/integration/test_roundtrip_bytes.py
+++ b/thinc/tests/integration/test_roundtrip_bytes.py
@@ -1,4 +1,3 @@
-import pytest
 from thinc.layers.maxout import Maxout
 from thinc.layers.chain import chain
 

--- a/thinc/tests/unit/test_affine.py
+++ b/thinc/tests/unit/test_affine.py
@@ -135,7 +135,9 @@ def test_dropout_gives_zero_gradients(W_b_input):
     model = chain(get_model(W_b_input), Dropout(1.0))
     nr_batch, nr_out, nr_in = get_shape(W_b_input)
     W, b, input_ = W_b_input
-    model.set_child_attrs("dropout", "rate", 1.0)
+    for node in model.walk():
+        if node.name == "dropout":
+            node.set_attr("rate", 1.0)
     fwd_dropped, finish_update = model.begin_update(input_)
     grad_BO = numpy.ones((nr_batch, nr_out), dtype="f")
     grad_BI = finish_update(grad_BO)

--- a/thinc/tests/unit/test_mem.py
+++ b/thinc/tests/unit/test_mem.py
@@ -64,7 +64,7 @@ def test_get_first_gradient(ops):
 
 def test_get_existing_gradient(ops):
     params = Memory(ops, size=10)
-    b = params.add("b", (5,))
+    params.add("b", (5,))
     db = params.add_gradient("d_b", "b")
     db += 1
     db = params.get("d_b")

--- a/thinc/tests/unit/test_pytorch_wrapper.py
+++ b/thinc/tests/unit/test_pytorch_wrapper.py
@@ -29,7 +29,6 @@ def check_learns_zero_output(model, sgd, X, Y):
         prev = total
 
 
-@pytest.mark.xfail
 @pytest.mark.skipif(not has_pytorch, reason="needs PyTorch")
 def test_unwrapped(nN=2, nI=3, nO=4):
     model = Affine(nO, nI)
@@ -40,7 +39,6 @@ def test_unwrapped(nN=2, nI=3, nO=4):
     check_learns_zero_output(model, sgd, X, Y)
 
 
-@pytest.mark.xfail
 @pytest.mark.skipif(not has_pytorch, reason="needs PyTorch")
 def test_wrapper(nN=2, nI=3, nO=4):
     model = PyTorchWrapper(torch.nn.Linear(nI, nO))

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -202,12 +202,15 @@ def get_width(X: Array, dim: int = -1) -> int:
         raise ValueError(err)
 
 
-def xp2torch(xp_tensor):
+def xp2torch(xp_tensor, requires_grad=False):
     """Convert a numpy or cupy tensor to a PyTorch tensor."""
     if hasattr(xp_tensor, "toDlpack"):
-        return torch.utils.dlpack.from_dlpack(xp_tensor.toDlpack())
+        torch_tensor = torch.utils.dlpack.from_dlpack(xp_tensor.toDlpack())
     else:
-        return torch.from_numpy(xp_tensor)
+        torch_tensor = torch.from_numpy(xp_tensor)
+    if requires_grad:
+        torch_tensor.requires_grad_()
+    return torch_tensor
 
 
 def torch2xp(torch_tensor):


### PR DESCRIPTION
Introduce specific support for having a model contain a non-Thinc model. This is better than storing the model in the generic `_attrs`, because we want to make sure we pass along calls to optimization and other parameter-relevant operations to the external models. Without a notion of these external models, we'll need each interface to be a special subclass of `Model`.

The "shims" system introduces a new base class, `Shim`, which interfaces to third-party packages should subclass. The `Shim` API is pretty small: you basically just have to make your class serializable with to/from bytes/disk methods, and you need to implement a `__call__` function that returns the output and the backprop callback. There are a couple of other methods as well, e.g. to cpu/gpu. Shims are stored within `model.shims`. I considered making shims a dict, but most of the time you'll only have one shim member, and there's not really much point to naming them. It's also better to make it more similar to `layers`.

The `PyTorchWrapper` tests now pass again 🎉 . It would be great to get a Tensorflow shim and wrapper in place now as well.