### PR TITLE
Fix model.ops type and related issues

### DIFF
--- a/thinc/backends/jax_ops.py
+++ b/thinc/backends/jax_ops.py
@@ -120,10 +120,10 @@ class JaxOps(Ops):
     ) -> Array2d:
         return backprop_mish(dY, X, threshold)
 
-    def relu(self, X: Array, inplace: bool = False) -> Array:
+    def relu(self, X: Array2d, inplace: bool = False) -> Array2d:
         return relu(X)
 
-    def backprop_relu(self, dY: Array, Y: Array, inplace: bool = False) -> Array:
+    def backprop_relu(self, dY: Array2d, Y: Array2d, inplace: bool = False) -> Array2d:
         return backprop_relu(dY, Y)
 
     def update_averages(

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -536,14 +536,14 @@ class Ops:
                 dX[b, o, which[b, o]] = dY[b, o]
         return dX
 
-    def relu(self, X: Array, inplace: bool = False) -> Array:
+    def relu(self, X: Array2d, inplace: bool = False) -> Array2d:
         if not inplace:
             return X * (X > 0)
         else:
             X *= X > 0
             return X
 
-    def backprop_relu(self, dY: Array, Y: Array, inplace: bool = False) -> Array:
+    def backprop_relu(self, dY: Array2d, Y: Array2d, inplace: bool = False) -> Array2d:
         if not inplace:
             return dY * (Y > 0)
         dY *= Y > 0

--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -2,7 +2,7 @@ from typing import Tuple, Callable, Optional, TypeVar, cast
 
 from ..model import Model
 from ..config import registry
-from ..types import Array2d
+from ..types import Array2d, Array1d
 from ..util import get_width
 from .noop import noop
 from ..types import XY_XY_OutT
@@ -65,7 +65,7 @@ def _array_forward(
 def _list_forward(
     model: Model[InT, OutT], X, Ys, callbacks, is_train: bool
 ) -> Tuple[OutT, Callable]:
-    lengths = model.ops.asarray([len(x) for x in X], dtype="i")
+    lengths: Array1d = model.ops.asarray([len(x) for x in X], dtype="i")
     Ys = [model.ops.xp.concatenate(Y, axis=0) for Y in Ys]
     widths = [Y.shape[1] for Y in Ys]
     output = model.ops.xp.hstack(Ys)

--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -44,7 +44,7 @@ def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Ca
         d_vectors = model.ops.alloc_f2d(*vectors.shape)
         model.ops.scatter_add(d_vectors, ids, d_output)
         model.inc_grad("E", d_vectors)
-        dX = model.ops.alloc(input_shape, dtype=ids.dtype)
+        dX: OutT = model.ops.alloc(input_shape, dtype=ids.dtype)
         return dX
 
     return output, backprop

--- a/thinc/layers/expand_window.py
+++ b/thinc/layers/expand_window.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable
+from typing import Tuple, Callable, cast
 
 from ..model import Model
 from ..config import registry
@@ -22,6 +22,6 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
     Y = model.ops.seq2col(X, nW)
 
     def backprop(dY: OutT) -> InT:
-        return model.ops.backprop_seq2col(dY, nW)
+        return cast(Array2d, model.ops.backprop_seq2col(dY, nW))
 
     return Y, backprop

--- a/thinc/layers/featureextractor.py
+++ b/thinc/layers/featureextractor.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Callable, Tuple
+from typing import List, Union, Callable, Tuple, cast
 
 from ..types import Array2d, Doc
 from ..model import Model
@@ -24,7 +24,7 @@ def forward(
             attrs = doc.to_array(columns)
         else:
             attrs = doc.doc.to_array(columns)[doc.start : doc.end]
-        features.append(model.ops.asarray(attrs, dtype="uint64"))
+        features.append(cast(Array2d, model.ops.asarray(attrs, dtype="uint64")))
 
     backprop: Callable[[OutT], List] = lambda d_features: []
     return features, backprop

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -51,7 +51,7 @@ def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Ca
         for i in range(keys.shape[0]):
             model.ops.scatter_add(dE, keys[i], d_output)
         model.inc_grad("E", dE)
-        dX = model.ops.alloc(input_shape, dtype="i")
+        dX: OutT = model.ops.alloc(input_shape, dtype="i")
         return dX
 
     return output, backprop

--- a/thinc/layers/linear.py
+++ b/thinc/layers/linear.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional
+from typing import Tuple, Callable, Optional, cast
 
 from ..model import Model
 from ..config import registry
@@ -30,7 +30,7 @@ def Linear(
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    W = model.get_param("W")
+    W = cast(Array2d, model.get_param("W"))
     b = model.get_param("b")
     Y = model.ops.gemm(X, W, trans2=True)
     Y += b

--- a/thinc/layers/list2array.py
+++ b/thinc/layers/list2array.py
@@ -2,7 +2,7 @@ from typing import Tuple, List, Callable, cast
 
 from ..model import Model
 from ..config import registry
-from ..types import Array2d
+from ..types import Array2d, Array1d
 
 
 InT = List[Array2d]
@@ -19,7 +19,7 @@ def list2array() -> Model[InT, OutT]:
 
 
 def forward(model: Model[InT, OutT], Xs: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    lengths = model.ops.asarray([len(x) for x in Xs], dtype="i")
+    lengths: Array1d = model.ops.asarray([len(x) for x in Xs], dtype="i")
 
     def backprop(dY: OutT) -> InT:
         return cast(InT, model.ops.unflatten(dY, lengths))

--- a/thinc/layers/list2ragged.py
+++ b/thinc/layers/list2ragged.py
@@ -2,7 +2,7 @@ from typing import Tuple, List, Callable, cast
 
 from ..model import Model
 from ..config import registry
-from ..types import Array2d, Ragged
+from ..types import Array2d, Array1d, Ragged
 
 
 InT = List[Array2d]
@@ -22,5 +22,5 @@ def forward(model: Model[InT, OutT], Xs: InT, is_train: bool) -> Tuple[OutT, Cal
     def backprop(dYr: OutT) -> InT:
         return cast(InT, model.ops.unflatten(dYr.data, dYr.lengths))
 
-    lengths = model.ops.asarray([len(x) for x in Xs], dtype="i")
+    lengths: Array1d = model.ops.asarray([len(x) for x in Xs], dtype="i")
     return Ragged(model.ops.flatten(Xs), lengths), backprop

--- a/thinc/layers/maxout.py
+++ b/thinc/layers/maxout.py
@@ -44,7 +44,7 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
     nP = model.get_dim("nP")
     nI = model.get_dim("nI")
     b = model.get_param("b")
-    W = cast(Array2d, model.get_param("W"))
+    W = model.get_param("W")
     W = W.reshape((nO * nP, nI))
     Y = model.ops.gemm(X, W, trans2=True)
     Y += b.reshape((nO * nP,))

--- a/thinc/layers/maxout.py
+++ b/thinc/layers/maxout.py
@@ -44,7 +44,7 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
     nP = model.get_dim("nP")
     nI = model.get_dim("nI")
     b = model.get_param("b")
-    W = model.get_param("W")
+    W = cast(Array2d, model.get_param("W"))
     W = W.reshape((nO * nP, nI))
     Y = model.ops.gemm(X, W, trans2=True)
     Y += b.reshape((nO * nP,))

--- a/thinc/layers/mish.py
+++ b/thinc/layers/mish.py
@@ -42,7 +42,7 @@ def Mish(
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    W = model.get_param("W")
+    W = cast(Array2d, model.get_param("W"))
     b = model.get_param("b")
     Y_pre_mish = model.ops.gemm(X, W, trans2=True)
     Y_pre_mish += b

--- a/thinc/layers/multisoftmax.py
+++ b/thinc/layers/multisoftmax.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Callable
+from typing import Optional, Tuple, Callable, cast
 
 from ..types import Array2d
 from ..model import Model
@@ -29,7 +29,7 @@ def MultiSoftmax(nOs: Tuple[int, ...], nI: Optional[int] = None) -> Model[InT, O
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
     nOs = model.get_attr("nOs")
-    W = model.get_param("W")
+    W = cast(Array2d, model.get_param("W"))
     b = model.get_param("b")
 
     def backprop(dY: OutT) -> InT:

--- a/thinc/layers/reduce_sum.py
+++ b/thinc/layers/reduce_sum.py
@@ -2,11 +2,11 @@ from typing import Callable, Tuple
 
 from ..model import Model
 from ..config import registry
-from ..types import Array, Ragged
+from ..types import Array2d, Ragged
 
 
 InT = Ragged
-OutT = Array
+OutT = Array2d
 
 
 @registry.layers("reduce_sum.v0")

--- a/thinc/layers/relu.py
+++ b/thinc/layers/relu.py
@@ -39,9 +39,8 @@ def ReLu(
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    W = model.get_param("W")
+    W = cast(Array2d, model.get_param("W"))
     b = model.get_param("b")
-
     Y = model.ops.affine(X, W, b)
     Y = model.ops.relu(Y)
 

--- a/thinc/layers/remap_ids.py
+++ b/thinc/layers/remap_ids.py
@@ -2,7 +2,7 @@ from typing import Tuple, Callable, Sequence, Dict, Any
 
 from ..model import Model
 from ..config import registry
-from ..types import Array2d, DTypes
+from ..types import Array2d, Array, DTypes
 
 
 InT = Sequence[Any]
@@ -32,7 +32,8 @@ def forward(
     default = model.get_attr("default")
     dtype = model.get_attr("dtype")
     values = [table.get(x, default) for x in inputs]
-    output = model.ops.asarray(values, dtype=dtype).reshape(-1, 1)
+    arr: Array = model.ops.asarray(values, dtype=dtype)
+    output: Array2d = arr.reshape((-1, 1))
 
     def backprop(dY: OutT) -> InT:
         return []

--- a/thinc/layers/residual.py
+++ b/thinc/layers/residual.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional, Union, List, TypeVar
+from typing import Tuple, Callable, Optional, List, TypeVar
 
 from ..model import Model
 from ..config import registry

--- a/thinc/layers/softmax.py
+++ b/thinc/layers/softmax.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional
+from typing import Tuple, Callable, Optional, cast
 
 from ..model import Model
 from ..config import registry
@@ -29,9 +29,8 @@ def Softmax(
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    W = model.get_param("W")
+    W = cast(Array2d, model.get_param("W"))
     b = model.get_param("b")
-
     Y = model.ops.affine(X, W, b)
     Y = model.ops.softmax(Y)
 

--- a/thinc/layers/staticvectors.py
+++ b/thinc/layers/staticvectors.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Optional
+from typing import Tuple, Callable, Optional, cast
 
 from ..types import Array, Array2d
 from ..model import Model
@@ -27,7 +27,7 @@ def StaticVectors(lang: str, nO: int, *, column: int = 0) -> Model[InT, OutT]:
 
 def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Callable]:
     column = model.get_attr("column")
-    W = model.get_param("W")
+    W = cast(Array2d, model.get_param("W"))
     vector_table = _get_vectors(model.ops, model.get_attr("lang"))
     if ids.ndim >= 2:
         ids = model.ops.as_contig(ids[:, column])

--- a/thinc/layers/strings2arrays.py
+++ b/thinc/layers/strings2arrays.py
@@ -3,7 +3,7 @@ from murmurhash import hash_unicode
 
 from ..model import Model
 from ..config import registry
-from ..types import Array2d
+from ..types import Array2d, Array
 
 
 InT = Sequence[str]
@@ -18,8 +18,8 @@ def strings2arrays() -> Model[InT, OutT]:
 
 def forward(model: Model[InT, OutT], Xs: InT, is_train: bool) -> Tuple[OutT, Callable]:
     hashes = [[hash_unicode(word) for word in X] for X in Xs]
-    arrays = [model.ops.asarray(h, dtype="uint64") for h in hashes]
-    arrays = [array.reshape((-1, 1)) for array in arrays]
+    hash_arrays: List[Array] = [model.ops.asarray(h, dtype="uint64") for h in hashes]
+    arrays: List[Array2d] = [array.reshape((-1, 1)) for array in hash_arrays]
 
     def backprop(dX: OutT) -> InT:
         return []

--- a/thinc/layers/uniqued.py
+++ b/thinc/layers/uniqued.py
@@ -43,7 +43,7 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
     uniq_shape = tuple(Y_uniq.shape)
 
     def backprop(dY: OutT) -> InT:
-        dY_uniq = layer.ops.alloc(uniq_shape, dtype="f")
+        dY_uniq: Array = layer.ops.alloc(uniq_shape, dtype="f")
         layer.ops.scatter_add(dY_uniq, layer.ops.asarray(inv, dtype="i"), dY)
         d_uniques = bp_Y_uniq(dY_uniq)
         # This confusing bit of indexing "ununiques"

--- a/thinc/layers/with_array.py
+++ b/thinc/layers/with_array.py
@@ -2,7 +2,7 @@ from typing import Tuple, Callable, List, Optional, TypeVar, Union, cast
 
 from ..model import Model
 from ..config import registry
-from ..types import Array2d, Padded, Ragged
+from ..types import Array1d, Array2d, Padded, Ragged
 
 
 ValT = TypeVar("ValT", bound=Array2d)
@@ -68,7 +68,7 @@ def _list_forward(
 ) -> Tuple[List[Array2d], Callable]:
     layer = model.layers[0]
     pad = model.get_attr("pad")
-    lengths = layer.ops.asarray([len(seq) for seq in Xs])
+    lengths: Array1d = layer.ops.asarray([len(seq) for seq in Xs])
     Xf = layer.ops.flatten(Xs, pad=pad)
     Yf, get_dXf = layer(Xf, is_train)
 

--- a/thinc/layers/with_flatten.py
+++ b/thinc/layers/with_flatten.py
@@ -22,7 +22,8 @@ def forward(
     Xflat: Sequence[Any] = _flatten(Xnest)
     Yflat, backprop_layer = layer(Xflat, is_train)
     # Get the split points. We want n-1 splits for n items.
-    splits = layer.ops.asarray([len(x) for x in Xnest[:-1]], dtype="i").cumsum()
+    arr: Array2d = layer.ops.asarray([len(x) for x in Xnest[:-1]], dtype="i")
+    splits = arr.cumsum()
     Ynest = layer.ops.xp.split(Yflat, splits, axis=-1)
 
     def backprop(dYnest: OutT) -> InT:

--- a/thinc/layers/with_padded.py
+++ b/thinc/layers/with_padded.py
@@ -56,8 +56,8 @@ def _get_padded(model: Model, seq: SeqT) -> Padded:
     elif _is_padded_data(seq):
         return Padded(*seq)  # type: ignore
     elif is_xp_array(seq):
-        size_at_t = model.ops.asarray([seq.shape[1]] * seq.shape[0], dtype="i")
-        lengths = model.ops.asarray([seq.shape[0]] * seq.shape[1], dtype="i")
+        size_at_t: Array1d = model.ops.asarray([seq.shape[1]] * seq.shape[0], dtype="i")
+        lengths: Array1d = model.ops.asarray([seq.shape[0]] * seq.shape[1], dtype="i")
         indices = model.ops.xp.arange(seq.shape[1])
         return Padded(cast(Array3d, seq), size_at_t, lengths, indices)
     else:

--- a/thinc/layers/with_ragged.py
+++ b/thinc/layers/with_ragged.py
@@ -50,7 +50,7 @@ def _get_ragged(model: Model, seq: SeqT) -> Ragged:
         return seq
     elif isinstance(seq, Padded):
         lists = model.ops.padded2list(seq)
-        lengths = model.ops.asarray([len(x) for x in lists], dtype="i")
+        lengths: Array1d = model.ops.asarray([len(x) for x in lists], dtype="i")
         return Ragged(model.ops.flatten(lists), lengths)
     elif _is_ragged_data(seq):
         return Ragged(*cast(RaggedData, seq))
@@ -84,7 +84,7 @@ def _padded_forward(
     Xs = padded2list(Xp)
     # Bit annoying here: padded is in a different order, so we need to make new
     # lengths.
-    lengths = layer.ops.asarray([len(x) for x in Xs], dtype="i")
+    lengths: Array1d = layer.ops.asarray([len(x) for x in Xs], dtype="i")
     Yr, get_dXr = layer(Ragged(flatten(Xs), lengths), is_train)
 
     def backprop(dYp: Padded):
@@ -102,7 +102,7 @@ def _list_forward(
     flatten = layer.ops.flatten
     unflatten = layer.ops.unflatten
 
-    lengths = layer.ops.asarray([len(x) for x in Xs], dtype="i")
+    lengths: Array1d = layer.ops.asarray([len(x) for x in Xs], dtype="i")
     Yr, get_dXr = layer(Ragged(flatten(Xs), lengths), is_train)
 
     def backprop(dYs: List[Array2d]) -> List[Array2d]:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -38,7 +38,7 @@ class Model(Generic[InT, OutT]):
     _thread_local = create_thread_local({"operators": {}}, ModelThreadState)
 
     name: str
-    ops: Union[NumpyOps, CupyOps]  # TODO: This is wrong, should be Ops
+    ops: Ops
     id: int
     _func: Callable
     _init: Callable


### PR DESCRIPTION
`Model.ops` was incorrectly typed as `Union[NumpyOps, CupyOps]`, which meant that a variety of type issues went unnoticed.

## TODO

- [ ] fix maxout