### PR TITLE
Extend Model API (node references, dim/param/grad names properties)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ tmp/
 .pytest_cache/
 .vscode/
 .mypy_cache
+env3.*/

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -268,7 +268,7 @@ class Model(Generic[InT, OutT]):
         if key not in self._mem:
             self.inc_grad(name, value)
         else:
-            data = self._mem[(self.id, value)]
+            data = self._mem[key]
             copy_array(dst=data, src=value)
 
     def has_attr(self, name: str) -> bool:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -129,27 +129,27 @@ class Model(Generic[InT, OutT]):
         return self._shims
 
     @property
-    def param_names(self) -> Tuple[str]:
+    def param_names(self) -> Tuple[str, ...]:
         """Get the names of registered parameter (including unset.)"""
         return tuple(self._params.keys())
 
     @property
-    def grad_names(self) -> Tuple[str]:
+    def grad_names(self) -> Tuple[str, ...]:
         """Get the names of parameters with registered gradients (including unset.)"""
         return tuple([name for name in self.param_names if self.has_grad(name)])
 
     @property
-    def dim_names(self) -> Tuple[str]:
+    def dim_names(self) -> Tuple[str, ...]:
         """Get the names of registered dimensions (including unset.)"""
         return tuple(self._dims.keys())
 
     @property
-    def attr_names(self) -> Tuple[str]:
+    def attr_names(self) -> Tuple[str, ...]:
         """Get the names of attributes."""
         return tuple(self._attrs.keys())
 
     @property
-    def ref_names(self) -> Tuple[str]:
+    def ref_names(self) -> Tuple[str, ...]:
         """Get the names of registered node references (including unset.)"""
         return tuple(self._refs.keys())
 


### PR DESCRIPTION
Noticed two gaps in the `Model` API when preparing the `ray_parallel` example and starting to prepare a spaCy branch for the new Thinc.

**Gap 1: Node references** In spaCy, we often want to fetch some named sublayer of a network later. This comes up especially often with the `tok2vec` layers, but it can happen for other stuff as well (for instance, you might want to note the output layer separately or something). In previous Thinc, we just blindly banged the new attribute onto the instance, like `model.tok2vec = tok2vec`.

This PR adds another attribute, `_refs`, with `get_ref/set_ref/has_ref` methods to interface for it. You can also pass `refs` into the constructor. There's also a method `remove_node` that walks over the tree, and removes removes a node from any `layers` lists that contain it and also remove references to it.

One question is, should it be considered valid for a node to have a reference if the node does not appear anywhere in the subtree? I think maybe that shouldn't be valid, as then we won't be able to serialize and deserialize correctly.

If we don't want to allow referenes to out-of-tree nodes, the `remove_node()` method will need to change in implementation slightly. What we should do is remove the node from the child layers, and then get a new node-set from `walk()`. We can then use this to filter the references.

**Gap 2: Get all param/grad/dim/attr names**: We have a way to fetch a particular param, dim or grad by name, but because the dicts are private we didn't have any way of getting the available names. I've added properties that return tuples for these. Tuples are good because users should not believe that `model.param_names.append()` should work. The lists include the names of stuff current set to `None`. You can use `model.has_dim()` etc to filter those lists.