### PR TITLE
Small refactor of config and registry parsing methods

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -110,3 +110,4 @@ exclude_lines =
 
 [mypy]
 ignore_missing_imports = True
+plugins = pydantic.mypy

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -24,6 +24,10 @@ class Config(dict):
         as JSON. Mostly used internally and modifies the config in place.
         """
         for section, values in config.items():
+            if section == "DEFAULT":
+                # Skip [DEFAULT] section for now since it causes validation
+                # errors and it's unclear if we want to use this?
+                continue
             parts = section.split(".")
             node = self
             for part in parts:

--- a/thinc/tests/unit/test_registry.py
+++ b/thinc/tests/unit/test_registry.py
@@ -281,7 +281,7 @@ def test_config_to_str():
 def test_validation_custom_types():
     def complex_args(
         rate: StrictFloat,
-        steps: PositiveInt = 10,
+        steps: PositiveInt = 10,  # type: ignore
         log_level: constr(regex="(DEUG|INFO|WARNING|ERROR)") = "ERROR",
     ):
         return None

--- a/thinc/tests/unit/test_registry.py
+++ b/thinc/tests/unit/test_registry.py
@@ -36,46 +36,6 @@ class ComplexSchema(BaseModel):
     level2_opt: DefaultsSchema = DefaultsSchema(required=1)
 
 
-def test_validate_simple_config():
-    simple_config = {"hello": 1, "world": 2}
-    f, v = my_registry.fill_and_validate(simple_config, HelloIntsSchema)
-    assert f == simple_config
-    assert v == simple_config
-
-
-def test_invalidate_simple_config():
-    invalid_config = {"hello": 1, "world": "hi!"}
-    with pytest.raises(ConfigValidationError):
-        f, v = my_registry.fill_and_validate(invalid_config, HelloIntsSchema)
-
-
-def test_invalidate_extra_args():
-    invalid_config = {"hello": 1, "world": 2, "extra": 3}
-    with pytest.raises(ConfigValidationError):
-        f, v = my_registry.fill_and_validate(invalid_config, HelloIntsSchema)
-
-
-def test_fill_defaults_simple_config():
-    valid_config = {"required": 1}
-    filled, v = my_registry.fill_and_validate(valid_config, DefaultsSchema)
-    assert filled["required"] == 1
-    assert filled["optional"] == "default value"
-    invalid_config = {"optional": "some value"}
-    with pytest.raises(ConfigValidationError):
-        f, v = my_registry.fill_and_validate(invalid_config, DefaultsSchema)
-
-
-def test_fill_recursive_config():
-    valid_config = {"outer_req": 1, "level2_req": {"hello": 4, "world": 7}}
-    filled, validation = my_registry.fill_and_validate(valid_config, ComplexSchema)
-    assert filled["outer_req"] == 1
-    assert filled["outer_opt"] == "default value"
-    assert filled["level2_req"]["hello"] == 4
-    assert filled["level2_req"]["world"] == 7
-    assert filled["level2_opt"]["required"] == 1
-    assert filled["level2_opt"]["optional"] == "default value"
-
-
 @my_registry.cats.register("catsie.v1")
 def catsie_v1(evil: StrictBool, cute: bool = True) -> str:
     if evil:
@@ -84,103 +44,20 @@ def catsie_v1(evil: StrictBool, cute: bool = True) -> str:
         return "meow"
 
 
-good_catsie = {"@cats": "catsie.v1", "evil": False, "cute": True}
+@my_registry.cats.register("catsie.v2")
+def catsie_v2(evil: StrictBool, cute: bool = True, cute_level: int = 1) -> str:
+    if evil:
+        return "scratch!"
+    else:
+        if cute_level > 2:
+            return "meow <3"
+        return "meow"
 
+
+good_catsie = {"@cats": "catsie.v1", "evil": False, "cute": True}
 ok_catsie = {"@cats": "catsie.v1", "evil": False, "cute": False}
 bad_catsie = {"@cats": "catsie.v1", "evil": True, "cute": True}
-
 worst_catsie = {"@cats": "catsie.v1", "evil": True, "cute": False}
-
-
-def test_is_promise():
-    assert my_registry.is_promise(good_catsie)
-    assert not my_registry.is_promise({"hello": "world"})
-    assert not my_registry.is_promise(1)
-
-
-def test_get_constructor():
-    func = my_registry.get_constructor(good_catsie)
-    assert func is catsie_v1
-
-
-def test_parse_args():
-    args, kwargs = my_registry.parse_args(bad_catsie)
-    assert args == []
-    assert kwargs == {"evil": True, "cute": True}
-
-
-def test_make_promise_schema():
-    schema = my_registry.make_promise_schema(good_catsie)
-    assert "evil" in schema.__fields__
-    assert "cute" in schema.__fields__
-
-
-def test_validate_promise():
-    config = {"required": 1, "optional": good_catsie}
-    filled, validated = my_registry.fill_and_validate(config, DefaultsSchema)
-    assert filled == config
-    assert validated == {"required": 1, "optional": "meow"}
-
-
-def test_fill_validate_promise():
-    config = {"required": 1, "optional": {"@cats": "catsie.v1", "evil": False}}
-    filled, validated = my_registry.fill_and_validate(config, DefaultsSchema)
-    assert filled["optional"]["cute"] is True
-
-
-def test_fill_invalidate_promise():
-    config = {"required": 1, "optional": {"@cats": "catsie.v1", "evil": False}}
-    with pytest.raises(ConfigValidationError):
-        filled, validated = my_registry.fill_and_validate(config, HelloIntsSchema)
-    config["optional"]["whiskers"] = True
-    with pytest.raises(ConfigValidationError):
-        filled, validated = my_registry.fill_and_validate(config, DefaultsSchema)
-
-
-def test_create_registry():
-    with pytest.raises(ValueError):
-        my_registry.create("cats")
-    my_registry.create("dogs")
-    assert hasattr(my_registry, "dogs")
-    assert len(my_registry.dogs.get_all()) == 0
-    my_registry.dogs.register("good_boy.v1", func=lambda x: x)
-    assert len(my_registry.dogs.get_all()) == 1
-    with pytest.raises(ValueError):
-        my_registry.create("dogs")
-
-
-def test_make_from_config_no_schema():
-    config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
-    result = my_registry.make_from_config(config)
-    assert result["one"] == 1
-    assert result["two"] == {"three": "scratch!"}
-    with pytest.raises(ConfigValidationError):
-        config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": "true"}}}
-        my_registry.make_from_config(config)
-
-
-def test_make_from_config_base_schema():
-    class TestBaseSubSchema(BaseModel):
-        three: str
-
-    class TestBaseSchema(BaseModel):
-        one: PositiveInt
-        two: TestBaseSubSchema
-
-        class Config:
-            extra = "forbid"
-
-    config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
-    my_registry.make_from_config(config, base_schema=TestBaseSchema)
-    config = {"one": -1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
-    with pytest.raises(ConfigValidationError):
-        # "one" is not a positive int
-        my_registry.make_from_config(config, base_schema=TestBaseSchema)
-    config = {"one": 1, "two": {"four": {"@cats": "catsie.v1", "evil": True}}}
-    with pytest.raises(ConfigValidationError):
-        # "three" is required in subschema
-        my_registry.make_from_config(config, base_schema=TestBaseSchema)
-
 
 EXAMPLE_CONFIG = """
 [DEFAULT]
