### PR TITLE
Fix up config/registry API and get coverage to 100%

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ structured input and variable-length sequences.
 🔮 [Read the release notes here.](https://github.com/explosion/thinc/releases/)
 
 [![Azure Pipelines](https://img.shields.io/azure-devops/build/explosion-ai/public/7/master.svg?logo=azure-pipelines&style=flat-square)](https://dev.azure.com/explosion-ai/public/_build?definitionId=7)
-[![codecov](https://ig.shields.io/codecov/c/gh/explosion/thinc?logo=codecov&logoColor=white&style=flat-square)](https://codecov.io/gh/explosion/thinc)
+[![codecov](https://img.shields.io/codecov/c/gh/explosion/thinc?logo=codecov&logoColor=white&style=flat-square)](https://codecov.io/gh/explosion/thinc)
 [![Current Release Version](https://img.shields.io/github/release/explosion/thinc.svg?style=flat-square&logo=github)](https://github.com/explosion/thinc/releases)
 [![PyPi Version](https://img.shields.io/pypi/v/thinc.svg?style=flat-square&logo=pypi&logoColor=white)](https://pypi.python.org/pypi/thinc)
 [![conda Version](https://img.shields.io/conda/vn/conda-forge/thinc.svg?style=flat-square&logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/thinc)

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -315,7 +315,7 @@ class registry(object):
             default = param.default if param.default != param.empty else ...
             # Handle spread arguments and use their annotation as Sequence[whatever]
             if param.kind == param.VAR_POSITIONAL:
-                spread_annot = Sequence[annotation]
+                spread_annot = Sequence[annotation]  # type: ignore
                 sig_args[ARGS_FIELD_ALIAS] = (spread_annot, default)
             else:
                 sig_args[param.name] = (annotation, default)

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -315,7 +315,7 @@ class registry(object):
             default = param.default if param.default != param.empty else ...
             # Handle spread arguments and use their annotation as Sequence[whatever]
             if param.kind == param.VAR_POSITIONAL:
-                spread_annot = Sequence.copy_with(annotation)  # type: ignore
+                spread_annot = Sequence[annotation]
                 sig_args[ARGS_FIELD_ALIAS] = (spread_annot, default)
             else:
                 sig_args[param.name] = (annotation, default)

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, Any, Optional, List, Tuple, Callable, Type
+from typing import Union, Dict, Any, Optional, List, Tuple, Callable, Type, Sequence
 from types import GeneratorType
 from configparser import ConfigParser, ExtendedInterpolation
 from pathlib import Path
@@ -103,10 +103,15 @@ class ConfigValidationError(ValueError):
         data = []
         for error in errors:
             err_loc = " -> ".join([str(p) for p in error.get("loc", [])])
-            # appending element at the end so it doesn't matter if it's empty
-            data.append((err_loc, error.get("msg"), element))
+            if element:
+                err_loc = f"{element} -> {err_loc}"
+            data.append((err_loc, error.get("msg")))
         result = [message, table(data), f"{config}"]
         ValueError.__init__(self, "\n\n" + "\n".join(result))
+
+
+ARGS_FIELD = "___args___"
+ARGS_FIELD_ALIAS = "A_R_G_S"  # user is unlikely going to use this
 
 
 class EmptySchema(BaseModel):
@@ -118,6 +123,8 @@ class EmptySchema(BaseModel):
 class _PromiseSchemaConfig:
     extra = "forbid"
     arbitrary_types_allowed = True
+    # Underscore fields are not allowed in model, so use alias
+    alias_generator = lambda f: ARGS_FIELD if f == ARGS_FIELD_ALIAS else f
 
 
 class registry(object):
@@ -207,7 +214,9 @@ class registry(object):
             key_parent = f"{parent}.{key}".strip(".")
             if cls.is_promise(value):
                 promise_schema = cls.make_promise_schema(value)
-                filled[key], _ = cls._fill(value, promise_schema, validate, parent=key_parent)
+                filled[key], _ = cls._fill(
+                    value, promise_schema, validate, parent=key_parent
+                )
                 # Call the function and populate the field value. We can't just
                 # create an instance of the type here, since this wouldn't work
                 # for generics / more complex custom types
@@ -215,7 +224,7 @@ class registry(object):
                 args, kwargs = cls.parse_args(filled[key])
                 try:
                     validation[key] = getter(*args, **kwargs)
-                except TypeError as err:
+                except Exception as err:
                     err_msg = "Can't construct config: calling registry function failed"
                     raise ConfigValidationError(
                         {key: value}, [{"msg": err, "loc": [getter.__name__]}], err_msg
@@ -233,7 +242,9 @@ class registry(object):
                     if not isinstance(field.type_, ModelMetaclass):
                         # If we don't have a pydantic schema and just a type
                         field_type = EmptySchema
-                filled[key], validation[key] = cls._fill(value, field_type, validate, parent=key_parent)
+                filled[key], validation[key] = cls._fill(
+                    value, field_type, validate, parent=key_parent
+                )
             else:
                 filled[key] = value
                 validation[key] = value
@@ -247,7 +258,7 @@ class registry(object):
         else:
             # Same as parse_obj, but without validation
             result = schema.construct(**validation)
-        validation.update(result.dict())
+        validation.update(result.dict(exclude={ARGS_FIELD_ALIAS}))
         for key, value in validation.items():
             if key not in filled:
                 filled[key] = value
@@ -261,17 +272,16 @@ class registry(object):
         if not hasattr(obj, "keys"):
             return False
         id_keys = [k for k in obj.keys() if k.startswith("@")]
-        if len(id_keys) != 1:
-            return False
-        else:
+        if len(id_keys):
             return True
+        return False
 
     @classmethod
     def get_constructor(cls, obj: Dict[str, Any]) -> Callable:
         id_keys = [k for k in obj.keys() if k.startswith("@")]
         if len(id_keys) != 1:
-            err = f"A block can only contain one function registry reference. Got: {id_keys}"
-            raise ValueError(err)
+            err_msg = f"A block can only contain one function registry reference. Got: {id_keys}"
+            raise ConfigValidationError(obj, [{"msg": err_msg}])
         else:
             key = id_keys[0]
             value = obj[key]
@@ -283,11 +293,11 @@ class registry(object):
         kwargs = {}
         for key, value in obj.items():
             if not key.startswith("@"):
-                if isinstance(key, int) or key.isdigit():
-                    args.append((int(key), value))
+                if key == ARGS_FIELD:
+                    args = value
                 else:
                     kwargs[key] = value
-        return [value for key, value in sorted(args)], kwargs
+        return args, kwargs
 
     @classmethod
     def make_promise_schema(cls, obj: Dict[str, Any]) -> Type[BaseModel]:
@@ -299,19 +309,18 @@ class registry(object):
         id_keys = [k for k in obj.keys() if k.startswith("@")]
         sig_args: Dict[str, Any] = {id_keys[0]: (str, ...)}
         for param in inspect.signature(func).parameters.values():
+            # If no annotation is specified assume it's anything
             annotation = param.annotation if param.annotation != param.empty else Any
             # If no default value is specified assume that it's required
-            if param.default != param.empty:
-                sig_args[param.name] = (annotation, param.default)
+            default = param.default if param.default != param.empty else ...
+            # Handle spread arguments and use their annotation as Sequence[whatever]
+            if param.kind == param.VAR_POSITIONAL:
+                spread_annot = Sequence.copy_with(annotation)  # type: ignore
+                sig_args[ARGS_FIELD_ALIAS] = (spread_annot, default)
             else:
-                sig_args[param.name] = (annotation, ...)
+                sig_args[param.name] = (annotation, default)
         sig_args["__config__"] = _PromiseSchemaConfig
         return create_model("ArgModel", **sig_args)
-
-    @classmethod
-    def get_return_type(cls, obj: Dict[str, Any]):
-        func = cls.get_constructor(obj)
-        return inspect.signature(func).return_annotation
 
 
 __all__ = ["Config", "registry"]

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Iterable, Union, Sequence
+from typing import Iterable, Union, Sequence, Optional
 from pydantic import BaseModel, StrictBool, StrictFloat, PositiveInt, constr
 import catalogue
 import thinc.config
@@ -7,57 +7,8 @@ from thinc.config import ConfigValidationError
 from thinc.types import Generator
 from thinc.api import Config
 
+from .util import make_tempdir
 
-class my_registry(thinc.config.registry):
-    cats = catalogue.create("thinc", "tests", "cats", entry_points=False)
-
-
-class HelloIntsSchema(BaseModel):
-    hello: int
-    world: int
-
-    class Config:
-        extra = "forbid"
-
-
-class DefaultsSchema(BaseModel):
-    required: int
-    optional: str = "default value"
-
-    class Config:
-        extra = "forbid"
-
-
-class ComplexSchema(BaseModel):
-    outer_req: int
-    outer_opt: str = "default value"
-
-    level2_req: HelloIntsSchema
-    level2_opt: DefaultsSchema = DefaultsSchema(required=1)
-
-
-@my_registry.cats.register("catsie.v1")
-def catsie_v1(evil: StrictBool, cute: bool = True) -> str:
-    if evil:
-        return "scratch!"
-    else:
-        return "meow"
-
-
-@my_registry.cats.register("catsie.v2")
-def catsie_v2(evil: StrictBool, cute: bool = True, cute_level: int = 1) -> str:
-    if evil:
-        return "scratch!"
-    else:
-        if cute_level > 2:
-            return "meow <3"
-        return "meow"
-
-
-good_catsie = {"@cats": "catsie.v1", "evil": False, "cute": True}
-ok_catsie = {"@cats": "catsie.v1", "evil": False, "cute": False}
-bad_catsie = {"@cats": "catsie.v1", "evil": True, "cute": True}
-worst_catsie = {"@cats": "catsie.v1", "evil": True, "cute": False}
 
 EXAMPLE_CONFIG = """
 [DEFAULT]
@@ -128,6 +79,58 @@ total_steps = 100000
 """
 
 
+class my_registry(thinc.config.registry):
+    cats = catalogue.create("thinc", "tests", "cats", entry_points=False)
+
+
+class HelloIntsSchema(BaseModel):
+    hello: int
+    world: int
+
+    class Config:
+        extra = "forbid"
+
+
+class DefaultsSchema(BaseModel):
+    required: int
+    optional: str = "default value"
+
+    class Config:
+        extra = "forbid"
+
+
+class ComplexSchema(BaseModel):
+    outer_req: int
+    outer_opt: str = "default value"
+
+    level2_req: HelloIntsSchema
+    level2_opt: DefaultsSchema = DefaultsSchema(required=1)
+
+
+@my_registry.cats.register("catsie.v1")
+def catsie_v1(evil: StrictBool, cute: bool = True) -> str:
+    if evil:
+        return "scratch!"
+    else:
+        return "meow"
+
+
+@my_registry.cats.register("catsie.v2")
+def catsie_v2(evil: StrictBool, cute: bool = True, cute_level: int = 1) -> str:
+    if evil:
+        return "scratch!"
+    else:
+        if cute_level > 2:
+            return "meow <3"
+        return "meow"
+
+
+good_catsie = {"@cats": "catsie.v1", "evil": False, "cute": True}
+ok_catsie = {"@cats": "catsie.v1", "evil": False, "cute": False}
+bad_catsie = {"@cats": "catsie.v1", "evil": True, "cute": True}
+worst_catsie = {"@cats": "catsie.v1", "evil": True, "cute": False}
+
+
 def test_validate_simple_config():
     simple_config = {"hello": 1, "world": 2}
     f, v = my_registry._fill(simple_config, HelloIntsSchema)
@@ -172,6 +175,8 @@ def test_is_promise():
     assert my_registry.is_promise(good_catsie)
     assert not my_registry.is_promise({"hello": "world"})
     assert not my_registry.is_promise(1)
+    invalid = {"@complex": "complex.v1", "rate": 1.0, "@cats": "catsie.v1"}
+    assert my_registry.is_promise(invalid)
 
 
 def test_get_constructor():
@@ -225,6 +230,14 @@ def test_create_registry():
         my_registry.create("dogs")
 
 
+def test_registry_methods():
+    with pytest.raises(ValueError):
+        my_registry.get("dfkoofkds", "catsie.v1")
+    my_registry.cats.register("catsie.v123")(None)
+    with pytest.raises(ValueError):
+        my_registry.get("cats", "catsie.v123")
+
+
 def test_make_from_config_no_schema():
     config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
     result = my_registry.make_from_config(config)
@@ -276,6 +289,24 @@ def test_optimizer_config():
 def test_config_to_str():
     cfg = Config().from_str(OPTIMIZER_CFG)
     assert cfg.to_str().strip() == OPTIMIZER_CFG.strip()
+    cfg = Config({"optimizer": {"foo": "bar"}}).from_str(OPTIMIZER_CFG)
+    assert cfg.to_str().strip() == OPTIMIZER_CFG.strip()
+
+
+def test_config_roundtrip_bytes():
+    cfg = Config().from_str(OPTIMIZER_CFG)
+    cfg_bytes = cfg.to_bytes()
+    new_cfg = Config().from_bytes(cfg_bytes)
+    assert new_cfg.to_str().strip() == OPTIMIZER_CFG.strip()
+
+
+def test_config_roundtrip_disk():
+    cfg = Config().from_str(OPTIMIZER_CFG)
+    with make_tempdir() as path:
+        cfg_path = path / "config.cfg"
+        cfg.to_disk(cfg_path)
+        new_cfg = Config().from_disk(cfg_path)
+    assert new_cfg.to_str().strip() == OPTIMIZER_CFG.strip()
 
 
 def test_validation_custom_types():
@@ -302,6 +333,13 @@ def test_validation_custom_types():
     with pytest.raises(ConfigValidationError):
         # top-level object is promise
         my_registry.make_from_config(cfg)
+    with pytest.raises(ConfigValidationError):
+        # top-level object is promise
+        my_registry.fill_config(cfg)
+    cfg = {"@complex": "complex.v1", "rate": 1.0, "@cats": "catsie.v1"}
+    with pytest.raises(ConfigValidationError):
+        # two constructors
+        my_registry.make_from_config({"config": cfg})
 
 
 def test_validation_no_validate():
@@ -327,14 +365,43 @@ def test_validation_fill_defaults():
     assert result["two"]["cute_level"] == 1
 
 
+def test_make_config_positional_args():
+    @my_registry.cats("catsie.v567")
+    def catsie_567(*args: Optional[str], foo: str = "bar"):
+        assert args[0] == "^_^"
+        assert args[1] == "^(*.*)^"
+        assert foo == "baz"
+        return args[0]
+
+    args = ["^_^", "^(*.*)^"]
+    cfg = {"config": {"@cats": "catsie.v567", "foo": "baz", "___args___": args}}
+    filled_cfg = my_registry.make_from_config(cfg)
+    assert filled_cfg["config"] == "^_^"
+
+
+def test_make_config_positional_args_complex():
+    @my_registry.cats("catsie.v890")
+    def catsie_890(*args: Optional[Union[StrictBool, PositiveInt]]):
+        assert args[0] == 123
+        return args[0]
+
+    cfg = {"config": {"@cats": "catsie.v890", "___args___": [123, True, 1, False]}}
+    filled_cfg = my_registry.make_from_config(cfg)
+    assert filled_cfg["config"] == 123
+    cfg = {"config": {"@cats": "catsie.v890", "___args___": [123, "True"]}}
+    with pytest.raises(ConfigValidationError):
+        # "True" is not a valid boolean or positive int
+        my_registry.make_from_config(cfg)
+
+
 def test_validation_generators_iterable():
-    @thinc.registry.optimizers("test_optimizer.v1")
+    @my_registry.optimizers("test_optimizer.v1")
     def test_optimizer_v1(
         rate: float, schedule: Union[float, Sequence[float], Generator]
     ) -> None:
         return None
 
-    @thinc.registry.schedules("test_schedule.v1")
+    @my_registry.schedules("test_schedule.v1")
     def test_schedule_v1(some_value: float = 1.0) -> Iterable[float]:
         while True:
             yield some_value
@@ -352,9 +419,29 @@ def test_validation_generators_iterable():
 def test_validation_unset_type_hints():
     """Test that unset type hints are handled correctly (and treated as Any)."""
 
-    @thinc.registry.optimizers("test_optimizer.v2")
+    @my_registry.optimizers("test_optimizer.v2")
     def test_optimizer_v2(rate, steps: int = 10) -> None:
         return None
 
     config = {"test": {"@optimizers": "test_optimizer.v2", "rate": 0.1, "steps": 20}}
     my_registry.make_from_config(config)
+
+
+def test_validation_bad_function():
+    @my_registry.optimizers("bad.v1")
+    def bad() -> None:
+        raise ValueError("This is an error in the function")
+        return None
+
+    @my_registry.optimizers("good.v1")
+    def good() -> None:
+        return None
+
+    # Bad function
+    config = {"test": {"@optimizers": "bad.v1"}}
+    with pytest.raises(ConfigValidationError):
+        my_registry.make_from_config(config)
+    # Bad function call
+    config = {"test": {"@optimizers": "good.v1", "invalid_arg": 1}}
+    with pytest.raises(ConfigValidationError):
+        my_registry.make_from_config(config)

--- a/thinc/tests/util.py
+++ b/thinc/tests/util.py
@@ -1,4 +1,15 @@
+import contextlib
+from pathlib import Path
+import tempfile
+import shutil
 from thinc.layers import Linear
+
+
+@contextlib.contextmanager
+def make_tempdir():
+    d = Path(tempfile.mkdtemp())
+    yield d
+    shutil.rmtree(str(d))
 
 
 def get_model(W_b_input, cls=Linear):


### PR DESCRIPTION
- [x] remove unused code
- [x] make config validation error traceback nicer (add root element to location list)
- [x] handle all exceptions in function calls (not just `TypeError`s)
- [x] return `True` for `is_promise`, even if multiple `@` values are present (will raise an error afterwards anyways)
- [x] make sure all errors related to config are `ConfigValidationError`s
- [x] make syntax for positional (spread) arguments work via `__args__`:

```ini
[config]
@schedules = "my_cool_schedule.v1"
__args__ = [10, 16, 31]
final = 20
```

```python
@thinc.registry.schedules("my_cool_schedule.v1")
def my_cool_schedule(*steps: int, final: int = 10):
    yield from steps
    while True:
        yield final
```
- [x] get test coverage for module to 100% 🎉
