### PR TITLE
WIP: Trouble with recursive objects in config

### DIFF
--- a/thinc/config.py
+++ b/thinc/config.py
@@ -214,14 +214,14 @@ class registry(object):
             key_parent = f"{parent}.{key}".strip(".")
             if cls.is_promise(value):
                 promise_schema = cls.make_promise_schema(value)
-                filled[key], _ = cls._fill(
+                filled[key], validation[key] = cls._fill(
                     value, promise_schema, validate, parent=key_parent
                 )
                 # Call the function and populate the field value. We can't just
                 # create an instance of the type here, since this wouldn't work
                 # for generics / more complex custom types
-                getter = cls.get_constructor(filled[key])
-                args, kwargs = cls.parse_args(filled[key])
+                getter = cls.get_constructor(validation[key])
+                args, kwargs = cls.parse_args(validation[key])
                 try:
                     validation[key] = getter(*args, **kwargs)
                 except Exception as err:

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1,11 +1,11 @@
 import pytest
-from typing import Iterable, Union, Sequence, Optional
+from typing import Iterable, Union, Sequence, Optional, List
 from pydantic import BaseModel, StrictBool, StrictFloat, PositiveInt, constr
 import catalogue
 import thinc.config
 from thinc.config import ConfigValidationError
 from thinc.types import Generator
-from thinc.api import Config
+from thinc.api import Config, registry, RAdam
 
 from .util import make_tempdir
 
@@ -21,8 +21,9 @@ use_averages = true
 
 [optimizer.learn_rate]
 @schedules = "warmup_linear.v1"
-start = 0.1
-steps = 10000
+initial_rate = 0.1
+warmup_steps = 10000
+total_steps = 100000
 
 [pipeline]
 
@@ -274,14 +275,16 @@ def test_make_from_config_schema():
 def test_read_config():
     byte_string = EXAMPLE_CONFIG.encode("utf8")
     cfg = Config().from_bytes(byte_string)
-    assert cfg["optimizer"]["learn_rate"]["start"] == 0.1
+
+    assert cfg["optimizer"]["beta1"] == 0.9
+    assert cfg["optimizer"]["learn_rate"]["initial_rate"] == 0.1
     assert cfg["pipeline"]["parser"]["factory"] == "parser"
     assert cfg["pipeline"]["parser"]["model"]["tok2vec"]["width"] == 128
 
 
 def test_optimizer_config():
     cfg = Config().from_str(OPTIMIZER_CFG)
-    result = my_registry.make_from_config(cfg)
+    result = my_registry.make_from_config(cfg, validate=True)
     optimizer = result["optimizer"]
     assert optimizer.b1 == 0.9
 
@@ -445,3 +448,33 @@ def test_validation_bad_function():
     config = {"test": {"@optimizers": "good.v1", "invalid_arg": 1}}
     with pytest.raises(ConfigValidationError):
         my_registry.make_from_config(config)
+
+
+TEST_CONFIG = """
+[optimizer]
+@optimizers = "my_cool_optimizer.v1"
+beta1 = 0.2
+
+[optimizer.learn_rate]
+@schedules = "my_cool_repetitive_schedule.v1"
+base_rate = 0.001
+repeat = 4
+"""
+
+
+@thinc.registry.optimizers.register("my_cool_optimizer.v1")
+def make_my_optimizer(learn_rate: List[float], beta1: float):
+    return RAdam(learn_rate, beta1=beta1)
+
+
+@thinc.registry.schedules("my_cool_repetitive_schedule.v1")
+def decaying(base_rate: float, repeat: int) -> List[float]:
+    return repeat * [base_rate]
+
+
+def test_objects_from_config():
+    config = Config().from_str(TEST_CONFIG)
+    loaded = registry.make_from_config(config)
+    optimizer = loaded["optimizer"]
+    assert optimizer.b1 == 0.2
+    assert optimizer.learn_rate == [0.001, 0.001, 0.001, 0.001]

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -462,17 +462,15 @@ repeat = 4
 """
 
 
-@thinc.registry.optimizers.register("my_cool_optimizer.v1")
-def make_my_optimizer(learn_rate: List[float], beta1: float):
-    return RAdam(learn_rate, beta1=beta1)
-
-
-@thinc.registry.schedules("my_cool_repetitive_schedule.v1")
-def decaying(base_rate: float, repeat: int) -> List[float]:
-    return repeat * [base_rate]
-
-
 def test_objects_from_config():
+    @thinc.registry.optimizers.register("my_cool_optimizer.v1")
+    def make_my_optimizer(learn_rate: List[float], beta1: float):
+        return RAdam(learn_rate, beta1=beta1)
+
+    @thinc.registry.schedules("my_cool_repetitive_schedule.v1")
+    def decaying(base_rate: float, repeat: int) -> List[float]:
+        return repeat * [base_rate]
+
     config = Config().from_str(TEST_CONFIG)
     loaded = registry.make_from_config(config)
     optimizer = loaded["optimizer"]


### PR DESCRIPTION
I'm pretty certain there's a bug in parsing recursive objects in thinc's `_fill` function on the current `develop` branch. I ran into it while testing from spaCy, so I tried creating a minimal example for testing here in `test_config.py`, avoiding generators and iterators etc for simplicity.

It looks like an object within an object is not returned properly. I tried debugging with this example. The `my_cool_repetitive_schedule.v1` creates the correct `learn_rate` object `[0.001, 0.001, 0.001, 0.001]` which is correctly [stored](https://github.com/explosion/thinc/blob/develop/thinc/config.py#L226) in `validation[key]`. But then when the recursive loop goes on to fill in `my_cool_optimizer.v1`, it doesn't have access to that object anymore, and fills in the original json `{'@schedules': 'my_cool_repetitive_schedule.v1', 'base_rate': 0.001, 'repeat': 4}` as `learn_rate` parameter instead.

You'll see this when the unit test crashes on `assert`. While the `optimizer` object is correct and has a proper field `b1` (from `beta1`), its `learn_rate` field is still a json string instead of the `List`.

I've been trying to fix this but no luck so far. @honnibal: could you have a look ?

PS: also fixed `EXAMPLE_CONFIG` which had some invalid arguments for `warmup_linear.v1`