### PR TITLE
reshape weights and gradient before calling ops.adam

### DIFF
--- a/thinc/optimizers.py
+++ b/thinc/optimizers.py
@@ -354,6 +354,8 @@ class Optimizer(object):
             weights[:] = slow
 
     def _adam(self, xp, weights, gradient, lr_scale, key, nr_upd):
+        weights_1D = weights.reshape((weights.size, ))
+        gradient_1D = gradient.reshape((gradient.size, ))
         if key not in self.mom1:
             self.mom1[key] = self.ops.alloc_f1d(weights.size)
         if key not in self.mom2:
@@ -366,7 +368,7 @@ class Optimizer(object):
         b1 = self.b1
         b2 = self.b2
         eps = self.eps
-        self.ops.adam(weights, gradient, mom1, mom2, b1, b2, eps, lr * lr_scale)
+        self.ops.adam(weights_1D, gradient_1D, mom1, mom2, b1, b2, eps, lr * lr_scale)
 
 
 __all__ = ["Adam", "RAdam", "SGD", "Optimizer", "ADAM_DEFAULTS", "SGD_DEFAULTS"]


### PR DESCRIPTION
PR #218 introduced a bug: when calling `ops.adam()` with a parameter of dimension >1, it would crash with the error
> self.ops.adam(weights, gradient, mom1, mom2, b1, b2, eps, lr * lr_scale)
> File "thinc\backends\numpy_ops.pyx", line 338, in thinc.backends.numpy_ops.NumpyOps.adam
> ValueError: Buffer has wrong number of dimensions (expected 1, got 2)

I'm assuming this is because before that PR, `Memory`  stored the parameters as long arrays that could be passed as such to  `ops.adam()`, but now they require reshaping first.