### PR TITLE
Fix errors using TensorFlowWrapper for multithreaded training

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -4,7 +4,7 @@ from .loss import CategoricalCrossentropy, L2Distance, CosineDistance
 from .loss import SequenceCategoricalCrossentropy
 from .model import Model, serialize_attr, deserialize_attr
 from .model import set_dropout_rate, change_attr_values
-from .shims import Shim, PyTorchShim, TensorFlowShim, keras_model_fns
+from .shims import Shim, PyTorchShim, TensorFlowShim, keras_model_fns, maybe_handshake_model
 from .optimizers import Adam, RAdam, SGD, Optimizer
 from .schedules import cyclic_triangular, warmup_linear, constant, constant_then
 from .schedules import decaying, slanted_triangular, compounding

--- a/thinc/layers/tensorflowwrapper.py
+++ b/thinc/layers/tensorflowwrapper.py
@@ -84,12 +84,10 @@ def keras_subclass(
 
 def TensorFlowWrapper(
     tensorflow_model: Any,
-    build_model: bool = True,
     convert_inputs: Optional[Callable] = None,
     convert_outputs: Optional[Callable] = None,
     optimizer: Optional[Any] = None,
     model_class: Type[Model] = Model,
-    input_shape: Optional[Tuple[int, ...]] = None,
     model_name: str = "tensorflow",
 ) -> Model[InT, OutT]:
     """Wrap a TensorFlow model, so that it has the same API as Thinc models.

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -34,6 +34,7 @@ class Model(Generic[InT, OutT]):
     """Class for implementing Thinc models and layers."""
 
     global_id: int = 0
+    global_id_lock: threading.Lock = threading.Lock()
     _thread_local = create_thread_local({"operators": {}}, ModelThreadState)
 
     name: str
@@ -95,7 +96,8 @@ class Model(Generic[InT, OutT]):
         self._shims = list(shims)
         # Take care to increment the base class here! It needs to be unique
         # across all models.
-        Model.global_id += 1
+        with Model.global_id_lock:
+            Model.global_id += 1
         self.id = Model.global_id
         self._has_params = {}
         for name, value in params.items():

--- a/thinc/shims/__init__.py
+++ b/thinc/shims/__init__.py
@@ -1,3 +1,3 @@
 from .shim import Shim
 from .pytorch import PyTorchShim
-from .tensorflow import keras_model_fns, TensorFlowShim
+from .tensorflow import keras_model_fns, TensorFlowShim, maybe_handshake_model

--- a/thinc/shims/shim.py
+++ b/thinc/shims/shim.py
@@ -2,6 +2,7 @@ from typing import Any, Optional, Tuple, Callable, Dict, Union
 import copy
 import contextlib
 from pathlib import Path
+import threading
 
 
 class Shim:  # pragma: no cover
@@ -16,13 +17,15 @@ class Shim:  # pragma: no cover
     rather than expecting that they'll be msgpack-serializable.
     """
 
-    global_id = 0
+    global_id: int = 0
+    global_id_lock: threading.Lock = threading.Lock()
     cfg: Dict
     _model: Any
     _optimizer: Optional[Any]
 
     def __init__(self, model: Any, config=None, optimizer: Any = None):
-        Shim.global_id += 1
+        with Shim.global_id_lock:
+            Shim.global_id += 1
         self.id = Shim.global_id
         self.cfg = dict(config) if config is not None else {}
         self._model = model

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -70,7 +70,6 @@ def maybe_handshake_model(keras_model, optimizer=None):
     return keras_model
 
 
-class TrackableBackprop(object):
 class TensorFlowShim(Shim):
     """Interface between a TensorFlow model and a Thinc Model. This container is
     *not* a Thinc Model subclass itself.

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -246,7 +246,6 @@ class TensorFlowShim(Shim):
         return self._model.catalogue_name, self._model.get_weights()
 
     def from_bytes(self, data):
-        tf.keras.backend.clear_session()
         ops: Ops = get_current_ops()
         if ops.device_type == "cpu":
             device = "CPU"
@@ -255,6 +254,7 @@ class TensorFlowShim(Shim):
 
         # Plain bytes
         if isinstance(data, (str, bytes)):
+            tf.keras.backend.clear_session()
             filelike = BytesIO(data)
             filelike.seek(0)
             with h5py.File(filelike, "r") as f:
@@ -265,6 +265,7 @@ class TensorFlowShim(Shim):
         catalogue_name, model_weights = data
         if self._model is None:
             model_fn = keras_model_fns.get(catalogue_name)
+            tf.keras.backend.clear_session()
             with tf.device(device):
                 if hasattr(self._model, "eg_args"):
                     ak: ArgsKwargs = self._model.eg_args

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -30,6 +30,42 @@ except ImportError:  # pragma: no cover
 keras_model_fns = catalogue.create("thinc", "keras", entry_points=True)
 
 
+def maybe_handshake_model(keras_model):
+    """Call the required predict/compile/build APIs to initialize a model if it
+    is a subclass of tf.keras.Model. This is required to be able to call set_weights
+    on subclassed layers."""
+    try:
+        keras_model.get_config()
+        return keras_model
+    except (AttributeError, NotImplementedError):
+        # Subclassed models don't implement get_config
+        pass
+
+    for prop_name in ["catalogue_name", "eg_x", "eg_y", "eg_shape"]:
+        if not hasattr(keras_model, prop_name):
+            raise ValueError(
+                "Keras subclassed models are not whole-model serializable by "
+                "TensorFlow. To work around this, you must decorate your keras "
+                "model subclasses with the 'keras_subclass' decorator. The decorator "
+                "requires a single X/Y input of fake-data that can be used to initialize "
+                "your subclass model properly when loading the saved version."
+            )
+
+    ops: Ops = get_current_ops()
+    if ops.device_type == "cpu":
+        device = "CPU"
+    else:  # pragma: no cover
+        device = tf.test.gpu_device_name()
+
+    with tf.device(device):
+        # Calling predict creates layers and weights for subclassed models
+        keras_model.compile(**keras_model.eg_compile)
+        keras_model.build(keras_model.eg_shape)
+        keras_model.predict(keras_model.eg_x)
+    return keras_model
+
+
+class TrackableBackprop(object):
 class TensorFlowShim(Shim):
     """Interface between a TensorFlow model and a Thinc Model. This container is
     *not* a Thinc Model subclass itself.
@@ -222,20 +258,15 @@ class TensorFlowShim(Shim):
                 with tf.device(device):
                     self._model = tf.keras.models.load_model(f)
                 return
-
+        # We only have to create the model if it doesn't already exist.
         catalogue_name, model_weights = data
-        model_fn = keras_model_fns.get(catalogue_name)
-        with tf.device(device):
-            if hasattr(self._model, "eg_args"):
-                ak: ArgsKwargs = self._model.eg_args
-                new_model = model_fn(*ak.args, **ak.kwargs)
-            else:
-                new_model = model_fn()
-        # Calling predict creates layers and weights for subclassed models
-        new_model.compile(**new_model.eg_compile)
-        new_model.build(new_model.eg_shape)
-        new_model.predict(new_model.eg_x)
-        # Once the weights are created we can overwrite them.
-        new_model.set_weights(model_weights)
-
-        self._model = new_model
+        if self._model is None:
+            model_fn = keras_model_fns.get(catalogue_name)
+            with tf.device(device):
+                if hasattr(self._model, "eg_args"):
+                    ak: ArgsKwargs = self._model.eg_args
+                    new_model = model_fn(*ak.args, **ak.kwargs)
+                else:
+                    new_model = model_fn()
+            self._model_initialized = maybe_handshake_model(new_model)
+        self._model.set_weights(model_weights)

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -241,9 +241,9 @@ class TensorFlowShim(Shim):
                     "Couldn't serialize to h5, and model has no factory "
                     "function for component serialization."
                 )
