### PR TITLE
fix input type for concatenate to support "a | b"

### DIFF
--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -15,6 +15,7 @@ OutT = TypeVar("OutT")
 def chain(*layers: Model) -> Model[InT, OutT]:
     """Compose two models `f` and `g` such that they become layers of a single
     feed-forward model that computes `g(f(x))`.
+    Also supports chaining more than 2 layers.
     """
     if not layers:
         return cast(Model[InT, OutT], noop())
@@ -24,8 +25,8 @@ def chain(*layers: Model) -> Model[InT, OutT]:
         layers[0].layers.extend(layers[1:])
         return layers[0]
     # Set type constraints for layers
-    layer0: Model[InT, Any] = layers[0]  # noqa: F841
-    layer1: Model[Any, OutT] = layers[-1]  # noqa: F841
+    first_layer: Model[InT, Any] = layers[0]  # noqa: F841
+    last_layer: Model[Any, OutT] = layers[-1]  # noqa: F841
     model: Model[InT, OutT] = Model(
         ">>".join(layer.name for layer in layers),
         forward,

--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -11,7 +11,7 @@ OutT = TypeVar("OutT", bound=Floats2d)
 
 
 @registry.layers("concatenate.v0")
-def concatenate(layers: List[Model]) -> Model[InT, OutT]:
+def concatenate(*layers: Model) -> Model[InT, OutT]:
     """Compose two or more models `f`, `g`, etc, such that their outputs are
     concatenated, i.e. `concatenate(f, g)(x)` computes `hstack(f(x), g(x))`.
     """


### PR DESCRIPTION
Changed the signature for `concatenate()` to `*layers: Model` instead of using a `List`, to allow using the operator in cases like `prefix | suffix`. The current version gave the error 

> concatenate() takes 1 positional argument but 2 were given