### PR TITLE
Add Decorator type to fix registry functions

### DIFF
--- a/thinc/config.py
+++ b/thinc/config.py
@@ -145,7 +145,9 @@ class registry(object):
         """Create a new custom registry."""
         if hasattr(cls, registry_name):
             raise ValueError(f"Registry '{registry_name}' already exists")
-        reg: Decorator = catalogue.create("thinc", registry_name, entry_points=entry_points)
+        reg: Decorator = catalogue.create(
+            "thinc", registry_name, entry_points=entry_points
+        )
         setattr(cls, registry_name, reg)
 
     @classmethod

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -1,5 +1,6 @@
 from typing import Union, Dict, Any, Optional, List, Tuple, Callable, Type, Sequence
 from types import GeneratorType
+from .types import Decorator
 from configparser import ConfigParser, ExtendedInterpolation
 from pathlib import Path
 from pydantic import BaseModel, create_model, ValidationError
@@ -135,16 +136,16 @@ class _PromiseSchemaConfig:
 
 
 class registry(object):
-    optimizers = catalogue.create("thinc", "optimizers", entry_points=True)
-    schedules = catalogue.create("thinc", "schedules", entry_points=True)
-    layers = catalogue.create("thinc", "layers", entry_points=True)
+    optimizers: Decorator = catalogue.create("thinc", "optimizers", entry_points=True)
+    schedules: Decorator = catalogue.create("thinc", "schedules", entry_points=True)
+    layers: Decorator = catalogue.create("thinc", "layers", entry_points=True)
 
     @classmethod
     def create(cls, registry_name: str, entry_points: bool = False) -> None:
         """Create a new custom registry."""
         if hasattr(cls, registry_name):
             raise ValueError(f"Registry '{registry_name}' already exists")
-        reg = catalogue.create("thinc", registry_name, entry_points=entry_points)
+        reg: Decorator = catalogue.create("thinc", registry_name, entry_points=entry_points)
         setattr(cls, registry_name, reg)
 
     @classmethod

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -570,8 +570,10 @@ class Doc(Sized, Container):
 
 InFunc = TypeVar("InFunc")
 
+
 class Decorator(Protocol):
     """Protocol to mark a function as returning its child with identical signature."""
+
     def __call__(self, name: str) -> Callable[[InFunc], InFunc]:
         ...
 

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Union, Tuple, Iterator, Sized, Container, Any, TypeVar, Generic
-from typing import Optional, List, Dict, Sequence, Iterable, Protocol
+from typing import Optional, List, Dict, Sequence, Iterable, Protocol, Callable
 import numpy
 import sys
 

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Union, Tuple, Iterator, Sized, Container, Any, TypeVar, Generic
-from typing import Optional, List, Dict, Sequence, Iterable
+from typing import Optional, List, Dict, Sequence, Iterable, Protocol
 import numpy
 import sys
 
@@ -565,6 +565,14 @@ class Doc(Sized, Container):
         ...
 
     def to_array(self, attr_ids: Union[str, int, List[Union[str, int]]]) -> Array:
+        ...
+
+
+InFunc = TypeVar("InFunc")
+
+class Decorator(Protocol):
+    """Protocol to mark a function as returning its child with identical signature."""
+    def __call__(self, name: str) -> Callable[[InFunc], InFunc]:
         ...
 
 

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass
 from typing import Union, Tuple, Iterator, Sized, Container, Any, TypeVar, Generic
-from typing import Optional, List, Dict, Sequence, Iterable, Protocol, Callable
+from typing import Optional, List, Dict, Sequence, Iterable, Callable
 import numpy
 import sys
 
 # Use typing_extensions for Python versions < 3.8
 if sys.version_info < (3, 8):
-    from typing_extensions import Literal
+    from typing_extensions import Literal, Protocol
 else:
-    from typing import Literal
+    from typing import Literal, Protocol
 
 try:
     import cupy

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -517,15 +517,9 @@ class IntsNd(Array):
 
 
 # Union of all int/float array types
-ArrayTypesInt = Union[
-    Ints1d, Ints2d, Ints3d, Ints4d, IntsNd,
-]
-ArrayTypesFloat = Union[
-    Floats1d, Floats2d, Floats3d, Floats4d, FloatsNd,
-]
-ArrayTypes = Union[
-    ArrayTypesFloat, ArrayTypesInt,
-]
+ArrayTypesInt = Union[Ints1d, Ints2d, Ints3d, Ints4d, IntsNd]
+ArrayTypesFloat = Union[Floats1d, Floats2d, Floats3d, Floats4d, FloatsNd]
+ArrayTypes = Union[ArrayTypesFloat, ArrayTypesInt]
 Array1d = Union[Ints1d, Floats1d]
 Array2d = Union[Ints2d, Floats2d]
 Array3d = Union[Ints3d, Floats3d]


### PR DESCRIPTION
Registered functions were becoming type-opaque, because of the registry decorator. Even after adding type annotations in catalogue, there were still problems getting it to work properly, because we assign the decorator to a class variable, which makes things that much more opaque to mypy.

I tried a few approaches, but it's complicated having an interaction between the type variable and the class. I don't really know what's going on but it complained of some sort of ambiguity.

My solution is to use a "protocol" to define a new type, `Decorator`. We can then declare the variable to be of that type when we assign it. This works! I even got a type error in my transformers script.

There's still some tricks to be solved with the `chain` operator. Not sure what's up but I don't always get type errors from incorrect combinations.