### PR TITLE
Improve inference of output shape

### DIFF
--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -100,7 +100,7 @@ def init(model: Model, X: Optional[InT] = None, Y: Optional[OutT] = None) -> Non
             if all(lyr.has_dim("nO") is False for lyr in model.layers[i+1:]):
                 layer.initialize(X=X, Y=Y)
             else:
-                raise ValueError("Cannot infer output size of layer: {layer.name}")
+                layer.initialize(X=X)
         else:
             layer.initialize(X=X)
         if X is not None:

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -78,6 +78,9 @@ def init(model: Model, X: Optional[InT] = None, Y: Optional[OutT] = None) -> Non
             model.set_dim("nO", model.layers[-1].get_dim("nO"))
         return
     # Try to set nO on each layer, where available.
+    # Shape inference is tricky, especially for the output. The policy is:
+    # if a layer doesn't expose a nO dim, then its output is assumed to be
+    # the same as its input.
     nO = None
     if Y is not None and isinstance(Y, (Ragged, Padded, Array, list)):
         nO = get_width(Y)
@@ -90,15 +93,23 @@ def init(model: Model, X: Optional[InT] = None, Y: Optional[OutT] = None) -> Non
             nO = layer.get_dim("nI")
         else:
             break
-    for layer in model.layers[:-1]:
-        layer.initialize(X=X)
+    seen_nO = False
+    for i, layer in enumerate(model.layers):
+        if layer.has_dim("nO") is None:
+            # If we're the last layer with an nO, use Y.
+            if all(lyr.has_dim("nO") is False for lyr in model.layers[i+1:]):
+                layer.initialize(X=X, Y=Y)
+            else:
+                raise ValueError("Cannot infer output size of layer: {layer.name}")
+        else:
+            layer.initialize(X=X)
         if X is not None:
             X = layer.predict(X)
-    model.layers[-1].initialize(X=X, Y=Y)
     if model.layers[0].has_dim("nI"):
         model.set_dim("nI", model.layers[0].get_dim("nI"))
-    if model.layers[-1].has_dim("nO"):
-        model.set_dim("nO", model.layers[-1].get_dim("nO"))
+    layers_with_nO = [lyr for lyr in model.layers if lyr.has_dim("nO")]
+    if layers_with_nO:
+        model.set_dim("nO", layers_with_nO[-1].get_dim("nO"))
 
 
 # Unfortunately mypy doesn't support type-level checking on the cardinality

--- a/thinc/tests/layers/test_feed_forward.py
+++ b/thinc/tests/layers/test_feed_forward.py
@@ -79,6 +79,17 @@ def test_model_shape(model, model1, model2, nI, nH, nO):
     assert model.get_dim("nO") == model2.get_dim("nO")
 
 
+def test_infer_output_shape():
+    model = ReLu(dropout=0.2)
+    X = model.ops.alloc_f2d(4, 5)
+    Y = model.ops.alloc_f2d(4, 2)
+    assert model.has_dim("nI") is None
+    assert model.has_dim("nO") is None
+    model.initialize(X=X, Y=Y)
+    assert model.get_dim("nI") == 5
+    assert model.get_dim("nO") == 2
+
+
 def test_predict_and_begin_update_match(model, model1, model2, input_data):
     model = chain(model1, model2)
     via_predict = model.predict(input_data)


### PR DESCRIPTION
In `chain.initialize`, we were assuming that the last last would be the one which needs the output dimension set by the variable `Y`. In fact arbitrary output layers might be set at the end.

The implementation is still pretty hacky here, and there will still be some problems. But at least I have an idea for how this should work:

We should tell people that if their layer doesn't register an `nO` dimension, `chain` is allowed to assume the layer input will be valid output. We use this to ignore layers like `dropout` and `LayerNorm` when inferring shapes.

We would still have some problems with the layers like `list2ragged`, `padded2list` etc. Shape inference past these layers could be possible in theory, but I don't currently see how to do it. I guess we would need to split things up a bit, and allow layers to optionally specify a function that tells how to calculate the output shape given an input batch, and the input shape given an output batch. It seems pretty bureaucratic though.