### PR TITLE
Experiment with representing dimension values in the type system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pydantic>=1.3.0,<2.0.0
 numpy>=1.7.0
 tqdm>=4.10.0,<5.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"
+typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"
 # Development dependencies
 cython>=0.25.0
 hypothesis>=2.0.0,<5.0.0

--- a/thinc/layers/relu.py
+++ b/thinc/layers/relu.py
@@ -1,5 +1,4 @@
 from typing import Tuple, Callable, Optional, TypeVar, cast
-from typing_extensions import Literal
 
 from ..model import Model, create_init
 from ..initializers import xavier_uniform_init, zero_init
@@ -7,7 +6,6 @@ from ..types import Array, Floats1d, Floats2d
 from .chain import chain
 from .layernorm import LayerNorm
 from .dropout import Dropout
-
 
 B = TypeVar("B", bound=int)
 O = TypeVar("O", bound=int)
@@ -44,8 +42,8 @@ def forward(
         X: Floats2d[B, I],
         is_train: bool
 ) -> Tuple[Floats2d[B, O], Callable]:
-    W: Floats2d[O, I] = model.get_param("W")
-    b: Floats1d[O] = model.get_param("b")
+    W: Floats2d[O, I] = cast(Floats2d, model.get_param("W"))
+    b: Floats1d[O] = cast(Floats1d, model.get_param("b"))
     Y: Floats2d[B, O] = model.ops.gemm(X, W, trans2=True)
     Y += b
     model.ops.relu(Y, inplace=True)

--- a/thinc/layers/relu.py
+++ b/thinc/layers/relu.py
@@ -1,11 +1,17 @@
 from typing import Tuple, Callable, Optional, TypeVar
+from typing_extensions import Literal
 
 from ..model import Model, create_init
 from ..initializers import xavier_uniform_init, zero_init
-from ..types import Array, Floats2d
+from ..types import Array, Floats1d, Floats2d
 from .chain import chain
 from .layernorm import LayerNorm
 from .dropout import Dropout
