### PR TITLE
Have concatenate support lists

### DIFF
--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -41,9 +41,7 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
     for lyr in model.layers:
         Y, cb = lyr(X, is_train=is_train)
         callbacks.append(cb)
-        #Y_stack = Y.reshape(sum(lengths), Y[0].shape[1])
-        Y_stack = model.ops.xp.concatenate(Y, axis=0)
-        Ys.append(Y_stack)
+        Ys.append(model.ops.xp.concatenate(Y, axis=0))
     widths = [Y.shape[1] for Y in Ys]
     output = model.ops.xp.hstack(Ys)
     output = model.ops.asarray(model.ops.unflatten(output, lengths))

--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -35,9 +35,18 @@ def concatenate(*layers: Model) -> Model[InT, OutT]:
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    Ys, callbacks = zip(*[lyr(X, is_train=is_train) for lyr in model.layers])
+    lengths = model.ops.asarray([len(x) for x in X], dtype="i")
+    Ys = []
+    callbacks = []
+    for lyr in model.layers:
+        Y, cb = lyr(X, is_train=is_train)
+        callbacks.append(cb)
+        #Y_stack = Y.reshape(sum(lengths), Y[0].shape[1])
+        Y_stack = model.ops.xp.concatenate(Y, axis=0)
+        Ys.append(Y_stack)
     widths = [Y.shape[1] for Y in Ys]
     output = model.ops.xp.hstack(Ys)
+    output = model.ops.asarray(model.ops.unflatten(output, lengths))
 
     def backprop(d_output: OutT) -> InT:
         dY = model.ops.xp.ascontiguousarray(d_output[:, : widths[0]])

--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -36,25 +36,34 @@ def concatenate(*layers: Model) -> Model[InT, OutT]:
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
     lengths = model.ops.asarray([len(x) for x in X], dtype="i")
+    convert_list = False
     Ys = []
     callbacks = []
     for lyr in model.layers:
         Y, cb = lyr(X, is_train=is_train)
         callbacks.append(cb)
-        Ys.append(model.ops.xp.concatenate(Y, axis=0))
+        if isinstance(Y, list):
+            convert_list = True
+            Ys.append(model.ops.xp.concatenate(Y, axis=0))
+        else:
+            Ys.append(Y)
     widths = [Y.shape[1] for Y in Ys]
     output = model.ops.xp.hstack(Ys)
-    output = model.ops.unflatten(output, lengths)
+    if convert_list:
+        output = model.ops.unflatten(output, lengths)
 
     def backprop(d_output: OutT) -> InT:
-        d_output = model.ops.xp.concatenate(d_output, axis=0)
+        if convert_list:
+            d_output = model.ops.xp.concatenate(d_output, axis=0)
         dY = model.ops.xp.ascontiguousarray(d_output[:, : widths[0]])
-        dY = model.ops.asarray(model.ops.unflatten(dY, lengths))
+        if convert_list:
+            dY = model.ops.asarray(model.ops.unflatten(dY, lengths))
         dX = callbacks[0](dY)
         start = widths[0]
         for bwd, width in zip(callbacks[1:], widths[1:]):
             dY = model.ops.xp.ascontiguousarray(d_output[:, start : start + width])
-            dY = model.ops.asarray(model.ops.unflatten(dY, lengths))
+            if convert_list:
+                dY = model.ops.asarray(model.ops.unflatten(dY, lengths))
             dX += bwd(dY)
             start += width
         return dX


### PR DESCRIPTION
Add in support for concatenating lists in the `concatenate` layer.

This works, as tested with spaCy. Before we had to do 
`concatenate_lists(CharacterEmbed(....), FeatureExtracter(...)`
now just `concatenate` works (without messing up the normal `concatenate` cases)