### PR TITLE
Friendly debugging errors

### DIFF
--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -44,7 +44,12 @@ def init(
         X_width = get_width(X)
         model.set_dim("nI", X_width)
         for layer in model.layers:
-            layer.set_dim("nI", X_width)
+            if layer.has_dim("nI") in [True, None]:
+                layer.set_dim("nI", X_width)
+            elif layer.has_dim("nV") in [True, None]:
+                layer.set_dim("nV", X_width)
+            else:
+                raise ValueError(f"Cannot find appropriate input dimension for concatenating layer '{layer.name}'.")
     for layer in model.layers:
         layer.initialize(X=X)
     model.set_dim("nO", sum(layer.get_dim("nO") for layer in model.layers))

--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -44,12 +44,7 @@ def init(
         X_width = get_width(X)
         model.set_dim("nI", X_width)
         for layer in model.layers:
-            if layer.has_dim("nI") in [True, None]:
-                layer.set_dim("nI", X_width)
-            elif layer.has_dim("nV") in [True, None]:
-                layer.set_dim("nV", X_width)
-            else:
-                raise ValueError(f"Cannot find appropriate input dimension for concatenating layer '{layer.name}'.")
+            layer.set_dim("nI", X_width)
     for layer in model.layers:
         layer.initialize(X=X)
     model.set_dim("nO", sum(layer.get_dim("nO") for layer in model.layers))

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -24,7 +24,7 @@ def HashEmbed(
         forward,
         init=create_init(initializer),
         params={"vectors": None},
-        dims={"nO": nO, "nV": nV},
+        dims={"nO": nO, "nV": nV, "nI": None},
         attrs={"seed": seed, "column": column},
     )
     if seed is None:

--- a/thinc/layers/maxout.py
+++ b/thinc/layers/maxout.py
@@ -18,7 +18,7 @@ OutT = Floats2d
 def Maxout(
     nO: Optional[int] = None,
     nI: Optional[int] = None,
-    nP: int = 3,
+    nP: Optional[int] = 3,
     *,
     init_W: Callable = xavier_uniform_init,
     init_b: Callable = zero_init,

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -225,7 +225,10 @@ class Model(Generic[InT, OutT]):
             if key not in self._mem:
                 self._mem.add(key, value.shape)
             data = self._mem[(self.id, name)]
-            copy_array(dst=data, src=value)
+            try:
+                copy_array(dst=data, src=value)
+            except ValueError as e:
+                raise ValueError(f"Cannot set param '{name}' for model '{self.name}': {e}.")
             self._params[name] = True
 
     def inc_grad(self, name: str, value: Array) -> None:
@@ -269,7 +272,11 @@ class Model(Generic[InT, OutT]):
             self.inc_grad(name, value)
         else:
             data = self._mem[key]
-            copy_array(dst=data, src=value)
+            try:
+                copy_array(dst=data, src=value)
+            except ValueError as e:
+                raise ValueError(f"Cannot set grad '{grad_name}' for model '{self.name}': {e}.")
+
 
     def has_attr(self, name: str) -> bool:
         """Check whether the model has the given attribute."""

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -193,6 +193,9 @@ class Model(Generic[InT, OutT]):
         """Set a value for a dimension."""
         if name not in self._dims:
             raise KeyError(f"Cannot set dimension '{name}' for model '{self.name}'.")
+        old_value = self._dims[name]
+        if old_value is not None and old_value != value:
+            raise ValueError(f"Attempt to change dimension '{name}' for model '{self.name}' from {old_value} to {value}.")
         self._dims[name] = value
 
     def has_param(self, name: str) -> Optional[bool]:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -182,17 +182,17 @@ class Model(Generic[InT, OutT]):
     def get_dim(self, name: str) -> int:
         """Retrieve the value of a dimension of the given name."""
         if name not in self._dims:
-            raise KeyError(f"Can't get dimension '{name}'")
+            raise KeyError(f"Cannot get dimension '{name}' for model '{self.name}'.")
         value = self._dims[name]
         if value is None:
-            raise ValueError(f"Cannot get dimension '{name}': value unset.")
+            raise ValueError(f"Cannot get dimension '{name}' for model '{self.name}': value unset.")
         else:
             return value
 
     def set_dim(self, name: str, value: int) -> None:
         """Set a value for a dimension."""
         if name not in self._dims:
-            raise KeyError(f"Can't set dimension '{name}'")
+            raise KeyError(f"Cannot set dimension '{name}' for model '{self.name}'.")
         self._dims[name] = value
 
     def has_param(self, name: str) -> Optional[bool]:
@@ -210,10 +210,10 @@ class Model(Generic[InT, OutT]):
     def get_param(self, name: str) -> Array:
         """Retrieve a weights parameter by name."""
         if name not in self._params:
-            raise KeyError(f"Unknown param: {name}")
+            raise KeyError(f"Unknown param: '{name}' for model '{self.name}'.")
         key = (self.id, name)
         if key not in self._mem:
-            raise KeyError(f"Parameter '{name}' has not been allocated yet")
+            raise KeyError(f"Parameter '{name}' for model '{self.name}' has not been allocated yet.")
         return self._mem[key]
 
     def set_param(self, name: str, value: Optional[Array]) -> None:
@@ -258,7 +258,7 @@ class Model(Generic[InT, OutT]):
         grad_name = f"d_{name}"
         key = (self.id, grad_name)
         if key not in self._mem:
-            raise KeyError(f"Gradient '{grad_name}' has not been allocated yet")
+            raise KeyError(f"Gradient '{grad_name}' has not been allocated yet for model '{self.name}'.")
         return self._mem[key]
 
     def set_grad(self, name: str, value: Array) -> None:
@@ -278,7 +278,7 @@ class Model(Generic[InT, OutT]):
     def get_attr(self, name: str) -> Any:
         """Get the attribute. Raises KeyError if not present."""
         if name not in self._attrs:
-            raise KeyError(f"Can't get attribute '{name}'")
+            raise KeyError(f"Cannot get attribute '{name}' for model '{self.name}'.")
         return self._attrs[name]
 
     def set_attr(self, name: str, value: Any) -> None:
@@ -299,10 +299,10 @@ class Model(Generic[InT, OutT]):
     def get_ref(self, name: str) -> "Model":
         """Retrieve the value of a reference of the given name."""
         if name not in self._refs:
-            raise KeyError(f"Can't get reference '{name}'")
+            raise KeyError(f"Cannot get reference '{name} for model '{self.name}'.")
         value = self._refs[name]
         if value is None:
-            raise ValueError(f"Cannot get reference '{name}': value unset.")
+            raise ValueError(f"Cannot get reference '{name}' for model '{self.name}': value unset.")
         else:
             return value
 

--- a/thinc/tests/test_serialize.py
+++ b/thinc/tests/test_serialize.py
@@ -54,7 +54,7 @@ def test_multi_model_load_missing_dims():
     b += 2
     data = model.to_bytes()
 
-    model2 = chain(Maxout(5), Maxout())
+    model2 = chain(Maxout(5, nP=None), Maxout(nP=None))
     model2 = model2.from_bytes(data)
     assert model2.layers[0].get_param("b")[0, 0] == 1
     assert model2.layers[1].get_param("b")[0, 0] == 2


### PR DESCRIPTION
1. Model/layer names in error msg helps debugging
2. Ensure HashEmbed has a default `None` `nI` dimension
3. Throw an error when a none-`None` dimension is set to a different value (this shouldn't really happen, right ?)
