### PR TITLE
Improve type-checking for chain

### DIFF
--- a/examples/howto/type_chain.py
+++ b/examples/howto/type_chain.py
@@ -1,0 +1,19 @@
+from thinc.api import chain, ReLu, MaxPool, Softmax, chain
+
+# This example should be run with mypy. This is an example of type-level checking 
+# for network validity.
+#
+# We first define an invalid network.
+# It's invalid because MaxPool expects Floats3d as input, while ReLu produces
+# Floats2d as output. chain has type-logic to verify input and output types
+# line up.
+#
+# You should see the error an error,
+# examples/howto/type_chain.py:10: error: Cannot infer type argument 2 of "chain"
+bad_model = chain(ReLu(10), MaxPool(), Softmax())
+
+# Now let's try it with a network that does work, just to be sure.
+good_model = chain(ReLu(10), ReLu(10), Softmax())
+
+# Finally we can reveal_type on the good model, to see what it thinks.
+reveal_type(good_model)

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -1,4 +1,6 @@
 # Weights layers
+
+
 from .cauchysimilarity import CauchySimilarity
 from .dropout import Dropout
 from .embed import Embed

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -13,11 +13,12 @@ Mid2T = TypeVar("Mid2T")
 # This implementation is named 'chains' because we have a type-shennanigans
 # function 'chain' below.
 @registry.layers("chain.v0")
-def chains(layer1: Model[InT, Mid1T], *layers: Model) -> Model[InT, Any]:
+def chains(layer1: Model[InT, Mid1T], layer2: Model[Mid1T, Any], *layers: Model) -> Model[InT, Any]:
     """Compose two models `f` and `g` such that they become layers of a single
     feed-forward model that computes `g(f(x))`.
     Also supports chaining more than 2 layers.
     """
+    layers = (layer1, layer2) + layers
     if layers[0]._func is forward:
         layers[0].layers.extend(layers[1:])
         return layers[0]
@@ -28,7 +29,7 @@ def chains(layer1: Model[InT, Mid1T], *layers: Model) -> Model[InT, Any]:
         dims={"nO": None, "nI": None},
         layers=layers,
     )
-    if layers and layers[0].has_dim("nI") and layers[-1].has_dim("nO"):
+    if layers[0].has_dim("nI") and layers[-1].has_dim("nO"):
         model.initialize()
     return model
 
@@ -113,18 +114,18 @@ def chain(
     *etc: Model
 ) -> Model[InT, Any]:
     if l3 is None:
-        return chains(l1, l2)
+        return chain(l1, l2)
     elif l4 is None:
-        return chains(l1, l2, l3)
+        return chain(l1, l2, l3)
     elif l5 is None:
-        return chains(l1, l2, l3, l4)
+        return chain(l1, l2, l3, l4)
     elif l6 is None:
-        return chains(l1, l2, l3, l4, l5)
+        return chain(l1, l2, l3, l4, l5)
     elif l7 is None:
-        return chains(l1, l2, l3, l4, l5, l6)
+        return chain(l1, l2, l3, l4, l5, l6)
     elif l8 is None:
-        return chains(l1, l2, l3, l4, l5, l6, l7)
+        return chain(l1, l2, l3, l4, l5, l6, l7)
     elif l9 is None:
-        return chains(l1, l2, l3, l4, l5, l6, l7, l8)
+        return chain(l1, l2, l3, l4, l5, l6, l7, l8)
     else:
-        return chains(l1, l2, l3, l4, l5, l6, l7, l8, *etc)
+        return chain(l1, l2, l3, l4, l5, l6, l7, l8, l9, *etc)

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -1,12 +1,14 @@
-from typing import Tuple, Callable, Optional, TypeVar, Any, Protocol, cast, overload
-from typing import Union
+from typing import Tuple, Callable, Optional, TypeVar, Any, cast
 
 from ..model import Model
 from ..config import registry
 from ..util import get_width
 from ..types import Ragged, Padded, Array
-from .noop import noop
 
+InT = TypeVar("InT")
+OutT = TypeVar("OutT")
+Mid1T = TypeVar("Mid1T")
+Mid2T = TypeVar("Mid2T")
 
 # This implementation is named 'chains' because we have a type-shennanigans
 # function 'chain' below.
@@ -91,6 +93,7 @@ def init(model: Model, X: Optional[InT] = None, Y: Optional[OutT] = None) -> Non
 # get read by mypy. Hence the trickery below.
 
 InT = TypeVar("InT")
+OutT = TypeVar("OutT")
 Mid1T = TypeVar("Mid1T")
 Mid2T = TypeVar("Mid2T")
 Mid3T = TypeVar("Mid3T")