-            # Check the factory function and throw ValueError if it doesn't exist
-            keras_model_fns.get(self._model.catalogue_name)
-            return self._model.catalogue_name, self._model.get_weights()
+        # Check the factory function and throw ValueError if it doesn't exist
+        keras_model_fns.get(self._model.catalogue_name)
+        return self._model.catalogue_name, self._model.get_weights()
 
     def from_bytes(self, data):
         tf.keras.backend.clear_session()

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -94,8 +94,10 @@ class TensorFlowShim(Shim):
             return self.predict(X)
 
     def predict(self, X: ArgsKwargs):
+        old_phase = tf.keras.backend.learning_phase()
         tf.keras.backend.set_learning_phase(0)
         Y = self._model(*X.args, **X.kwargs)
+        tf.keras.backend.set_learning_phase(old_phase)
         return Y
 
     def begin_update(self, X: ArgsKwargs):

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -93,29 +93,6 @@ def test_tensorflow_wrapper_built_model(model: Model[Array, Array], X: Array, Y:
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
-def test_tensorflow_wrapper_unbuilt_model_hides_config_errors(
-    tf_model, X: Array, Y: Array
-):
-    import tensorflow as tf
-
-    # input_shape is needed to de/serialize keras models properly
-    # so we throw an error as soon as we can detect that case.
-    with pytest.raises(ValueError):
-        TensorFlowWrapper(tf.keras.Sequential([tf.keras.layers.Dense(12)]))
-    # You can override the model build at construction, but then
-    # you must specify the input shape another way.
-    model: Model[Array, Array] = TensorFlowWrapper(
-        tf.keras.Sequential([tf.keras.layers.Dense(12)]), build_model=False
-    )
-    # Can't de/serialize without an input_shape
-    with pytest.raises(ValueError):
-        model.from_bytes(model.to_bytes())
-    # Can't print a keras summary
-    with pytest.raises(ValueError):
-        str(model.shims[0])
-
-
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_predict(model: Model[Array, Array], X: Array):
     model.predict(X)
 

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -164,9 +164,7 @@ def test_tensorflow_wrapper_serialize_model_subclass(
             x = self.in_dense(inputs)
             return self.out_dense(x)
 
-    model: Model[Array, Array] = TensorFlowWrapper(
-        CustomKerasModel(), input_shape=input_shape
-    )
+    model: Model[Array, Array] = TensorFlowWrapper(CustomKerasModel())
     # Train the model to predict the right single answer
     optimizer = Adam()
     for i in range(50):
@@ -212,6 +210,27 @@ def test_tensorflow_wrapper_keras_subclass_decorator_compile_args():
 
     assert model.shims[0]._model.loss == "binary_crossentropy"
     assert isinstance(model, Model)
+
+
+@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+def test_tensorflow_wrapper_keras_subclass_compile_optimizer():
+    import tensorflow as tf
+
+    @keras_subclass(
+        "TestModel", X=numpy.array([0.0, 0.0]), Y=numpy.array([0.5]), input_shape=(2,),
+    )
+    class TestModel(tf.keras.Model):
+        def call(self, inputs):
+            return inputs
+
+    optimizer = tf.keras.optimizers.Adam(lr=3e-18)
+    model = TensorFlowWrapper(TestModel(), optimizer=optimizer)
+    weights_model = model.shims[0]._optimizer.get_weights()
+    for w1, w2 in zip(optimizer.get_weights(), weights_model):
+        assert numpy.array_equal(w1, w2)
+    lr_key = "learning_rate"
+    assert optimizer._get_hyper(lr_key) == 3e-18
+    assert optimizer._get_hyper(lr_key) == model.shims[0]._optimizer._get_hyper(lr_key)
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -330,3 +330,26 @@ def test_all_operators(op):
             with pytest.raises(TypeError):
                 value = m1 | m2  # noqa: F841
     assert Model._thread_local.operators == {}
+
+
+def test_unique_id_multithreading():
+    """Create a bunch of threads and assert they all get unique IDs"""
+
+    list_of_ids = []
+
+    def get_model_id(id_list, index):
+        id_list.append(create_model(name=f"worker{index}").id)
+
+    counter = 0
+    while len(list_of_ids) < 1000:
+        workers = []
+        for i in range(50):
+            w = threading.Thread(target=get_model_id, args=(list_of_ids, counter))
+            workers.append(w)
+            counter += 1
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join()
+
+    assert len(list_of_ids) == len(list(set(list_of_ids)))

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -191,9 +191,6 @@ def test_plus_chain():
         assert m.name == "a"
 
 
-# TODO: This currently causes a n AttributeError in the first thread. The error
-# isn't raised in the test (because threading) but it's written to stdout.
-@pytest.mark.skip(reason="need to fix error")
 def test_overload_operators_in_subthread():
     """Test we can create a model in a child thread with overloaded operators."""
     # Worker1 will start and run, while worker 2 sleeps after Model.define_operators.

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Sequence, cast, Dict, Optional, Callable, TypeVar
+from typing import Any, Union, Sequence, cast, Dict, Optional, Callable, TypeVar, Type
 import numpy
 import threading
 import random
@@ -57,8 +57,10 @@ def fix_random_seed(seed: int = 0) -> None:  # pragma: no cover
         cupy.random.seed(seed)
 
 
-def create_thread_local(attrs: Dict[str, Any]):
-    obj = threading.local()
+def create_thread_local(
+    attrs: Dict[str, Any], local_class: Type[threading.local] = threading.local
+):
+    obj = local_class()
     for name, value in attrs.items():
         setattr(obj, name, value)
     return obj


### PR DESCRIPTION
 - add `get_thread_state` helper for backends. When called it will get the thread local for the current thread, or create it from the global state attributes.
 - After some searching I found a blog post that talked about a subtle detail that meant you cannot do mutable thread local data without subclassing threading.local. Update model operators thread local to use a subclass. This prevents errors in the overloaded operators test.

Source: http://slinkp.com/python-thread-locals-20171201.html