### PR TITLE
Track origin of ConfigValidationError

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -15,7 +15,7 @@ from .backends import Ops, CupyOps, NumpyOps
 from .layers import Dropout, Embed, ExtractWindow, HashEmbed, LayerNorm, Linear
 from .layers import Maxout, Mish, MultiSoftmax, ReLu, Residual, Softmax, BiLSTM, LSTM
 from .layers import CauchySimilarity, ParametricAttention, PyTorchWrapper
-from .layers import SparseLinear, StaticVectors, PyTorchBiLSTM
+from .layers import SparseLinear, StaticVectors, PyTorchBiLSTM, FeatureExtractor
 
 from .layers import add, bidirectional, chain, clone, concatenate, foreach, noop
 from .layers import recurrent, uniqued, siamese, list2ragged, ragged2list

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -12,7 +12,7 @@ from .util import to_categorical, get_width, xp2torch, torch2xp
 from .backends import get_ops, set_current_ops, get_current_ops, use_device
 from .backends import Ops, CupyOps, NumpyOps
 
-from .layers import Affine, Dropout, Embed, ExtractWindow, HashEmbed, LayerNorm
+from .layers import Affine, CauchySimilarity, Dropout, Embed, ExtractWindow, HashEmbed, LayerNorm
 from .layers import Maxout, Mish, MultiSoftmax, ReLu, Residual, Softmax, BiLSTM, LSTM
 
 from .layers import add, bidirectional, chain, clone, concatenate, foreach, noop

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -104,7 +104,7 @@ class ConfigValidationError(ValueError):
         for error in errors:
             err_loc = " -> ".join([str(p) for p in error.get("loc", [])])
             # appending element at the end so it doesn't matter if it's empty
-            data.append((err_loc, error.get("msg", element)))
+            data.append((err_loc, error.get("msg"), element))
         result = [message, table(data), f"{config}"]
         ValueError.__init__(self, "\n\n" + "\n".join(result))
 

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -103,10 +103,8 @@ class ConfigValidationError(ValueError):
         data = []
         for error in errors:
             err_loc = " -> ".join([str(p) for p in error.get("loc", [])])
-            if element:
-                data.append((element, err_loc, error.get("msg")))
-            else:
-                data.append((err_loc, error.get("msg")))
+            # appending element at the end so it doesn't matter if it's empty
+            data.append((err_loc, error.get("msg", element)))
         result = [message, table(data), f"{config}"]
         ValueError.__init__(self, "\n\n" + "\n".join(result))
 

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -96,13 +96,14 @@ class ConfigValidationError(ValueError):
         self,
         config: Union[Config, Dict[str, Dict[str, Any]]],
         errors: List[Dict[str, Any]],
+        element: str,
         message: str = "Config validation error",
     ) -> None:
         """Custom error for validating configs."""
         data = []
         for error in errors:
             err_loc = " -> ".join([str(p) for p in error.get("loc", [])])
-            data.append((err_loc, error.get("msg")))
+            data.append((element, err_loc, error.get("msg")))
         result = [message, table(data), f"{config}"]
         ValueError.__init__(self, "\n\n" + "\n".join(result))
 
@@ -192,6 +193,7 @@ class registry(object):
         config: Union[Config, Dict[str, Dict[str, Any]]],
         schema: Type[BaseModel] = EmptySchema,
         validate: bool = True,
+        parent: str = "",
     ) -> Tuple[Config, Config]:
         """Build two representations of the config: one where the promises are
         preserved, and a second where the promises are represented by their
@@ -201,9 +203,10 @@ class registry(object):
         filled: Dict[str, Any] = {}
         validation: Dict[str, Any] = {}
         for key, value in config.items():
+            key_parent = str(parent + "." + key).strip(".")
             if cls.is_promise(value):
                 promise_schema = cls.make_promise_schema(value)
-                filled[key], _ = cls._fill(value, promise_schema, validate)
+                filled[key], _ = cls._fill(value, promise_schema, validate, parent=key_parent)
                 # Call the function and populate the field value. We can't just
                 # create an instance of the type here, since this wouldn't work
                 # for generics / more complex custom types
@@ -229,7 +232,7 @@ class registry(object):
                     if not isinstance(field.type_, ModelMetaclass):
                         # If we don't have a pydantic schema and just a type
                         field_type = EmptySchema
-                filled[key], validation[key] = cls._fill(value, field_type, validate)
+                filled[key], validation[key] = cls._fill(value, field_type, validate, parent=key_parent)
             else:
                 filled[key] = value
                 validation[key] = value
@@ -239,7 +242,7 @@ class registry(object):
             try:
                 result = schema.parse_obj(validation)
             except ValidationError as e:
-                raise ConfigValidationError(config, e.errors())
+                raise ConfigValidationError(config, e.errors(), element=parent)
         else:
             # Same as parse_obj, but without validation
             result = schema.construct(**validation)

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -96,8 +96,8 @@ class ConfigValidationError(ValueError):
         self,
         config: Union[Config, Dict[str, Dict[str, Any]]],
         errors: List[Dict[str, Any]],
-        element: str,
         message: str = "Config validation error",
+        element: str = "",
     ) -> None:
         """Custom error for validating configs."""
         data = []

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -103,7 +103,10 @@ class ConfigValidationError(ValueError):
         data = []
         for error in errors:
             err_loc = " -> ".join([str(p) for p in error.get("loc", [])])
-            data.append((element, err_loc, error.get("msg")))
+            if element:
+                data.append((element, err_loc, error.get("msg")))
+            else:
+                data.append((err_loc, error.get("msg")))
         result = [message, table(data), f"{config}"]
         ValueError.__init__(self, "\n\n" + "\n".join(result))
 
@@ -203,7 +206,7 @@ class registry(object):
         filled: Dict[str, Any] = {}
         validation: Dict[str, Any] = {}
         for key, value in config.items():
-            key_parent = str(parent + "." + key).strip(".")
+            key_parent = f"{parent}.{key}".strip(".")
             if cls.is_promise(value):
                 promise_schema = cls.make_promise_schema(value)
                 filled[key], _ = cls._fill(value, promise_schema, validate, parent=key_parent)

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -3,6 +3,7 @@ from .cauchysimilarity import CauchySimilarity
 from .dropout import Dropout
 from .embed import Embed
 from .extractwindow import ExtractWindow
+from .featureextractor import FeatureExtractor
 from .hashembed import HashEmbed
 from .layernorm import LayerNorm
 from .linear import Linear


### PR DESCRIPTION
When running a config file through validation, the current code would show a tabular format of errors from Pydantic, but without specifying where exactly in the config they came from:

```
Config validation error

args                 field required
kwargs               field required
depth                extra fields not permitted
embed_size           extra fields not permitted
maxout_pieces        extra fields not permitted
pretrained_vectors   extra fields not permitted
width                extra fields not permitted
window_size          extra fields not permitted
```

This PR changes that into: 

```
Config validation error

nlp.pipeline.tok2vec.model   args                 field required
nlp.pipeline.tok2vec.model   kwargs               field required
nlp.pipeline.tok2vec.model   depth                extra fields not permitted
nlp.pipeline.tok2vec.model   embed_size           extra fields not permitted
nlp.pipeline.tok2vec.model   maxout_pieces        extra fields not permitted
nlp.pipeline.tok2vec.model   pretrained_vectors   extra fields not permitted
nlp.pipeline.tok2vec.model   width                extra fields not permitted
nlp.pipeline.tok2vec.model   window_size          extra fields not permitted
```

By keeping track of the keys we're running through as we're parsing and validating the config.