### PR TITLE
Fix TensorFlow shim and tests

### DIFF
--- a/thinc/model.py
+++ b/thinc/model.py
@@ -486,6 +486,9 @@ class Model(Generic[InT, OutT]):
             if hasattr(layer, "_mem"):
                 layer._mem._mem = self.ops.xp.asarray(layer._mem._mem)
                 layer._mem.ops = layer.ops
+            for shim in layer.shims:
+                if hasattr(shim, "to_gpu"):
+                    shim.to_gpu(gpu_id)
         return device
 
     def to_cpu(self) -> None:  # pragma: no cover
@@ -496,6 +499,9 @@ class Model(Generic[InT, OutT]):
                 if hasattr(layer._mem._mem, "get"):
                     layer._mem._mem = layer._mem._mem.get()
                 layer._mem.ops = layer.ops
+            for shim in layer.shims:
+                if hasattr(shim, "to_cpu"):
+                    shim.to_cpu()
 
     def to_bytes(self) -> bytes:
         """Serialize the model to a bytes representation. Models are usually

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -74,7 +74,7 @@ def test_tensorflow_wrapper_roundtrip_conversion():
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
-def test_tensorflow_wrapper_construction_requires_keras_model(tf_model):
+def test_tensorflow_wrapper_construction_requires_keras_model():
     import tensorflow as tf
 
     keras_model = tf.keras.Sequential([tf.keras.layers.Dense(12, input_shape=(12,))])
@@ -198,7 +198,8 @@ def test_tensorflow_wrapper_use_params(
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs Tensorflow")
-def test_tensorflow_wrapper_to_cpu(model: Model[Array, Array], X: Array):
+def test_tensorflow_wrapper_to_cpu(tf_model):
+    model = TensorFlowWrapper(tf_model)
     model.to_cpu()
 
 


### PR DESCRIPTION
- [x] remove unused `to_disk`/`from_disk` from shim (we just delegate to the bytes methods here)
- [x] make sure `to_cpu`/`to_gpu` also calls shim methods if available
- [x] fix problem where state dict would have the wrong weight names when copying the model (because it was created before and passed in). Not sure if my fix is great but the tests pass.
- [x] tidy up and improve test coverage