### PR TITLE
TensorflowWrapper changes to support mathy model

### DIFF
--- a/thinc/layers/tensorflowwrapper.py
+++ b/thinc/layers/tensorflowwrapper.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Tuple, TypeVar, Optional
+from typing import Any, Callable, Optional, Tuple, Type, TypeVar
 
 from ..model import Model
 from ..shims import TensorFlowShim
@@ -21,6 +21,8 @@ def TensorFlowWrapper(
     build_model: bool = True,
     convert_inputs: Optional[Callable] = None,
     convert_outputs: Optional[Callable] = None,
+    model_class: Type[Model] = Model,
+    model_name: str = "tensorflow",
 ) -> Model[InT, OutT]:
     """Wrap a TensorFlow model, so that it has the same API as Thinc models.
     To optimize the model, you'll need to create a TensorFlow optimizer and call
@@ -38,8 +40,8 @@ def TensorFlowWrapper(
         convert_inputs = _convert_inputs
     if convert_outputs is None:
         convert_outputs = _convert_outputs
-    return Model(
-        "tensorflow",
+    return model_class(
+        model_name,
         forward,
         shims=[TensorFlowShim(tensorflow_model)],
         attrs={"convert_inputs": convert_inputs, "convert_outputs": convert_outputs},

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -235,7 +235,7 @@ def test_tensorflow_wrapper_convert_inputs(data, n_args, kwargs_keys):
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_thinc_model_subclass(tf_model):
     class CustomModel(Model):
-        def fn() -> int:
+        def fn(self) -> int:
             return 1337
 
     model = TensorFlowWrapper(tf_model, model_class=CustomModel)

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -222,7 +222,7 @@ def test_tensorflow_wrapper_to_gpu(model: Model[Array, Array], X: Array):
         # fmt: on
     ],
 )
-def test_convert_inputs(data, n_args, kwargs_keys):
+def test_tensorflow_wrapper_convert_inputs(data, n_args, kwargs_keys):
     import tensorflow as tf
 
     keras_model = tf.keras.Sequential([tf.keras.layers.Dense(12, input_shape=(12,))])
@@ -230,3 +230,20 @@ def test_convert_inputs(data, n_args, kwargs_keys):
     convert_inputs = model.get_attr("convert_inputs")
     Y, backprop = convert_inputs(model, data, is_train=True)
     check_input_converters(Y, backprop, data, n_args, kwargs_keys, tf.Tensor)
+
+
+@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+def test_tensorflow_wrapper_thinc_model_subclass(tf_model):
+    class CustomModel(Model):
+        def fn() -> int:
+            return 1337
+
+    model = TensorFlowWrapper(tf_model, model_class=CustomModel)
+    assert isinstance(model, CustomModel)
+    assert model.fn() == 1337
+
+
+@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+def test_tensorflow_wrapper_thinc_set_model_name(tf_model):
+    model = TensorFlowWrapper(tf_model, model_name="cool")
+    assert model.name == "cool"


### PR DESCRIPTION
This adds misc fixes/features to the thinc tensorflow shim/wrapper to support Mathy's keras models.

Changes:
 - [x] Allow specifying a custom `thinc.model.Model` subclass for the wrapper
