### PR TITLE
Model failure repros

### DIFF
--- a/model_fails.py
+++ b/model_fails.py
@@ -1,0 +1,70 @@
+from typing import List
+
+from thinc.api import (  # noqa
+    Adam,
+    Dropout,
+    Embed,
+    LayerNorm,
+    Maxout,
+    Model,
+    Ops,
+    ParametricAttention,
+    ReLu,
+    Softmax,
+    chain,
+    list2array,
+    list2padded,
+    list2ragged,
+    padded2list,
+    ragged2list,
+    reduce_mean,
+    reduce_sum,
+    to_categorical,
+    with_array,
+    with_list,
+    with_ragged,
+)
+from thinc.types import Array2d
+
+
+def test_model(model):
+
+    # fmt: off
+    X = [
+        model.ops.asarray([
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        ], dtype="f")
+    ]
+    Y = [2]
+    # fmt: on
+    model.initialize(X, model.ops.asarray(Y))
+    model.predict(X)
+
+
+if __name__ == "__main__":
+
+    def working_baseline() -> Model[List[Array2d], Array2d]:
+        """This model works"""
+        return chain(list2ragged(), reduce_sum(), ReLu(12, dropout=0.5), ReLu(1))
+
+    test_model(working_baseline())
+
+    def adding_attention() -> Model[List[Array2d], Array2d]:
+        """This model works if you comment out the attention layer.
+
+        With the attention layer you get:
+        > AttributeError: 'numpy.ndarray' object has no attribute 'lengths'
+        """
+        return chain(
+            list2ragged(),
+            reduce_sum(),
+            ReLu(12, dropout=0.5),
+            # ERROR: Why can't I attach a ReLu to an attention layer?
+            ParametricAttention(12),
+            ReLu(1),
+        )
+
+    test_model(adding_attention())


### PR DESCRIPTION
Add a "model_fails.py" script in the root to minimally reproduce some failure cases I ran into while working on the mathy demo