### PR TITLE
Test and fix uniqued layer

### DIFF
--- a/thinc/layers/uniqued.py
+++ b/thinc/layers/uniqued.py
@@ -31,8 +31,8 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
     column = model.get_attr("column")
     layer = model.layers[0]
     keys = X[:, column]
-    if not isinstance(keys, numpy.ndarray):
-        keys = keys.get()
+    if not isinstance(keys, numpy.ndarray): 
+        keys = keys.get() # pragma: no cover
     uniq_keys, ind, inv, counts = numpy.unique(
         keys, return_index=True, return_inverse=True, return_counts=True
     )
@@ -58,6 +58,6 @@ def init(
     layer = model.layers[0]
     layer.initialize(X=X, Y=Y)
     if layer.has_dim("nI"):
-        model.set_dim("nI", layer.get_dim("nI"))
+        model.set_dim("nI", layer.get_dim("nI")) # pragma: no cover
     if layer.has_dim("nO"):
         model.set_dim("nO", layer.get_dim("nO"))

--- a/thinc/layers/uniqued.py
+++ b/thinc/layers/uniqued.py
@@ -31,8 +31,8 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
     column = model.get_attr("column")
     layer = model.layers[0]
     keys = X[:, column]
-    if not isinstance(keys, numpy.ndarray): 
-        keys = keys.get() # pragma: no cover
+    if not isinstance(keys, numpy.ndarray):
+        keys = keys.get()  # pragma: no cover
     uniq_keys, ind, inv, counts = numpy.unique(
         keys, return_index=True, return_inverse=True, return_counts=True
     )
@@ -58,6 +58,6 @@ def init(
     layer = model.layers[0]
     layer.initialize(X=X, Y=Y)
     if layer.has_dim("nI"):
-        model.set_dim("nI", layer.get_dim("nI")) # pragma: no cover
+        model.set_dim("nI", layer.get_dim("nI"))  # pragma: no cover
     if layer.has_dim("nO"):
         model.set_dim("nO", layer.get_dim("nO"))

--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -19,9 +19,9 @@ def lists_of_integers(draw, columns=2, lo=0, hi=ROWS):
     # should be between a min and max value.
     int_list = draw(lists(integers(min_value=lo, max_value=hi)))
     # Now we can use this int list to make an array, and it'll be the arrays
-    # that our functions receive. 
+    # that our functions receive.
     # We trim the list, so we're of length divisible by columns.
-    int_list = int_list[len(int_list) % columns:]
+    int_list = int_list[len(int_list) % columns :]
     # And make the array and reshape it.
     array = numpy.array(int_list, dtype="uint64")
     return array.reshape((-1, columns))
@@ -54,6 +54,6 @@ def test_uniqued_doesnt_change_result(model, X):
     assert_allclose(dX, dXu)
     if X.size:
         # Check that different inputs do give different results
-        Z, bp_Z = model(X+1, is_train=True)
+        Z, bp_Z = model(X + 1, is_train=True)
         with pytest.raises(AssertionError):
             assert_allclose(Y, Z)

--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -1,0 +1,38 @@
+import pytest
+import numpy
+from thinc.layers import uniqued, Embed
+from numpy.testing import assert_allclose
+from hypothesis import given
+from hypothesis.strategies import integers, lists, composite
+
+ROWS = 10
+
+@composite
+def lists_of_integers(draw, columns=2, lo=0, hi=ROWS):
+    int_list = draw(lists(integers(min_value=lo, max_value=hi)))
+    # Trim so we're of length divisible by columns.
+    int_list = int_list[len(int_list) % columns:]
+    array = numpy.array(int_list, dtype="uint64")
+    return array.reshape((-1, columns))
+
+
+@pytest.fixture
+def model(nO=128):
+    return Embed(nO, ROWS, column=0)
+
+
+@given(X=lists_of_integers(lo=0, hi=ROWS))
+def test_uniqued_doesnt_change_result(model, X):
+    if X.size == 0:
+        return
+    umodel = uniqued(model, column=1)
+    Y, bp_Y = model(X, is_train=True)
+    Yu, bp_Yu = umodel(X, is_train=True)
+    assert_allclose(Y, Yu)
+    dX = bp_Y(Y)
+    dXu = bp_Yu(Yu)
+    assert_allclose(dX, dXu)
+    # Check that different inputs do give different results
+    Z, bp_Z = model(X+1, is_train=True)
+    with pytest.raises(AssertionError):
+        assert_allclose(Y, Z)

--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -1,17 +1,28 @@
 import pytest
 import numpy
-from thinc.layers import uniqued, Embed
+from thinc.layers import Embed
+from ...layers.uniqued import uniqued
 from numpy.testing import assert_allclose
 from hypothesis import given
 from hypothesis.strategies import integers, lists, composite
 
 ROWS = 10
 
+# This test uses a newer hypothesis feature than the skanky flatmap-style
+# I used previously. This is much nicer, although it still takes some getting
+# used to. The key feature is this composite decorator. It injects a function,
+# 'draw'.
 @composite
 def lists_of_integers(draw, columns=2, lo=0, hi=ROWS):
+    # We call draw to get example values, which we can manipulate.
+    # Here we get a list of integers, where each member of the list
+    # should be between a min and max value.
     int_list = draw(lists(integers(min_value=lo, max_value=hi)))
-    # Trim so we're of length divisible by columns.
+    # Now we can use this int list to make an array, and it'll be the arrays
+    # that our functions receive. 
+    # We trim the list, so we're of length divisible by columns.
     int_list = int_list[len(int_list) % columns:]
+    # And make the array and reshape it.
     array = numpy.array(int_list, dtype="uint64")
     return array.reshape((-1, columns))
 
@@ -21,18 +32,28 @@ def model(nO=128):
     return Embed(nO, ROWS, column=0)
 
 
+def test_uniqued_calls_init():
+    calls = []
+    embed = Embed(5, 5, column=0)
+    embed._init = lambda *args, **kwargs: calls.append(True)
+    embed.initialize()
+    assert calls == [True]
+    uembed = uniqued(embed)
+    uembed.initialize()
+    assert calls == [True, True]
+
+
 @given(X=lists_of_integers(lo=0, hi=ROWS))
 def test_uniqued_doesnt_change_result(model, X):
-    if X.size == 0:
-        return
-    umodel = uniqued(model, column=1)
+    umodel = uniqued(model, column=model.get_attr("column"))
     Y, bp_Y = model(X, is_train=True)
     Yu, bp_Yu = umodel(X, is_train=True)
     assert_allclose(Y, Yu)
     dX = bp_Y(Y)
     dXu = bp_Yu(Yu)
     assert_allclose(dX, dXu)
-    # Check that different inputs do give different results
-    Z, bp_Z = model(X+1, is_train=True)
-    with pytest.raises(AssertionError):
-        assert_allclose(Y, Z)
+    if X.size:
+        # Check that different inputs do give different results
+        Z, bp_Z = model(X+1, is_train=True)
+        with pytest.raises(AssertionError):
+            assert_allclose(Y, Z)


### PR DESCRIPTION
There was a small long-standing bug in the backprop, that was masked by the fact that previously we returned `None` from most embedding layers' backprop, so we never actually called the un-unique.

I've also used a newer style from Hypothesis in this test. The old Hypothesis API was pretty tough, but this new one is very promising. I hope we can use it more in future for correctness tests, where we need a lot of examples.