### PR TITLE
add cauchysimilarity import

### DIFF
--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -165,7 +165,7 @@ class NumpyOps(Ops):
         '''
         cdef int B = seq.shape[0]
         cdef int I = seq.shape[1]
-        cdef ndarray cols = self.allocate((B, (2 * nW+1) * I), dtype='float32')
+        cdef ndarray cols = self.allocate((B, (2*nW + 1) * I), dtype='float32')
         seq2col(<float*>cols.data, &seq[0,0], nW, B, I)
         return cols
 

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -1,5 +1,6 @@
 # Weights layers
 from .affine import Affine
+from .cauchysimilarity import CauchySimilarity
 from .dropout import Dropout
 from .embed import Embed
 from .extractwindow import ExtractWindow


### PR DESCRIPTION
`CauchySimilarity` was missing from the imports in `layers.init`, causing trouble in spaCy imports.

Also reformated the formula for calculating output size after adding context from a window, I thought the spacing was confusing...