### PR TITLE
restore some edits from concatenate

### DIFF
--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -71,11 +71,14 @@ def _list_forward(
     output = model.ops.unflatten(output, lengths)
 
     def backprop(d_output: OutT) -> InT:
+        d_output = model.ops.xp.concatenate(d_output, axis=0)
         dY = model.ops.as_contig(d_output[:, : widths[0]])
+        dY = model.ops.asarray(model.ops.unflatten(dY, lengths))
         dX = callbacks[0](dY)
         start = widths[0]
         for bwd, width in zip(callbacks[1:], widths[1:]):
             dY = model.ops.as_contig(d_output[:, start : start + width])
+            dY = model.ops.asarray(model.ops.unflatten(dY, lengths))
             dX += bwd(dY)
             start += width
         return dX


### PR DESCRIPTION
In spaCy, `test_tok2vec_configs` was failing on calling `backprop(vectors)` because of the recent changes to `concatenate`. I reverted part of the edits from [here](https://github.com/explosion/thinc/commit/4d32ac32e165f425fb30c69281c4dd0dda142c72#diff-5be155357e784dde8a496aa6aad6771fL74), and that seems to fix it. I'm not sure why this got removed in the first place though.