+
+
+B = TypeVar("B", bound=int)
+O = TypeVar("O", bound=int)
+I = TypeVar("I", bound=int)
 
 
 def ReLu(
@@ -17,7 +23,7 @@ def ReLu(
     dropout: Optional[float] = None,
     normalize: bool = False,
 ) -> Model:
-    model = Model[Floats2d, Floats2d](
+    model = Model[Floats2d[B, O], Floats2d[B, O]](
         "relu",
         forward,
         init=create_init({"W": init_W, "b": init_b}),
@@ -33,15 +39,18 @@ def ReLu(
     return model
 
 
-def forward(model: Model, X: Floats2d, is_train: bool) -> Tuple[Floats2d, Callable]:
-    W = model.get_param("W")
-    b = model.get_param("b")
-
-    Y = model.ops.gemm(X, W, trans2=True)
+def forward(
+        model: Model,
+        X: Floats2d[B, I],
+        is_train: bool
+) -> Tuple[Floats2d[B, O], Callable]:
+    W: Floats2d[O, I] = model.get_param("W")
+    b: Floats1d[O] = model.get_param("b")
+    Y: Floats2d[B, O] = model.ops.gemm(X, W, trans2=True)
     Y += b
     model.ops.relu(Y, inplace=True)
 
-    def backprop(dY: Floats2d) -> Floats2d:
+    def backprop(dY: Floats2d[B, O]) -> Floats2d[B, I]:
         dY = model.ops.backprop_relu(dY, Y)
         model.inc_grad("b", dY.sum(axis=0))
         model.inc_grad("W", model.ops.gemm(dY, X, trans1=True))

--- a/thinc/layers/relu.py
+++ b/thinc/layers/relu.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional, TypeVar
+from typing import Tuple, Callable, Optional, TypeVar, cast
 from typing_extensions import Literal
 
 from ..model import Model, create_init

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -484,9 +484,9 @@ class Model(Generic[InT, OutT]):
         # Serialize references by their index into the flattened tree.
         # This is the main reason we can't accept out-of-tree references:
         # we'd have no way to serialize/deserialize them.
+        node_to_i: Dict[Optional[Model], int]
+        refs: Dict[str, Optional[int]]
         node_to_i = {node: i for i, node in enumerate(nodes)}
-        # We also need an entry 'None', as references can be set to None.
-        node_to_i[None] = None
         for i, layer in enumerate(nodes):
             # Separate attrs that need to be serialized/deserialized with
             # to_/from_bytes.
@@ -497,8 +497,7 @@ class Model(Generic[InT, OutT]):
                     obj_attrs[name] = value.to_bytes()
                 else:
                     flat_attrs[name] = value
-
-            refs = {name: node_to_i[ref] for name, ref in layer._refs.items()}
+            refs = {name: node_to_i.get(ref) for name, ref in layer._refs.items()}
             weights.append(
                 {
                     "dims": layer._dims,

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -434,9 +434,7 @@ def get_array_validators(*, ndim, dtype):
 
 
 f1d1 = TypeVar("f1d1", bound=int)
-
-
-class Floats1d(Generic[f1d1], Array):
+class Floats1d(Array, Generic[f1d1]):
     """1-dimensional array of floats."""
 
     @classmethod
@@ -449,7 +447,7 @@ f2d1 = TypeVar("f2d1", bound=int)
 f2d2 = TypeVar("f2d2", bound=int)
 
 
-class Floats2d(Generic[f2d1, f2d2], Array):
+class Floats2d(Array, Generic[f2d1, f2d2]):
     """2-dimensional array of floats."""
 
     @classmethod

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -9,7 +9,10 @@ from typing import (
     Any,
     Optional,
     List,
+    Generic,
+    TypeVar,
 )
+from typing_extensions import Literal
 from enum import Enum
 import numpy
 
@@ -430,7 +433,8 @@ def get_array_validators(*, ndim, dtype):
     )
 
 
-class Floats1d(Array):
+f1d1 = TypeVar("f1d1", bound=int)
+class Floats1d(Generic[f1d1], Array):
     """1-dimensional array of floats."""
 
     @classmethod
@@ -439,7 +443,9 @@ class Floats1d(Array):
             yield validator
 
 
-class Floats2d(Array):
+f2d1 = TypeVar("f2d1", bound=int)
+f2d2 = TypeVar("f2d2", bound=int)
+class Floats2d(Generic[f2d1, f2d2], Array):
     """2-dimensional array of floats."""
 
     @classmethod
@@ -448,7 +454,10 @@ class Floats2d(Array):
             yield validator
 
 
-class Floats3d(Array):
+f3d1 = TypeVar("f3d1", bound=int)
+f3d2 = TypeVar("f3d2", bound=int)
+f3d3 = TypeVar("f3d3", bound=int)
+class Floats3d(Generic[f3d1, f3d2, f3d3], Array):
     """3-dimensional array of floats."""
 
     @classmethod
@@ -456,8 +465,11 @@ class Floats3d(Array):
         for validator in get_array_validators(ndim=3, dtype=xp.float32):
             yield validator
 
-
-class Floats4d(Array):
+f4d1 = TypeVar("f4d1", bound=int)
+f4d2 = TypeVar("f4d2", bound=int)
+f4d3 = TypeVar("f4d3", bound=int)
+f4d4 = TypeVar("f4d4", bound=int)
+class Floats4d(Generic[f4d1, f4d2, f4d3, f4d4], Array):
     """4-dimensional array of floats."""
 
     @classmethod
@@ -465,8 +477,8 @@ class Floats4d(Array):
         for validator in get_array_validators(ndim=4, dtype=xp.float32):
             yield validator
 
-
-class FloatsNd(Array):
+f_ndim = TypeVar("f_ndim", bound=int)
+class FloatsNd(Generic[f_ndim], Array):
     """N-dimensional array of floats."""
 
     @classmethod
@@ -474,8 +486,8 @@ class FloatsNd(Array):
         for validator in get_array_validators(ndim=None, dtype=xp.float32):
             yield validator
 
-
-class Ints1d(Array):
+i1d1 = TypeVar("i1d1", bound=int)
+class Ints1d(Generic[i1d1], Array):
     """1-dimensional array of ints."""
 
     @classmethod
@@ -483,8 +495,9 @@ class Ints1d(Array):
         for validator in get_array_validators(ndim=1, dtype=xp.int32):
             yield validator
 
-
-class Ints2d(Array):
+i2d1 = TypeVar("i2d1", bound=int)
+i2d2 = TypeVar("i2d2", bound=int)
+class Ints2d(Generic[i2d1, i2d2], Array):
     """2-dimensional array of ints."""
 
     @classmethod
@@ -492,8 +505,11 @@ class Ints2d(Array):
         for validator in get_array_validators(ndim=2, dtype=xp.int32):
             yield validator
 
-
-class Ints3d(Array):
+i3d1 = TypeVar("i3d1", bound=int)
+i3d2 = TypeVar("i3d2", bound=int)
+i3d3 = TypeVar("i3d3", bound=int)
+i3d4 = TypeVar("i3d4", bound=int)
+class Ints3d(Generic[i3d1, i3d2, i3d3], Array):
     """3-dimensional array of ints."""
 
     @classmethod
@@ -501,8 +517,11 @@ class Ints3d(Array):
         for validator in get_array_validators(ndim=3, dtype=xp.int32):
             yield validator
 
-
-class Ints4d(Array):
+i4d1 = TypeVar("i4d1", bound=int)
+i4d2 = TypeVar("i4d2", bound=int)
+i4d3 = TypeVar("i4d3", bound=int)
+i4d4 = TypeVar("i4d4", bound=int)
+class Ints4d(Generic[i4d1, i4d2, i4d3, i4d4], Array):
     """4-dimensional array of ints."""
 
     @classmethod
@@ -511,7 +530,8 @@ class Ints4d(Array):
             yield validator
 
 
-class IntsNd(Array):
+i_ndim = TypeVar("i_ndim", bound=int)
+class IntsNd(Generic[i_ndim], Array):
     """N-dimensional array of ints."""
 
     @classmethod

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -12,7 +12,6 @@ from typing import (
     Generic,
     TypeVar,
 )
-from typing_extensions import Literal
 from enum import Enum
 import numpy
 

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -1,19 +1,28 @@
+import sys
 from dataclasses import dataclass
-from typing import (
-    Union,
-    Tuple,
-    Callable,
-    Iterator,
-    Sized,
-    Container,
-    Any,
-    Optional,
-    List,
-    Generic,
-    TypeVar,
-)
 from enum import Enum
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Container,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Sized,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
 import numpy
+
+# Use typing_extensions for Python versions < 3.8
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
 
 
 try:
@@ -40,6 +49,8 @@ class DTypes(str, Enum):
 
 
 ndim = TypeVar("ndim", bound=int)
+
+
 class Array(Generic[ndim], Sized, Container):
     T: "Array"
     base: Optional["Array"]
@@ -434,6 +445,8 @@ def get_array_validators(*, ndim, dtype):
 
 
 f1d1 = TypeVar("f1d1", bound=int)
+
+
 class Floats1d(Array, Generic[f1d1]):
     """1-dimensional array of floats."""
 
@@ -447,7 +460,7 @@ f2d1 = TypeVar("f2d1", bound=int)
 f2d2 = TypeVar("f2d2", bound=int)
 
 
-class Floats2d(Array, Generic[f2d1, f2d2]):
+class Floats2d(Generic[f2d1, f2d2], Array[Literal[2]]):
     """2-dimensional array of floats."""
 
     @classmethod
@@ -461,7 +474,7 @@ f3d2 = TypeVar("f3d2", bound=int)
 f3d3 = TypeVar("f3d3", bound=int)
 
 
-class Floats3d(Generic[f3d1, f3d2, f3d3], Array):
+class Floats3d(Generic[f3d1, f3d2, f3d3], Array[Literal[3]]):
     """3-dimensional array of floats."""
 
     @classmethod
@@ -476,7 +489,7 @@ f4d3 = TypeVar("f4d3", bound=int)
 f4d4 = TypeVar("f4d4", bound=int)
 
 
-class Floats4d(Generic[f4d1, f4d2, f4d3, f4d4], Array):
+class Floats4d(Generic[f4d1, f4d2, f4d3, f4d4], Array[Literal[4]]):
     """4-dimensional array of floats."""
 
     @classmethod
@@ -488,7 +501,7 @@ class Floats4d(Generic[f4d1, f4d2, f4d3, f4d4], Array):
 f_ndim = TypeVar("f_ndim", bound=int)
 
 
-class FloatsNd(Generic[f_ndim], Array):
+class FloatsNd(Array[f_ndim]):
     """N-dimensional array of floats."""
 
     @classmethod
@@ -500,7 +513,7 @@ class FloatsNd(Generic[f_ndim], Array):
 i1d1 = TypeVar("i1d1", bound=int)
 
 
-class Ints1d(Generic[i1d1], Array):
+class Ints1d(Generic[i1d1], Array[Literal[1]]):
     """1-dimensional array of ints."""
 
     @classmethod
@@ -513,7 +526,7 @@ i2d1 = TypeVar("i2d1", bound=int)
 i2d2 = TypeVar("i2d2", bound=int)
 
 
-class Ints2d(Generic[i2d1, i2d2], Array):
+class Ints2d(Generic[i2d1, i2d2], Array[Literal[2]]):
     """2-dimensional array of ints."""
 
     @classmethod
@@ -528,7 +541,7 @@ i3d3 = TypeVar("i3d3", bound=int)
 i3d4 = TypeVar("i3d4", bound=int)
 
 
-class Ints3d(Generic[i3d1, i3d2, i3d3], Array):
+class Ints3d(Generic[i3d1, i3d2, i3d3], Array[Literal[3]]):
     """3-dimensional array of ints."""
 
     @classmethod
@@ -543,7 +556,7 @@ i4d3 = TypeVar("i4d3", bound=int)
 i4d4 = TypeVar("i4d4", bound=int)
 
 
-class Ints4d(Generic[i4d1, i4d2, i4d3, i4d4], Array):
+class Ints4d(Generic[i4d1, i4d2, i4d3, i4d4], Array[Literal[4]]):
     """4-dimensional array of ints."""
 
     @classmethod
@@ -555,7 +568,7 @@ class Ints4d(Generic[i4d1, i4d2, i4d3, i4d4], Array):
 i_ndim = TypeVar("i_ndim", bound=int)
 
 
-class IntsNd(Generic[i_ndim], Array):
+class IntsNd(Array[i_ndim]):
     """N-dimensional array of ints."""
 
     @classmethod

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -434,6 +434,8 @@ def get_array_validators(*, ndim, dtype):
 
 
 f1d1 = TypeVar("f1d1", bound=int)
+
+
 class Floats1d(Generic[f1d1], Array):
     """1-dimensional array of floats."""
 
@@ -445,6 +447,8 @@ class Floats1d(Generic[f1d1], Array):
 
 f2d1 = TypeVar("f2d1", bound=int)
 f2d2 = TypeVar("f2d2", bound=int)
+
+
 class Floats2d(Generic[f2d1, f2d2], Array):
     """2-dimensional array of floats."""
 
@@ -457,6 +461,8 @@ class Floats2d(Generic[f2d1, f2d2], Array):
 f3d1 = TypeVar("f3d1", bound=int)
 f3d2 = TypeVar("f3d2", bound=int)
 f3d3 = TypeVar("f3d3", bound=int)
+
+
 class Floats3d(Generic[f3d1, f3d2, f3d3], Array):
     """3-dimensional array of floats."""
 
@@ -465,10 +471,13 @@ class Floats3d(Generic[f3d1, f3d2, f3d3], Array):
         for validator in get_array_validators(ndim=3, dtype=xp.float32):
             yield validator
 
+
 f4d1 = TypeVar("f4d1", bound=int)
 f4d2 = TypeVar("f4d2", bound=int)
 f4d3 = TypeVar("f4d3", bound=int)
 f4d4 = TypeVar("f4d4", bound=int)
+
+
 class Floats4d(Generic[f4d1, f4d2, f4d3, f4d4], Array):
     """4-dimensional array of floats."""
 
@@ -477,7 +486,10 @@ class Floats4d(Generic[f4d1, f4d2, f4d3, f4d4], Array):
         for validator in get_array_validators(ndim=4, dtype=xp.float32):
             yield validator
 
+
 f_ndim = TypeVar("f_ndim", bound=int)
+
+
 class FloatsNd(Generic[f_ndim], Array):
     """N-dimensional array of floats."""
 
@@ -486,7 +498,10 @@ class FloatsNd(Generic[f_ndim], Array):
         for validator in get_array_validators(ndim=None, dtype=xp.float32):
             yield validator
 
+
 i1d1 = TypeVar("i1d1", bound=int)
+
+
 class Ints1d(Generic[i1d1], Array):
     """1-dimensional array of ints."""
 
@@ -495,8 +510,11 @@ class Ints1d(Generic[i1d1], Array):
         for validator in get_array_validators(ndim=1, dtype=xp.int32):
             yield validator
 
+
 i2d1 = TypeVar("i2d1", bound=int)
 i2d2 = TypeVar("i2d2", bound=int)
+
+
 class Ints2d(Generic[i2d1, i2d2], Array):
     """2-dimensional array of ints."""
 
@@ -505,10 +523,13 @@ class Ints2d(Generic[i2d1, i2d2], Array):
         for validator in get_array_validators(ndim=2, dtype=xp.int32):
             yield validator
 
+
 i3d1 = TypeVar("i3d1", bound=int)
 i3d2 = TypeVar("i3d2", bound=int)
 i3d3 = TypeVar("i3d3", bound=int)
 i3d4 = TypeVar("i3d4", bound=int)
+
+
 class Ints3d(Generic[i3d1, i3d2, i3d3], Array):
     """3-dimensional array of ints."""
 
@@ -517,10 +538,13 @@ class Ints3d(Generic[i3d1, i3d2, i3d3], Array):
         for validator in get_array_validators(ndim=3, dtype=xp.int32):
             yield validator
 
+
 i4d1 = TypeVar("i4d1", bound=int)
 i4d2 = TypeVar("i4d2", bound=int)
 i4d3 = TypeVar("i4d3", bound=int)
 i4d4 = TypeVar("i4d4", bound=int)
+
+
 class Ints4d(Generic[i4d1, i4d2, i4d3, i4d4], Array):
     """4-dimensional array of ints."""
 
@@ -531,6 +555,8 @@ class Ints4d(Generic[i4d1, i4d2, i4d3, i4d4], Array):
 
 
 i_ndim = TypeVar("i_ndim", bound=int)
+
+
 class IntsNd(Generic[i_ndim], Array):
     """N-dimensional array of ints."""
 

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -39,7 +39,8 @@ class DTypes(str, Enum):
     uint64 = "uint64"
 
 
-class Array(Sized, Container):
+ndim = TypeVar("ndim", bound=int)
+class Array(Generic[ndim], Sized, Container):
     T: "Array"
     base: Optional["Array"]
 


### PR DESCRIPTION
We can't expect the type checking to provide full validation over literal types, as we won't be able to express something like "concatenate returns output with dimensionality equal to the sum of its layers' dimensionality. However, even if the checking doesn't really work properly, it's worth discussing what this could look like, and what we can and can't do with it.

I'm not 100% sure I'm doing this right, but I've tried to make the `Floats1d`, `Floats2d` etc arrays into generics, giving us space to pass type variables in to represent the dimensions. I've taken care to use distinct variables for each class. I'm not sure this is actually necessary? I didn't want mypy to think the dimensions across the classes matched the same values or something.

Arguably we could avoid having the `Floats1d`, `Floats2d` etc classes, and make these generic with respect to number of dimensions. I think that's probably worse: I think it's worth being able to express `Floats2d` concisely, and to me it seems to make things simpler and easier to work with. If it turns out making this a parametric type with a literal is better, sure we can do that.

The main thing that I think is neat is having a way to document the expected dimensionalities in the code.

I have no idea what conventions we should use to distinguish the dimension type variables from real variables, though. We want the type variables to have concise names, but we still want concise names available within the code. I think we need a better variable convention in general around this stuff. For instance, maybe weights parameters should be named like `wW`, `wB` by convention? Then their gradients could still be `dW`.