@@ -251,6 +128,136 @@ total_steps = 100000
 """
 
 
+def test_validate_simple_config():
+    simple_config = {"hello": 1, "world": 2}
+    f, v = my_registry._fill(simple_config, HelloIntsSchema)
+    assert f == simple_config
+    assert v == simple_config
+
+
+def test_invalidate_simple_config():
+    invalid_config = {"hello": 1, "world": "hi!"}
+    with pytest.raises(ConfigValidationError):
+        f, v = my_registry._fill(invalid_config, HelloIntsSchema)
+
+
+def test_invalidate_extra_args():
+    invalid_config = {"hello": 1, "world": 2, "extra": 3}
+    with pytest.raises(ConfigValidationError):
+        f, v = my_registry._fill(invalid_config, HelloIntsSchema)
+
+
+def test_fill_defaults_simple_config():
+    valid_config = {"required": 1}
+    filled, v = my_registry._fill(valid_config, DefaultsSchema)
+    assert filled["required"] == 1
+    assert filled["optional"] == "default value"
+    invalid_config = {"optional": "some value"}
+    with pytest.raises(ConfigValidationError):
+        f, v = my_registry._fill(invalid_config, DefaultsSchema)
+
+
+def test_fill_recursive_config():
+    valid_config = {"outer_req": 1, "level2_req": {"hello": 4, "world": 7}}
+    filled, validation = my_registry._fill(valid_config, ComplexSchema)
+    assert filled["outer_req"] == 1
+    assert filled["outer_opt"] == "default value"
+    assert filled["level2_req"]["hello"] == 4
+    assert filled["level2_req"]["world"] == 7
+    assert filled["level2_opt"]["required"] == 1
+    assert filled["level2_opt"]["optional"] == "default value"
+
+
+def test_is_promise():
+    assert my_registry.is_promise(good_catsie)
+    assert not my_registry.is_promise({"hello": "world"})
+    assert not my_registry.is_promise(1)
+
+
+def test_get_constructor():
+    func = my_registry.get_constructor(good_catsie)
+    assert func is catsie_v1
+
+
+def test_parse_args():
+    args, kwargs = my_registry.parse_args(bad_catsie)
+    assert args == []
+    assert kwargs == {"evil": True, "cute": True}
+
+
+def test_make_promise_schema():
+    schema = my_registry.make_promise_schema(good_catsie)
+    assert "evil" in schema.__fields__
+    assert "cute" in schema.__fields__
+
+
+def test_validate_promise():
+    config = {"required": 1, "optional": good_catsie}
+    filled, validated = my_registry._fill(config, DefaultsSchema)
+    assert filled == config
+    assert validated == {"required": 1, "optional": "meow"}
+
+
+def test_fill_validate_promise():
+    config = {"required": 1, "optional": {"@cats": "catsie.v1", "evil": False}}
+    filled, validated = my_registry._fill(config, DefaultsSchema)
+    assert filled["optional"]["cute"] is True
+
+
+def test_fill_invalidate_promise():
+    config = {"required": 1, "optional": {"@cats": "catsie.v1", "evil": False}}
+    with pytest.raises(ConfigValidationError):
+        filled, validated = my_registry._fill(config, HelloIntsSchema)
+    config["optional"]["whiskers"] = True
+    with pytest.raises(ConfigValidationError):
+        filled, validated = my_registry._fill(config, DefaultsSchema)
+
+
+def test_create_registry():
+    with pytest.raises(ValueError):
+        my_registry.create("cats")
+    my_registry.create("dogs")
+    assert hasattr(my_registry, "dogs")
+    assert len(my_registry.dogs.get_all()) == 0
+    my_registry.dogs.register("good_boy.v1", func=lambda x: x)
+    assert len(my_registry.dogs.get_all()) == 1
+    with pytest.raises(ValueError):
+        my_registry.create("dogs")
+
+
+def test_make_from_config_no_schema():
+    config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
+    result = my_registry.make_from_config(config)
+    assert result["one"] == 1
+    assert result["two"] == {"three": "scratch!"}
+    with pytest.raises(ConfigValidationError):
+        config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": "true"}}}
+        my_registry.make_from_config(config)
+
+
+def test_make_from_config_schema():
+    class TestBaseSubSchema(BaseModel):
+        three: str
+
+    class TestBaseSchema(BaseModel):
+        one: PositiveInt
+        two: TestBaseSubSchema
+
+        class Config:
+            extra = "forbid"
+
+    config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
+    my_registry.make_from_config(config, schema=TestBaseSchema)
+    config = {"one": -1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
+    with pytest.raises(ConfigValidationError):
+        # "one" is not a positive int
+        my_registry.make_from_config(config, schema=TestBaseSchema)
+    config = {"one": 1, "two": {"four": {"@cats": "catsie.v1", "evil": True}}}
+    with pytest.raises(ConfigValidationError):
+        # "three" is required in subschema
+        my_registry.make_from_config(config, schema=TestBaseSchema)
+
+
 def test_read_config():
     byte_string = EXAMPLE_CONFIG.encode("utf8")
     cfg = Config().from_bytes(byte_string)
@@ -285,7 +292,36 @@ def test_validation_custom_types():
     my_registry.make_from_config({"config": cfg})
     cfg = {"@complex": "complex.v1", "rate": 1.0, "steps": -1, "log_level": "INFO"}
     with pytest.raises(ConfigValidationError):
+        # steps is not a positive int
         my_registry.make_from_config({"config": cfg})
     cfg = {"@complex": "complex.v1", "rate": 1.0, "steps": 20, "log_level": "none"}
     with pytest.raises(ConfigValidationError):
+        # log_level is not a string matching the regex
         my_registry.make_from_config({"config": cfg})
+    cfg = {"@complex": "complex.v1", "rate": 1.0, "steps": 20, "log_level": "INFO"}
+    with pytest.raises(ConfigValidationError):
+        # top-level object is promise
+        my_registry.make_from_config(cfg)
+
+
+def test_validation_no_validate():
+    config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": "false"}}}
+    result = my_registry.make_from_config(config, validate=False)
+    assert result["one"] == 1
+    assert result["two"] == {"three": "scratch!"}
+
+
+def test_validation_fill_defaults():
+    config = {"one": 1, "two": {"@cats": "catsie.v1"}}
+    result = my_registry.fill_config(config, validate=False)
+    assert len(result["two"]) == 2  # no value filled in for "evil"
+    with pytest.raises(ConfigValidationError):
+        # Required arg "evil" is not defined
+        my_registry.fill_config(config)
+    config = {"one": 1, "two": {"@cats": "catsie.v2", "evil": False}}
+    # Fill in with new defaults
+    result = my_registry.fill_config(config)
+    assert len(result["two"]) == 4
+    assert result["two"]["evil"] is False
+    assert result["two"]["cute"] is True
+    assert result["two"]["cute_level"] == 1


### PR DESCRIPTION
- [x] make registry methods return `Config` object instead of dict (so you can directly call `to_disk` etc. on the result, which makes sense, since you also typically pass in a config, and the config otherwise behaves like a dict)
- [x] only use one `_fill` helper for recursive validation and filling, and add two separate classmethods to expose the result: `make_from_config` (returns filled config with resolved functions from registry) and `fill_config` (only fills in default values from schema and/or function signature and returns updated config)
- [x] allow toggling validation for both modes
- [x] improve handling of unset required arguments and how errors are raised for it (also skip it if validation is disabled instead of raising the error)
- [x] skip `[DEFAULT]` default section in interpreted configparser result for now – not sure if we want to use this at all, since it introduces another layer of defaults? If users want it, they can add any custom config section and use that for interpolation? The `DEFAULT` is kinda unintuitive and messes up the validation, because all top-level schemas would now require it.
- [x] add more tests and docstrings