### PR TITLE
update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ dataclasses>=0.6,<1.0; python_version < "3.7"
 typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"
 # Development dependencies
 cython>=0.25.0
-hypothesis>=2.0.0,<5.0.0
-pytest
+hypothesis>=3.27.0,<5.0.0
+pytest>=5.2.0
 pytest-cov
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0


### PR DESCRIPTION
I ran into issues with older versions which were fixed by updating. I changed the specs in the `requirements.txt` according to these links:
* https://hypothesis.readthedocs.io/en/latest/changes.html#v3-27-0 : `deadline` since 3.27.0
* https://stackoverflow.com/a/58189684/7961860: a certain bug in `pytest` that got fixed after 5.2.0