### PR TITLE
Small type fixes

### DIFF
--- a/thinc/config.py
+++ b/thinc/config.py
@@ -12,14 +12,14 @@ class Config(dict):
     under the hood.
     """
 
-    def __init__(self, data: Optional[Union[Dict[str, Any], "Config"]] = None) -> None:
+    def __init__(self, data: Optional[Union[Dict[str, Any], "ConfigParser"]] = None) -> None:
         """Initialize a new Config object with optional data."""
         dict.__init__(self)
         if data is None:
             data = {}
         self.update(data)
 
-    def interpret_config(self, config: Union[Dict[str, Any], "Config"]):
+    def interpret_config(self, config: Union[Dict[str, Any], "ConfigParser"]):
         """Interpret a config, parse nested sections and parse the values
         as JSON. Mostly used internally and modifies the config in place.
         """

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -122,7 +122,7 @@ class Model:
 
     @classmethod
     @contextlib.contextmanager
-    def define_operators(cls, operators):
+    def define_operators(cls, operators: Dict[str, Callable]):
         """Bind operators to specified functions for the scope of the context:
 
         Example:


### PR DESCRIPTION
- adding type for `operators` in `Model.define_operators`
- I think `Config` should get as `data` a `dict` object or a `ConfigParser` ? Or is there also a use-case where a `Config` parser itself is given as argument? (and would this not be caught already because `Config` inherits from `dict` ?) Either way a change is needed because `Config.from_str` calls `interpret_config` with a `ConfigParser`.