@@ -100,7 +103,6 @@ Mid6T = TypeVar("Mid6T")
 Mid7T = TypeVar("Mid7T")
 Mid8T = TypeVar("Mid8T")
 Mid9T = TypeVar("Mid9T")
-OutT = TypeVar("OutT")
 
 
 def chain(

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -10,9 +10,17 @@ OutT = TypeVar("OutT")
 Mid1T = TypeVar("Mid1T")
 Mid2T = TypeVar("Mid2T")
 
+# TODO: Unhack this when we can
+# We currently have an issue with Pydantic when arguments have generic types.
+# https://github.com/samuelcolvin/pydantic/issues/1158
+# For now we work around the issue by applying the decorator to this blander
+# version of the function.
+@registry.layers("chain.v0")
+def chain_no_types(*layer: Model) -> Model:
+    return chains(*layer)
+
 # This implementation is named 'chains' because we have a type-shennanigans
 # function 'chain' below.
-@registry.layers("chain.v0")
 def chains(layer1: Model[InT, Mid1T], layer2: Model[Mid1T, Any], *layers: Model) -> Model[InT, Any]:
     """Compose two models `f` and `g` such that they become layers of a single
     feed-forward model that computes `g(f(x))`.
@@ -101,6 +109,7 @@ Mid7T = TypeVar("Mid7T")
 Mid8T = TypeVar("Mid8T")
 Mid9T = TypeVar("Mid9T")
 
+
 def chain(
     l1: Model[InT, Mid1T],
     l2: Model[Mid1T, Mid2T],
@@ -114,18 +123,18 @@ def chain(
     *etc: Model
 ) -> Model[InT, Any]:
     if l3 is None:
-        return chain(l1, l2)
+        return chains(l1, l2)
     elif l4 is None:
-        return chain(l1, l2, l3)
+        return chains(l1, l2, l3)
     elif l5 is None:
-        return chain(l1, l2, l3, l4)
+        return chains(l1, l2, l3, l4)
     elif l6 is None:
-        return chain(l1, l2, l3, l4, l5)
+        return chains(l1, l2, l3, l4, l5)
     elif l7 is None:
-        return chain(l1, l2, l3, l4, l5, l6)
+        return chains(l1, l2, l3, l4, l5, l6)
     elif l8 is None:
-        return chain(l1, l2, l3, l4, l5, l6, l7)
+        return chains(l1, l2, l3, l4, l5, l6, l7)
     elif l9 is None:
-        return chain(l1, l2, l3, l4, l5, l6, l7, l8)
+        return chains(l1, l2, l3, l4, l5, l6, l7, l8)
     else:
-        return chain(l1, l2, l3, l4, l5, l6, l7, l8, l9, *etc)
+        return chains(l1, l2, l3, l4, l5, l6, l7, l8, l9, *etc)

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -1,4 +1,5 @@
-from typing import Tuple, Callable, Optional, TypeVar, Any, cast
+from typing import Tuple, Callable, Optional, TypeVar, Any, Protocol, cast, overload
+from typing import Union
 
 from ..model import Model
 from ..config import registry
@@ -7,27 +8,18 @@ from ..types import Ragged, Padded, Array
 from .noop import noop
 
 
-InT = TypeVar("InT")
-OutT = TypeVar("OutT")
-
-
+# This implementation is named 'chains' because we have a type-shennanigans
+# function 'chain' below.
 @registry.layers("chain.v0")
-def chain(*layers: Model) -> Model[InT, OutT]:
+def chains(layer1: Model[InT, Mid1T], *layers: Model) -> Model[InT, Any]:
     """Compose two models `f` and `g` such that they become layers of a single
     feed-forward model that computes `g(f(x))`.
     Also supports chaining more than 2 layers.
     """
-    if not layers:
-        return cast(Model[InT, OutT], noop())
-    elif len(layers) == 1:
-        return layers[0]
-    elif layers[0]._func is forward:
+    if layers[0]._func is forward:
         layers[0].layers.extend(layers[1:])
         return layers[0]
-    # Set type constraints for layers
-    first_layer: Model[InT, Any] = layers[0]  # noqa: F841
-    last_layer: Model[Any, OutT] = layers[-1]  # noqa: F841
-    model: Model[InT, OutT] = Model(
+    model: Model[InT, Any] = Model(
         ">>".join(layer.name for layer in layers),
         forward,
         init=init,
@@ -90,3 +82,51 @@ def init(model: Model, X: Optional[InT] = None, Y: Optional[OutT] = None) -> Non
         model.set_dim("nI", model.layers[0].get_dim("nI"))
     if model.layers[-1].has_dim("nO"):
         model.set_dim("nO", model.layers[-1].get_dim("nO"))
+
+
+# Unfortunately mypy doesn't support type-level checking on the cardinality
+# of variadic arguments: in other words, if you have an *args, you can't have
+# a type-checked condition on len(args). But we *can* get sneaky:
+# you can have a type-checked condition on *optional* args, and these *will*
+# get read by mypy. Hence the trickery below.
+
+InT = TypeVar("InT")
+Mid1T = TypeVar("Mid1T")
+Mid2T = TypeVar("Mid2T")
+Mid3T = TypeVar("Mid3T")
+Mid4T = TypeVar("Mid4T")
+Mid5T = TypeVar("Mid5T")
+Mid6T = TypeVar("Mid6T")
+Mid7T = TypeVar("Mid7T")
+Mid8T = TypeVar("Mid8T")
+Mid9T = TypeVar("Mid9T")
+OutT = TypeVar("OutT")
+
+def chain(
+    l1: Model[InT, Mid1T],
+    l2: Model[Mid1T, Mid2T],
+    l3: Optional[Model[Mid2T, Mid3T]]=None,
+    l4: Optional[Model[Mid3T, Mid4T]]=None,
+    l5: Optional[Model[Mid4T, Mid5T]]=None,
+    l6: Optional[Model[Mid5T, Mid6T]]=None,
+    l7: Optional[Model[Mid6T, Mid7T]]=None,
+    l8: Optional[Model[Mid7T, Mid8T]]=None,
+    l9: Optional[Model[Mid8T, Mid9T]]=None,
+    *etc: Model
+) -> Model:
+    if l3 is None:
+        return cast(Model[InT, Mid2T], chains(l1, l2))
+    elif l4 is None:
+        return cast(Model[InT, Mid3T], chains(l1, l2, l3))
+    elif l5 is None:
+        return cast(Model[InT, Mid4T], chains(l1, l2, l3, l4))
+    elif l6 is None:
+        return cast(Model[InT, Mid5T], chains(l1, l2, l3, l4, l5))
+    elif l7 is None:
+        return cast(Model[InT, Mid6T], chains(l1, l2, l3, l4, l5, l6))
+    elif l8 is None:
+        return cast(Model[InT, Mid7T], chains(l1, l2, l3, l4, l5, l6, l7))
+    elif l9 is None:
+        return cast(Model[InT, Mid8T], chains(l1, l2, l3, l4, l5, l6, l7, l8))
+    else:
+        return cast(Model[InT, Mid9T], chains(l1, l2, l3, l4, l5, l6, l7, l8, *etc))

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional, TypeVar, Any, cast
+from typing import Tuple, Callable, Optional, TypeVar, Any, cast, Union
 
 from ..model import Model
 from ..config import registry
@@ -92,10 +92,6 @@ def init(model: Model, X: Optional[InT] = None, Y: Optional[OutT] = None) -> Non
 # you can have a type-checked condition on *optional* args, and these *will*
 # get read by mypy. Hence the trickery below.
 
-InT = TypeVar("InT")
-OutT = TypeVar("OutT")
-Mid1T = TypeVar("Mid1T")
-Mid2T = TypeVar("Mid2T")
 Mid3T = TypeVar("Mid3T")
 Mid4T = TypeVar("Mid4T")
 Mid5T = TypeVar("Mid5T")
@@ -103,7 +99,6 @@ Mid6T = TypeVar("Mid6T")
 Mid7T = TypeVar("Mid7T")
 Mid8T = TypeVar("Mid8T")
 Mid9T = TypeVar("Mid9T")
-
 
 def chain(
     l1: Model[InT, Mid1T],
@@ -116,20 +111,20 @@ def chain(
     l8: Optional[Model[Mid7T, Mid8T]] = None,
     l9: Optional[Model[Mid8T, Mid9T]] = None,
     *etc: Model
-) -> Model:
+) -> Model[InT, Any]:
     if l3 is None:
-        return cast(Model[InT, Mid2T], chains(l1, l2))
+        return chains(l1, l2)
     elif l4 is None:
-        return cast(Model[InT, Mid3T], chains(l1, l2, l3))
+        return chains(l1, l2, l3)
     elif l5 is None:
-        return cast(Model[InT, Mid4T], chains(l1, l2, l3, l4))
+        return chains(l1, l2, l3, l4)
     elif l6 is None:
-        return cast(Model[InT, Mid5T], chains(l1, l2, l3, l4, l5))
+        return chains(l1, l2, l3, l4, l5)
     elif l7 is None:
-        return cast(Model[InT, Mid6T], chains(l1, l2, l3, l4, l5, l6))
+        return chains(l1, l2, l3, l4, l5, l6)
     elif l8 is None:
-        return cast(Model[InT, Mid7T], chains(l1, l2, l3, l4, l5, l6, l7))
+        return chains(l1, l2, l3, l4, l5, l6, l7)
     elif l9 is None:
-        return cast(Model[InT, Mid8T], chains(l1, l2, l3, l4, l5, l6, l7, l8))
+        return chains(l1, l2, l3, l4, l5, l6, l7, l8)
     else:
-        return cast(Model[InT, Mid9T], chains(l1, l2, l3, l4, l5, l6, l7, l8, *etc))
+        return chains(l1, l2, l3, l4, l5, l6, l7, l8, *etc)

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -102,16 +102,17 @@ Mid8T = TypeVar("Mid8T")
 Mid9T = TypeVar("Mid9T")
 OutT = TypeVar("OutT")
 
+
 def chain(
     l1: Model[InT, Mid1T],
     l2: Model[Mid1T, Mid2T],
-    l3: Optional[Model[Mid2T, Mid3T]]=None,
-    l4: Optional[Model[Mid3T, Mid4T]]=None,
-    l5: Optional[Model[Mid4T, Mid5T]]=None,
-    l6: Optional[Model[Mid5T, Mid6T]]=None,
-    l7: Optional[Model[Mid6T, Mid7T]]=None,
-    l8: Optional[Model[Mid7T, Mid8T]]=None,
-    l9: Optional[Model[Mid8T, Mid9T]]=None,
+    l3: Optional[Model[Mid2T, Mid3T]] = None,
+    l4: Optional[Model[Mid3T, Mid4T]] = None,
+    l5: Optional[Model[Mid4T, Mid5T]] = None,
+    l6: Optional[Model[Mid5T, Mid6T]] = None,
+    l7: Optional[Model[Mid6T, Mid7T]] = None,
+    l8: Optional[Model[Mid7T, Mid8T]] = None,
+    l9: Optional[Model[Mid8T, Mid9T]] = None,
     *etc: Model
 ) -> Model:
     if l3 is None:

--- a/thinc/layers/clone.py
+++ b/thinc/layers/clone.py
@@ -17,6 +17,8 @@ def clone(orig: Model[InT, OutT], n: int) -> Model[InT, OutT]:
     """
     if n == 0:
         return cast(Model[InT, OutT], noop())
+    elif n == 1:
+        return orig
     layers: List[Model] = [orig]
     for i in range(n - 1):
         layers.append(orig.copy())

--- a/thinc/layers/clone.py
+++ b/thinc/layers/clone.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, cast
+from typing import TypeVar, cast, List
 
 from .noop import noop
 from .chain import chain
@@ -17,7 +17,7 @@ def clone(orig: Model[InT, OutT], n: int) -> Model[InT, OutT]:
     """
     if n == 0:
         return cast(Model[InT, OutT], noop())
-    layers = [orig]
+    layers: List[Model] = [orig]
     for i in range(n - 1):
         layers.append(orig.copy())
-    return chain(*layers)
+    return cast(Model[InT, OutT], chain(*layers))

--- a/thinc/layers/dropout.py
+++ b/thinc/layers/dropout.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, List, Union, TypeVar, cast
+from typing import Tuple, Callable, List, TypeVar
 
 from ..model import Model
 from ..config import registry

--- a/thinc/layers/dropout.py
+++ b/thinc/layers/dropout.py
@@ -29,7 +29,7 @@ def forward(model: Model, X, is_train: bool) -> Tuple:
     if rate == 0 or not is_enabled:
         return X, lambda dY: dY
     elif isinstance(X, Ragged):
-        return _dropout_ragged(model, X, is_train) 
+        return _dropout_ragged(model, X, is_train)
     elif isinstance(X, Padded):
         return _dropout_padded(model, X, is_train)
     elif isinstance(X, list):
@@ -38,7 +38,9 @@ def forward(model: Model, X, is_train: bool) -> Tuple:
         return _dropout_array(model, X, is_train)
 
 
-def _dropout_array(model: Model[ArrayT, ArrayT], X: ArrayT, is_train: bool) -> Tuple[ArrayT, Callable]:
+def _dropout_array(
+    model: Model[ArrayT, ArrayT], X: ArrayT, is_train: bool
+) -> Tuple[ArrayT, Callable]:
     rate = model.get_attr("rate")
     mask = model.ops.get_dropout_mask(X.shape, rate)
 

--- a/thinc/layers/maxout.py
+++ b/thinc/layers/maxout.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional, Dict
+from typing import Tuple, Callable, Optional, Dict, cast
 
 from ..model import Model
 from ..config import registry
@@ -35,7 +35,7 @@ def Maxout(
     if normalize:
         model = chain(model, LayerNorm())
     if dropout is not None:
-        model = chain(model, Dropout(dropout))
+        model = chain(model, cast(Model[InT, OutT], Dropout(dropout)))
     if nO is not None and nI is not None:
         model.initialize()
     return model

--- a/thinc/layers/mish.py
+++ b/thinc/layers/mish.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional
+from typing import Tuple, Callable, Optional, cast
 
 from ..model import Model, create_init
 from ..initializers import xavier_uniform_init, zero_init
@@ -34,9 +34,9 @@ def Mish(
         params={"W": None, "b": None},
     )
     if normalize is not None:
-        model = chain(model, LayerNorm())
+        model = chain(model, cast(Model[InT, OutT], LayerNorm()))
     if dropout is not None:
-        model = chain(model, Dropout(dropout))
+        model = chain(model, cast(Model[InT, OutT], Dropout(dropout)))
     if nO is not None and nI is not None:
         model.initialize()
     return model

--- a/thinc/layers/pytorchwrapper.py
+++ b/thinc/layers/pytorchwrapper.py
@@ -71,7 +71,9 @@ def forward(model: Model, X: InT, is_train: bool) -> Tuple[OutT, Callable]:
 # Default conversion functions
 
 
-def _convert_inputs(model: Model, X: Any, is_train: bool) -> Tuple[ArgsKwargs, Callable[[ArgsKwargs], Any]]:
+def _convert_inputs(
+    model: Model, X: Any, is_train: bool
+) -> Tuple[ArgsKwargs, Callable[[ArgsKwargs], Any]]:
     xp2torch_ = lambda x: xp2torch(x, requires_grad=is_train)
     converted = convert_recursive(is_xp_array, xp2torch_, X)
     if isinstance(converted, ArgsKwargs):

--- a/thinc/layers/relu.py
+++ b/thinc/layers/relu.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional
+from typing import Tuple, Callable, Optional, cast
 
 from ..model import Model, create_init
 from ..initializers import xavier_uniform_init, zero_init
@@ -22,7 +22,7 @@ def ReLu(
     init_b: Callable = zero_init,
     dropout: Optional[float] = None,
     normalize: bool = False,
-) -> Model:
+) -> Model[InT, OutT]:
     model: Model[InT, OutT] = Model(
         "relu",
         forward,
@@ -33,7 +33,7 @@ def ReLu(
     if normalize:
         model = chain(model, LayerNorm())
     if dropout is not None:
-        model = chain(model, Dropout(dropout))
+        model = chain(model, cast(Model[Floats2d, Floats2d], Dropout(dropout)))
     if nO is not None and nI is not None:
         model.initialize()
     return model

--- a/thinc/layers/softmax.py
+++ b/thinc/layers/softmax.py
@@ -17,7 +17,7 @@ def Softmax(
     *,
     init_W: Callable = zero_init,
     init_b: Callable = zero_init
-) -> Model:
+) -> Model[InT, OutT]:
     model: Model[InT, OutT] = Model(
         "softmax",
         forward,

--- a/thinc/tests/layers/test_combinators.py
+++ b/thinc/tests/layers/test_combinators.py
@@ -39,13 +39,13 @@ def model3(nO):
 
 
 def test_chain_zero():
-    model = chain()
-    assert isinstance(model, Model)
+    with pytest.raises(TypeError):
+        model = chain()
 
 
 def test_chain_one(model1):
-    model = chain(model1)
-    assert isinstance(model, Model)
+    with pytest.raises(TypeError):
+        model = chain(model1)
 
 
 def test_chain_two(model1, model2):


### PR DESCRIPTION
Getting the `chain` operator to validate well is pretty tough. It seems mypy doesn't really support variable args: I can't get it to branch the type-logic on `len(args)`. Here's a hack that works in the meantime -- hopefully a new version of mypy will add support for what we need.

Instead of conditioning on the length of the variable, we can define a bunch of optionals, and condition on *those*. I've added support for up to 10, with the remaining backing off.

This gives a (pretty cryptic) type error on a broken model. The return type still isn't right though.

I think the right response here is "thanks I hate it". But at least we'll be able to make this work? Hopefully we can engage with mypy and get a better solution.