### PR TITLE
small bugfix in cupy asarray

### DIFF
--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -34,7 +34,7 @@ class CupyOps(Ops):
         # forward "unset".
         dtype = {"dtype": dtype} if dtype is not None else {}
         if isinstance(X, cupy.ndarray):
-            return self.xp.asarray(X, dtype=dtype)
+            return self.xp.asarray(X, **dtype)
         elif hasattr(X, "data_ptr"):
             # Handles PyTorch Tensors
             pointer = cupy.cuda.MemoryPointer(X.data_ptr())

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -299,11 +299,6 @@ class Ops:
         loss = losses.sum()
         return loss
 
-    def get_norm(self, X: Array):
-        norms = self.xp.linalg.norm(X, axis=1)
-        norms[norms == 0] = 1
-        return norms
-
     def dtanh(self, Y: ArrayT, *, inplace: bool = False) -> ArrayT:
         if inplace:
             Y **= 2

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -514,6 +514,8 @@ class Model(Generic[InT, OutT]):
         result from loading and serializing a model.
         """
         msg = srsly.msgpack_loads(bytes_data)
+        if not "nodes" in msg.keys():
+            raise ValueError("Trying to read a Model that was created with an incompatible version of Thinc.")
         nodes = list(self.walk())
         if len(msg["nodes"]) != len(nodes):
             raise ValueError("Cannot deserialize model: mismatched structure.")


### PR DESCRIPTION
There was one spot where the cupy function call wasn't yet rewritten to `**dtype`.

Also added a more user-friendly warning in `Model.from_bytes` to point to incompatible versions (bound to happen).