### PR TITLE
Support dropout in embedding layers

### DIFF
--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -14,10 +14,7 @@ class Ops:
     xp: Xp = numpy
 
     def __init__(
-        self,
-        device_type: DeviceTypes = "cpu",
-        device_id: int = -1,
-        **kwargs
+        self, device_type: DeviceTypes = "cpu", device_id: int = -1, **kwargs
     ) -> None:
         self.device_type = device_type
         self.device_id = device_id

--- a/thinc/initializers.py
+++ b/thinc/initializers.py
@@ -15,6 +15,7 @@ from .util import partial
 # It's especially helpful for JAX, which has a pretty intrincate PRNG scheme I
 # haven't figured out yet.
 
+
 def glorot_uniform_init(ops: Ops, shape: Shape) -> Array:
     scale = numpy.sqrt(6.0 / (shape[0] + shape[1]))
     return ops.asarray(numpy.random.uniform(-scale, scale, shape), dtype="f")

--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Optional
+from typing import Dict, Callable, Tuple, Optional, Any
 
 from ..model import Model
 from ..config import registry
@@ -21,7 +21,7 @@ def Embed(
     dropout: Optional[float] = None 
 ) -> Model[InT, OutT]:
     """Map integers to vectors, using a fixed-size lookup table."""
-    attrs = {"column": column}
+    attrs: Dict[str, Any] = {"column": column}
     if dropout is not None:
         attrs["dropout_rate"] = dropout
     return Model(

--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -47,7 +47,6 @@ def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Ca
         ids = ids[:, column]
     ids *= ids < nV
     output = vectors[ids.astype("i")]
-
     drop_mask = model.ops.get_dropout_mask((vectors.shape[1],), dropout)
     output *= drop_mask
 

--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -18,7 +18,7 @@ def Embed(
     *,
     column: int = 0,
     initializer: Callable = uniform_init,
-    dropout: Optional[float] = None 
+    dropout: Optional[float] = None
 ) -> Model[InT, OutT]:
     """Map integers to vectors, using a fixed-size lookup table."""
     attrs: Dict[str, Any] = {"column": column}

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -19,14 +19,18 @@ def HashEmbed(
     seed: Optional[int] = None,
     column: int = 0,
     initializer: Callable = uniform_init,
+    dropout: Optional[float]=0.0
 ) -> Model[InT, OutT]:
+    attrs = {"column": column, "seed": seed}
+    if dropout is not None:
+        attrs["dropout_rate"] = dropout
     model: Model[InT, OutT] = Model(
         "hashembed",
         forward,
         init=partial(init, initializer),
         params={"E": None},
         dims={"nO": nO, "nV": nV, "nI": None},
-        attrs={"seed": seed, "column": column},
+        attrs=attrs,
     )
     if seed is None:
         model.set_attr("seed", model.id)
@@ -34,6 +38,8 @@ def HashEmbed(
 
 
 def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Callable]:
+    if model.has_attr("dropout_rate"):
+        dropout = model.get_attr("dropout_rate")
     E = model.get_param("E")
     seed = model.get_attr("seed")
     column = model.get_attr("column")
@@ -42,19 +48,22 @@ def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Ca
     if ids.ndim >= 2:
         ids = model.ops.as_contig(ids[:, column], dtype="uint64")
     keys = model.ops.hash(ids, seed) % nV
-    output = E[keys].sum(axis=1)
+    vectors = E[keys].sum(axis=1)
+    drop_mask = model.ops.get_dropout_mask((vectors.shape[1],), dropout)
+    vectors *= drop_mask
 
-    def backprop(d_output: OutT) -> InT:
+    def backprop(d_vectors: OutT) -> InT:
+        d_vectors *= drop_mask
         keys = model.ops.hash(ids, seed) % nV
         dE = model.ops.alloc_f2d(*E.shape)
         keys = model.ops.as_contig(keys.T, dtype="i")
         for i in range(keys.shape[0]):
-            model.ops.scatter_add(dE, keys[i], d_output)
+            model.ops.scatter_add(dE, keys[i], d_vectors)
         model.inc_grad("E", dE)
         dX: OutT = model.ops.alloc(input_shape, dtype="i")
         return dX
 
-    return output, backprop
+    return vectors, backprop
 
 
 def init(

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -40,6 +40,8 @@ def HashEmbed(
 def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Callable]:
     if model.has_attr("dropout_rate"):
         dropout = model.get_attr("dropout_rate")
+    else:
+        dropout = None
     E = model.get_param("E")
     seed = model.get_attr("seed")
     column = model.get_attr("column")

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -19,7 +19,7 @@ def HashEmbed(
     seed: Optional[int] = None,
     column: int = 0,
     initializer: Callable = uniform_init,
-    dropout: Optional[float]=0.0
+    dropout: Optional[float] = None
 ) -> Model[InT, OutT]:
     attrs: Dict[str, Any] = {"column": column, "seed": seed}
     if dropout is not None:

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Optional
+from typing import Callable, Dict, Tuple, Optional, Any
 
 from ..model import Model
 from ..config import registry
@@ -21,7 +21,7 @@ def HashEmbed(
     initializer: Callable = uniform_init,
     dropout: Optional[float]=0.0
 ) -> Model[InT, OutT]:
-    attrs = {"column": column, "seed": seed}
+    attrs: Dict[str, Any] = {"column": column, "seed": seed}
     if dropout is not None:
         attrs["dropout_rate"] = dropout
     model: Model[InT, OutT] = Model(

--- a/thinc/layers/staticvectors.py
+++ b/thinc/layers/staticvectors.py
@@ -60,23 +60,9 @@ def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Ca
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
 ) -> Model[InT, OutT]:
-    vector_table = _get_vectors(model.ops, model.get_attr("lang"))
+    vector_table = model.get_attr("vectors").data
     model.set_dim("nV", vector_table.shape[0])
     model.set_dim("nM", vector_table.shape[1])
     W = model.ops.alloc_f2d(model.get_dim("nO"), model.get_dim("nM"))
     model.set_param("W", W)
     return model
-
-
-def _get_vectors(ops: Ops, lang: str) -> Array:
-    key = (ops.device_type, lang)
-    if key not in context_vectors.get():
-        nlp = load_spacy(lang)
-        context_vectors.get()[key] = ops.asarray(nlp.vocab.vectors.data)
-    return context_vectors.get()[key]
-
-
-def load_spacy(lang: str, **kwargs):
-    import spacy
-
-    return spacy.load(lang, **kwargs)

--- a/thinc/layers/staticvectors.py
+++ b/thinc/layers/staticvectors.py
@@ -1,8 +1,7 @@
 from typing import Tuple, Callable, Optional, cast
 
-from ..types import Array, Array2d, Unserializable
+from ..types import Array2d, Unserializable
 from ..model import Model
-from ..backends import Ops
 from ..config import registry
 from contextvars import ContextVar
 
@@ -14,11 +13,16 @@ context_vectors: ContextVar[dict] = ContextVar("context_vectors", default={})
 
 
 @registry.layers("StaticVectors.v0")
-def StaticVectors(nO: Optional[int]=None, vectors: Optional[Array2d]=None, *, column: int = 0, dropout: Optional[float]=None) -> Model[InT, OutT]:
+def StaticVectors(
+    nO: Optional[int] = None,
+    vectors: Optional[Array2d] = None,
+    *,
+    column: int = 0,
+    dropout: Optional[float] = None
+) -> Model[InT, OutT]:
     attrs = {"column": column, "vectors": Unserializable(vectors)}
     if dropout is not None:
         attrs["dropout_rate"] = dropout
- 
     return Model(
         "static_vectors",
         forward,

--- a/thinc/layers/staticvectors.py
+++ b/thinc/layers/staticvectors.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Callable, Optional, cast
 
-from ..types import Array, Array2d
+from ..types import Array, Array2d, Unserializable
 from ..model import Model
 from ..backends import Ops
 from ..config import registry
@@ -12,14 +12,10 @@ OutT = Array2d
 
 context_vectors: ContextVar[dict] = ContextVar("context_vectors", default={})
 
-class VectorsTable:
-    def __init__(self, data):
-        self.data = data
-
 
 @registry.layers("StaticVectors.v0")
-def StaticVectors(nO: Optional[int]=None, vectors: Optional[Array2d]=None, *, column: int = 0) -> Model[InT, OutT]:
-    attrs = {"column": column, "vectors": vectors}
+def StaticVectors(nO: Optional[int]=None, vectors: Optional[Array2d]=None, *, column: int = 0, dropout: Optional[float]=None) -> Model[InT, OutT]:
+    attrs = {"column": column, "vectors": Unserializable(vectors)}
     if dropout is not None:
         attrs["dropout_rate"] = dropout
  
@@ -28,7 +24,7 @@ def StaticVectors(nO: Optional[int]=None, vectors: Optional[Array2d]=None, *, co
         forward,
         init=init,
         params={"W": None},
-        attrs=VectorsTable(vectors),
+        attrs=attrs,
         dims={"nM": None, "nV": None, "nO": nO},
     )
 

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -732,13 +732,15 @@ def change_attr_values(model: _ModelT, mapping: Dict[str, Dict[str, Any]]) -> _M
     return model
 
 
-def set_dropout_rate(model: _ModelT, drop: float, attrs={"dropout": "rate"}) -> _ModelT:
-    """Walk over the model's nodes, setting the dropout rate. Dropout nodes are
-    identified by name. You can configure the name-to-attribute mapping using
-    the `attrs` dict.
+def set_dropout_rate(model: _ModelT, drop: float, attrs=["dropout_rate"]) -> _ModelT:
+    """Walk over the model's nodes, setting the dropout rate. You can specify
+    one or more attribute names, by default it looks for ["dropout_rate"].
     """
-    mapping = {name: {attr: drop} for name, attr in attrs.items()}
-    return change_attr_values(model, mapping)
+    for node in model.walk():
+        for attr in attrs:
+            if node.has_attr(attr):
+                node.set_attr(attr, drop)
+    return model
 
 
 __all__ = [

--- a/thinc/optimizers.py
+++ b/thinc/optimizers.py
@@ -344,7 +344,7 @@ class Optimizer(object):
         b2 = self.b2
         fix1 = 1.0 - (b1 ** nr_upd)
         fix2 = 1.0 - (b2 ** nr_upd)
-        lr = self.learn_rate * fix2**0.5 / fix1
+        lr = self.learn_rate * fix2 ** 0.5 / fix1
         eps = self.eps
         # needs to be 1D going into the adam function
         weights_1D, gradient_1D, mom1, mom2 = self.ops.adam(

--- a/thinc/tests/layers/test_lstm.py
+++ b/thinc/tests/layers/test_lstm.py
@@ -61,7 +61,6 @@ def test_LSTM_init_with_sizes(nO, nI):
             assert initial_cells.shape == (nO,)
 
 
-#@pytest.mark.xfail(reason="validation, TODO: fix")
 def test_LSTM_fwd_bwd_shapes(nO, nI):
     nO = 1
     nI = 2

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -169,9 +169,9 @@ def test_change_attr_values(model_with_no_args):
 def test_set_dropout(model_with_no_args):
     model = model_with_no_args
     model.name = "dropout"
-    model.set_attr("rate", 0.0)
+    model.set_attr("dropout_rate", 0.0)
     set_dropout_rate(model, 0.2)
-    assert model.get_attr("rate") == 0.2
+    assert model.get_attr("dropout_rate") == 0.2
 
 
 def test_bind_plus():

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -718,4 +718,5 @@ class ArgsKwargs:
 @dataclass
 class Unserializable:
     """Wrap a value to prevent it from being serialized by msgpack."""
+
     data: Any

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -713,3 +713,9 @@ class ArgsKwargs:
         """Yield enumerate(self.args), followed by self.kwargs.items()"""
         yield from enumerate(self.args)
         yield from self.kwargs.items()
+
+
+@dataclass
+class Unserializable:
+    """Wrap a value to prevent it from being serialized by msgpack."""
+    data: Any


### PR DESCRIPTION
* Add `dropout_rate` attr to `HashEmbed`, `Embed` and `StaticEmbed` layers. Dropout is applied by creating one dropout mask vector for the whole batch, and applying it.

* Change `Dropout` layer to use the attr name `dropout_rate`, rather than `rate`.

* Change the `set_dropout_rate` helper to just look for the attr name, rather than the nodes.

* Remove traces of spaCy from the `StaticVectors` table. Instead expect vectors as an array, and wrap it in an arbitrary object to prevent msgpack serialization.