### PR TITLE
Pass nI to LayerNorm

### DIFF
--- a/thinc/layers/maxout.py
+++ b/thinc/layers/maxout.py
@@ -33,7 +33,7 @@ def Maxout(
         params={"W": None, "b": None},
     )
     if normalize:
-        model = chain(model, LayerNorm())
+        model = chain(model, LayerNorm(nI=nO))
     if dropout is not None:
         model = chain(model, cast(Model[InT, OutT], Dropout(dropout)))
     if nO is not None and nI is not None:

--- a/thinc/layers/mish.py
+++ b/thinc/layers/mish.py
@@ -34,7 +34,7 @@ def Mish(
         params={"W": None, "b": None},
     )
     if normalize:
-        model = chain(model, cast(Model[InT, OutT], LayerNorm()))
+        model = chain(model, cast(Model[InT, OutT], LayerNorm(nI=nO)))
     if dropout is not None:
         model = chain(model, cast(Model[InT, OutT], Dropout(dropout)))
     if nO is not None and nI is not None:

--- a/thinc/layers/relu.py
+++ b/thinc/layers/relu.py
@@ -31,7 +31,7 @@ def ReLu(
         params={"W": None, "b": None},
     )
     if normalize:
-        model = chain(model, LayerNorm())
+        model = chain(model, LayerNorm(nI=nO))
     if dropout is not None:
         model = chain(model, cast(Model[Array2d, Array2d], Dropout(dropout)))
     if nO is not None and nI is not None:


### PR DESCRIPTION
Pass `nI` as the previous layer's `nO`. Had a case where the dimension remained unset if I didn't do this (perhaps also pointing to an issue with dimension inference?). Either way - this makes the code more robust.