### PR TITLE
Fixing chain ini and maxout backprop

### DIFF
--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -84,7 +84,8 @@ def init(model: Model, X: Optional[InT] = None, Y: Optional[OutT] = None) -> Non
             break
     for layer in model.layers[:-1]:
         layer.initialize(X=X)
-        X = layer.predict(X)
+        if X is not None:
+            X = layer.predict(X)
     model.layers[-1].initialize(X=X, Y=Y)
     if model.layers[0].has_dim("nI"):
         model.set_dim("nI", model.layers[0].get_dim("nI"))

--- a/thinc/layers/maxout.py
+++ b/thinc/layers/maxout.py
@@ -57,7 +57,7 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
         dY = model.ops.backprop_maxout(d_best, which, nP)
         dY = dY.reshape((dY.shape[0], nO * nP))
         model.inc_grad("W", model.ops.gemm(dY, X, trans1=True).reshape((nO, nP, nI)))
-        model.inc_grad("b", dY.sum(axis=0))
+        model.inc_grad("b", dY.sum(axis=0).reshape((nO, nP)))
         return model.ops.gemm(dY, W.reshape((nO * nP, nI)))
 
     return best, backprop

--- a/thinc/layers/maxout.py
+++ b/thinc/layers/maxout.py
@@ -55,9 +55,9 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
 
     def backprop(d_best: OutT) -> InT:
         dY = model.ops.backprop_maxout(d_best, which, nP)
+        model.inc_grad("b", dY.sum(axis=0))
         dY = dY.reshape((dY.shape[0], nO * nP))
         model.inc_grad("W", model.ops.gemm(dY, X, trans1=True).reshape((nO, nP, nI)))
-        model.inc_grad("b", dY.sum(axis=0).reshape((nO, nP)))
         return model.ops.gemm(dY, W.reshape((nO * nP, nI)))
 
     return best, backprop

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -249,7 +249,12 @@ class Model(Generic[InT, OutT]):
             grad = self._mem[key]
         else:
             grad = self._mem.add_gradient(key, param_key)
-        grad += value
+        try:
+            grad += value
+        except ValueError as e:
+            raise ValueError(
+                f"Cannot add a value to the gradient of parameter '{name}' for model '{self.name}': {e}."
+            )
         self._grads[grad_name] = True
 
     def has_grad(self, name: str) -> Optional[bool]:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -249,12 +249,15 @@ class Model(Generic[InT, OutT]):
             grad = self._mem[key]
         else:
             grad = self._mem.add_gradient(key, param_key)
-        try:
-            grad += value
-        except ValueError as e:
+
+        if grad.shape != value.shape:
             raise ValueError(
-                f"Cannot add a value to the gradient of parameter '{name}' for model '{self.name}': {e}."
+                f"Cannot add a value to the gradient of parameter '{name}' for model '{self.name}' "
+                f"as the shapes should match, but found {grad.shape} for the original gradient, and "
+                f"{value.shape} for the value that should be added."
             )
+
+        grad += value
         self._grads[grad_name] = True
 
     def has_grad(self, name: str) -> Optional[bool]:


### PR DESCRIPTION
- The initialization of `chain` would throw an error if the underlying layer didn't not properly handle `predict(None)`, so preventing that here for robustness.
- `maxout` had a bug in its backprop function: the value to increment `b` needs to be reshaped to `(nO, nP)` (right?)
- Raising an informative error when these sort of wrong shapes occur in `inc_grad` 