### PR TITLE
Replace thread locals with contextvars

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ numpy>=1.7.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"
 typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"
+contextvars>=2.4,<3; python_version < "3.7"
 # Development dependencies
 cython>=0.25.0
 hypothesis>=3.27.0,<5.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"
     typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"
+    contextvars>=2.4,<3; python_version < "3.7"
 
 [options.extras_require]
 cuda =

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -221,13 +221,13 @@ def _overload_plus(operator, sleep):
         else:
             value = m1 * m2
     assert value == "ab"
-    assert Model._thread_local.operators == {}
+    assert Model._context_operators.get() == {}
 
 
 def test_nested_operator_contexts():
     m1 = create_model(name="a")
     m2 = create_model(name="b")
-    assert Model._thread_local.operators == {}
+    assert Model._context_operators.get() == {}
     with Model.define_operators({"+": lambda a, b: a.name + b.name}):
         value = m1 + m2
         with pytest.raises(TypeError):
@@ -247,7 +247,7 @@ def test_nested_operator_contexts():
         with pytest.raises(TypeError):
             value = m1 * m2
     assert value == "ab"
-    assert Model._thread_local.operators == {}
+    assert Model._context_operators.get() == {}
 
 
 @pytest.mark.parametrize("op", "+ - * @ / // % ** << >> & ^ |".split())
@@ -329,7 +329,7 @@ def test_all_operators(op):
         else:
             with pytest.raises(TypeError):
                 value = m1 | m2  # noqa: F841
-    assert Model._thread_local.operators == {}
+    assert Model._context_operators.get()
 
 
 def test_unique_id_multithreading():

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -329,7 +329,7 @@ def test_all_operators(op):
         else:
             with pytest.raises(TypeError):
                 value = m1 | m2  # noqa: F841
-    assert Model._context_operators.get()
+    assert Model._context_operators.get() == {}
 
 
 def test_unique_id_multithreading():

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -1,7 +1,6 @@
 from typing import Any, Union, Sequence, cast, Dict, Optional, Callable, TypeVar
-from typing import Type, List
+from typing import List
 import numpy
-import threading
 import random
 import functools
 from wasabi import table
@@ -59,15 +58,6 @@ def fix_random_seed(seed: int = 0) -> None:  # pragma: no cover
     numpy.random.seed(seed)
     if cupy is not None:
         cupy.random.seed(seed)
-
-
-def create_thread_local(
-    attrs: Dict[str, Any], local_class: Type[threading.local] = threading.local
-):
-    obj = local_class()
-    for name, value in attrs.items():
-        setattr(obj, name, value)
-    return obj
 
 
 def is_xp_array(obj: Any) -> bool:


### PR DESCRIPTION
:arrow_up: Replace thread locals with contextvars.

This would allow using Thinc in scenarios that are not purely thread-based, like `asyncio` (e.g. in FastAPI apps). While still working the same for thread-based scenarios.

From PEP 567: https://www.python.org/dev/peps/pep-0567/#backwards-compatibility

> This proposal preserves 100% backwards compatibility.
> 
> Libraries that use threading.local() to store context-related values, currently work correctly only for synchronous code. Switching them to use the proposed API will keep their behavior for synchronous code unmodified, but will automatically enable support for asynchronous code.

---

Python docs: https://docs.python.org/3/library/contextvars.html
PEP 567 "Converting code that uses threading.local()": https://www.python.org/dev/peps/pep-0567/#converting-code-that-uses-threading-local