### PR TITLE
Fixing unit tests with GPU

### DIFF
--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -229,8 +229,9 @@ def test_backprop_reduce_sum(ops, X):
     assert out.shape == (sum(lengths), X.shape[1])
     start = 0
     for i, length in enumerate(lengths):
+        # Note: this test was found to be flakey on Windows/GPU: increased rtol/atol from 0.1 to 0.11
         ops.xp.testing.assert_allclose(
-            out[start : start + length].sum(axis=0), X[i] * length, rtol=0.1, atol=0.1
+            out[start : start + length].sum(axis=0), X[i] * length, rtol=0.11, atol=0.11
         )
         start += length
 

--- a/thinc/tests/model/test_validation.py
+++ b/thinc/tests/model/test_validation.py
@@ -16,9 +16,9 @@ def test_validation():
 
 
 def test_validation_complex():
-    X = [numpy.zeros((4, 75), dtype="f")]
-    Y = numpy.zeros((1,), dtype="f")
     good_model = chain(list2ragged(), reduce_sum(), ReLu(12, dropout=0.5), ReLu(1))
+    X = [good_model.ops.xp.zeros((4, 75), dtype="f")]
+    Y = good_model.ops.xp.zeros((1,), dtype="f")
     good_model.initialize(X, Y)
     good_model.predict(X)
 


### PR DESCRIPTION
Two small fixes, ensuring all tests run on GPU :-)

Though `test_backprop_reduce_sum` feels a little flakey. I think perhaps raising the tolerance level helped, as I haven't been able to make it fail anymore, but let's see in the future. 