### PR TITLE
Add with_debug layer

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -30,6 +30,7 @@ from .layers import residual, uniqued, siamese, list2ragged, ragged2list
 from .layers import with_array, with_padded, with_list, with_ragged, with_flatten
 from .layers import with_reshape, with_getitem, strings2arrays, list2array
 from .layers import list2ragged, ragged2list, list2padded, padded2list, remap_ids
+from .layers import with_debug
 
 from .layers import reduce_max, reduce_mean, reduce_sum
 

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -51,6 +51,7 @@ from .with_list import with_list
 from .with_ragged import with_ragged
 from .with_reshape import with_reshape
 from .with_getitem import with_getitem
+from .with_debug import with_debug
 
 
 __all__ = [
@@ -98,5 +99,6 @@ __all__ = [
     "with_ragged",
     "with_padded",
     "with_flatten",
+    "with_debug",
     "remap_ids",
 ]

--- a/thinc/layers/with_debug.py
+++ b/thinc/layers/with_debug.py
@@ -1,5 +1,6 @@
 from typing import Optional, Callable, Any, Tuple
-from thinc.api import Model
+
+from ..model import Model
 
 
 do_nothing = lambda *args, **kwargs: None

--- a/thinc/layers/with_debug.py
+++ b/thinc/layers/with_debug.py
@@ -1,0 +1,36 @@
+from typing import Optional, Callable, Any, Tuple
+from thinc.api import Model
+
+
+def with_debug(
+    layer: Model,
+    name: Optional[str] = None,
+    *,
+    on_init: Optional[Callable[[Model, Any, Any], None]] = None,
+    on_forward: Optional[Callable[[Model, Any, bool], None]] = None,
+    on_backprop: Optional[Callable[[Any], None]] = None,
+):
+    """Debugging layer that wraps any layer and allows executing callbacks
+    during the forward pass, backward pass and initialization. The callbacks
+    will receive the same arguments as the functions they're called in.
+    """
+    name = layer.name if name is None else name
+
+    def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
+        if on_forward:
+            on_forward(model, X, is_train)
+        layer_Y, layer_callback = layer(X, is_train=is_train)
+
+        def backprop(dY: Any) -> Any:
+            if on_backprop:
+                on_backprop(dY)
+            return layer_callback(dY)
+
+        return layer_Y, backprop
+
+    def init(model: Model, X: Any, Y: Any) -> Model:
+        if on_init:
+            on_init(model, X, Y)
+        return layer.initialize(X, Y)
+
+    return Model(f"debug:{name}", forward, init=init)

--- a/thinc/layers/with_debug.py
+++ b/thinc/layers/with_debug.py
@@ -2,13 +2,16 @@ from typing import Optional, Callable, Any, Tuple
 from thinc.api import Model
 
 
+do_nothing = lambda *args, **kwargs: None
+
+
 def with_debug(
     layer: Model,
     name: Optional[str] = None,
     *,
-    on_init: Optional[Callable[[Model, Any, Any], None]] = None,
-    on_forward: Optional[Callable[[Model, Any, bool], None]] = None,
-    on_backprop: Optional[Callable[[Any], None]] = None,
+    on_init: Callable[[Model, Any, Any], None] = do_nothing,
+    on_forward: Callable[[Model, Any, bool], None] = do_nothing,
+    on_backprop: Callable[[Any], None] = do_nothing,
 ):
     """Debugging layer that wraps any layer and allows executing callbacks
     during the forward pass, backward pass and initialization. The callbacks
@@ -17,20 +20,17 @@ def with_debug(
     name = layer.name if name is None else name
 
     def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
-        if on_forward:
-            on_forward(model, X, is_train)
+        on_forward(model, X, is_train)
         layer_Y, layer_callback = layer(X, is_train=is_train)
 
         def backprop(dY: Any) -> Any:
-            if on_backprop:
-                on_backprop(dY)
+            on_backprop(dY)
             return layer_callback(dY)
 
         return layer_Y, backprop
 
     def init(model: Model, X: Any, Y: Any) -> Model:
-        if on_init:
-            on_init(model, X, Y)
+        on_init(model, X, Y)
         return layer.initialize(X, Y)
 
     return Model(f"debug:{name}", forward, init=init)

--- a/thinc/tests/layers/test_with_debug.py
+++ b/thinc/tests/layers/test_with_debug.py
@@ -1,0 +1,25 @@
+from mock import MagicMock
+from thinc.api import with_debug, Linear
+
+
+def test_with_debug():
+    on_init = MagicMock()
+    on_forward = MagicMock()
+    on_backprop = MagicMock()
+    model = with_debug(
+        Linear(), on_init=on_init, on_forward=on_forward, on_backprop=on_backprop
+    )
+    on_init.assert_not_called()
+    on_forward.assert_not_called()
+    on_backprop.assert_not_called()
+    X = model.ops.alloc_f2d(1, 1)
+    Y = model.ops.alloc_f2d(1, 1)
+    model.initialize(X=X, Y=Y)
+    on_init.assert_called_once_with(model, X, Y)
+    on_forward.assert_not_called()
+    on_backprop.assert_not_called()
+    Yh, backprop = model(X, is_train=True)
+    on_forward.assert_called_once_with(model, X, True)
+    on_backprop.assert_not_called()
+    backprop(Y)
+    on_backprop.assert_called_once_with(Y)


### PR DESCRIPTION
Wraps any layer and can be called with 3 optional callbacks: `on_init`, `on_forward` and `on_backprop`, which receive the same arguments as the functions they're called in. Can be used to log stuff, inspect inputs/outputs, benchmark etc.