### PR TITLE
Add partial registry functions for losses and initializers

### DIFF
--- a/thinc/config.py
+++ b/thinc/config.py
@@ -136,9 +136,13 @@ class _PromiseSchemaConfig:
 
 
 class registry(object):
+    # fmt: off
     optimizers: Decorator = catalogue.create("thinc", "optimizers", entry_points=True)
     schedules: Decorator = catalogue.create("thinc", "schedules", entry_points=True)
     layers: Decorator = catalogue.create("thinc", "layers", entry_points=True)
+    losses: Decorator = catalogue.create("thinc", "losses", entry_points=True)
+    initializers: Decorator = catalogue.create("thinc", "initializers", entry_points=True)
+    # fmt: on
 
     @classmethod
     def create(cls, registry_name: str, entry_points: bool = False) -> None:

--- a/thinc/initializers.py
+++ b/thinc/initializers.py
@@ -1,5 +1,8 @@
+from typing import Callable
+
+from .config import registry
 from .types import Array
-from .util import get_array_module, copy_array
+from .util import get_array_module, copy_array, partial
 
 
 def xavier_uniform_init(data: Array, *, inplace: bool = False) -> Array:
@@ -12,6 +15,11 @@ def xavier_uniform_init(data: Array, *, inplace: bool = False) -> Array:
         return xp.random.uniform(-scale, scale, data.shape)
 
 
+@registry.initializers("xavier_uniform_init.v0")
+def configure_xavier_uniform_init(*, inplace: bool = False) -> Callable[[Array], Array]:
+    return partial(xavier_uniform_init, inplace=inplace)
+
+
 def zero_init(data: Array, *, inplace: bool = False) -> Array:
     if inplace:
         data.fill(0.0)
@@ -21,8 +29,13 @@ def zero_init(data: Array, *, inplace: bool = False) -> Array:
         return xp.zeros_like(data)
 
 
+@registry.initializers("zero_init.v0")
+def configure_zero_init(*, inplace: bool = False) -> Callable[[Array], Array]:
+    return partial(zero_init, inplace=inplace)
+
+
 def uniform_init(
-    data: Array, lo: float = -0.1, hi: float = 0.1, *, inplace: bool = False
+    data: Array, *, lo: float = -0.1, hi: float = 0.1, inplace: bool = False
 ) -> Array:
     xp = get_array_module(data)
     values = xp.random.uniform(lo, hi, data.shape)
