### PR TITLE
Fix setting chained model's output dimension

### DIFF
--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -96,5 +96,6 @@ def init(
             layer.set_dim("nI", X_width)
     for layer in model.layers:
         layer.initialize(X=X, Y=Y)
-    model.set_dim("nO", sum(layer.get_dim("nO") for layer in model.layers))
+    if None not in [layer.has_dim("nO") for layer in model.layers]:
+        model.set_dim("nO", sum(layer.get_dim("nO") for layer in model.layers))
     return model


### PR DESCRIPTION
Only set the `chain` model's `nO` dim if all the chained layers have an `nO` set. Popped up in a test with spaCy.