@@ -31,6 +44,13 @@ def uniform_init(
         return data
     else:
         return values.astype(data.dtype)
+
+
+@registry.initializers("uniform_init.v0")
+def configure_uniform_init(
+    *, lo: float = -0.1, hi: float = 0.1, inplace: bool = False
+) -> Callable[[Array], Array]:
+    return partial(uniform_init, lo=lo, hi=hi, inplace=inplace)
 
 
 def normal_init(data: Array, *, fan_in: int = -1, inplace: bool = False) -> Array:
@@ -46,6 +66,13 @@ def normal_init(data: Array, *, fan_in: int = -1, inplace: bool = False) -> Arra
         return data
     else:
         return inits
+
+
+@registry.initializers("normal_init.v0")
+def configure_normal_init(
+    *, fan_in: int = -1, inplace: bool = False
+) -> Callable[[Array], Array]:
+    return partial(normal_init, fan_in=fan_in, inplace=inplace)
 
 
 __all__ = ["normal_init", "uniform_init", "xavier_uniform_init", "zero_init"]

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -5,7 +5,7 @@ import catalogue
 import thinc.config
 from thinc.config import ConfigValidationError
 from thinc.types import Generator
-from thinc.api import Config, registry, RAdam
+from thinc.api import Config, RAdam
 import numpy
 import inspect
 
@@ -492,7 +492,7 @@ def test_objects_from_config():
     def decaying(base_rate: float, repeat: int) -> List[float]:
         return repeat * [base_rate]
 
-    loaded = registry.make_from_config(config)
+    loaded = my_registry.make_from_config(config)
     optimizer = loaded["optimizer"]
     assert optimizer.b1 == 0.2
     assert optimizer.learn_rate == [0.001, 0.001, 0.001, 0.001]
@@ -502,7 +502,7 @@ def test_partials_from_config():
     """Test that functions registered with partial applications are handled
     correctly (e.g. losses)."""
     cfg = {"test": {"@losses": "L1_distance.v0", "margin": 0.5}}
-    func = registry.make_from_config(cfg)["test"]
+    func = my_registry.make_from_config(cfg)["test"]
     assert hasattr(func, "__call__")
     # The partial will still have margin as an arg, just with default
     assert len(inspect.signature(func).parameters) == 4

--- a/thinc/tests/test_initializers.py
+++ b/thinc/tests/test_initializers.py
@@ -1,5 +1,6 @@
 import pytest
 from thinc.api import xavier_uniform_init, zero_init, uniform_init, normal_init
+from thinc import registry
 import numpy
 
 
@@ -12,3 +13,20 @@ def test_initializer_func_setup(init_func):
     assert not numpy.array_equal(data, result)
     result = init_func(data, inplace=True)
     assert numpy.array_equal(data, result)
+
+
+@pytest.mark.parametrize(
+    "name,kwargs",
+    [
+        ("xavier_uniform_init.v0", {"inplace": False}),
+        ("zero_init.v0", {"inplace": True}),
+        ("uniform_init.v0", {"lo": -0.5, "hi": 0.5, "inplace": False}),
+        ("normal_init.v0", {"fan_in": 5, "inplace": True}),
+    ],
+)
+def test_initializer_from_config(name, kwargs):
+    """Test that initializers are loaded and configured correctly from registry
+    (as partials)."""
+    cfg = {"test": {"@initializers": name, **kwargs}}
+    func = registry.make_from_config(cfg)["test"]
+    func(numpy.ndarray([1, 2, 3, 4], dtype="f"))

--- a/thinc/tests/test_loss.py
+++ b/thinc/tests/test_loss.py
@@ -2,6 +2,7 @@ import pytest
 from mock import MagicMock
 import numpy
 from thinc.api import categorical_crossentropy, L1_distance, cosine_distance
+from thinc import registry
 
 
 @pytest.mark.parametrize("shape,labels", [([100, 100, 100], [-1, -1, -1])])
@@ -27,3 +28,18 @@ def test_cosine_distance():
     assert len(loss) == 2
     vec2 = numpy.asarray([[0, 0, 0]])
     cosine_distance(vec1, vec2, ignore_zeros=True)
+
+
+@pytest.mark.parametrize(
+    "name,kwargs",
+    [
+        ("categorical_crossentropy.v0", {}),
+        ("L1_distance.v0", {"margin": 0.5}),
+        ("cosine_distance.v0", {"ignore_zeros": True}),
+    ],
+)
+def test_loss_from_config(name, kwargs):
+    """Test that losses are loaded and configured correctly from registry
+    (as partials)."""
+    cfg = {"test": {"@losses": name, **kwargs}}
+    registry.make_from_config(cfg)["test"]

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -1,9 +1,10 @@
 from typing import Iterable, Any, Union, Tuple, Iterator, Sequence, cast, Dict
-from typing import Optional, Callable
+from typing import Optional, Callable, TypeVar
 import numpy
 import itertools
 import threading
 import random
+import functools
 
 try:  # pragma: no cover
     import cupy
@@ -319,6 +320,19 @@ def tensorflow2xp(tensorflow_tensor: "tf.Tensor") -> Array:  # pragma: no cover
     """Convert a Tensorflow tensor to numpy or cupy tensor."""
     assert_tensorflow_installed()
     return tensorflow_tensor.numpy()
+
+
+# This is how functools.partials seems to do it, too, to retain the return type
+PartialT = TypeVar("PartialT")
+
+
+def partial(func: Callable[..., PartialT], *args: Any, **kwargs: Any) -> Callable[..., PartialT]:
+    """Wrapper around functools.partial that retains docstrings and can include
+    other workarounds if needed.
+    """
+    partial_func = functools.partial(func, *args, **kwargs)
+    partial_func.__doc__ = func.__doc__
+    return partial_func
 
 
 __all__ = [


### PR DESCRIPTION
Specifying the default settings for those functions in the config makes sense and is consistent – but we can't actually call the functions, since they take data. In those cases, the loaded config returns a partial function.