### PR TITLE
Simplify Model attrs

### DIFF
--- a/examples/01_intro_model_definition_methods.ipynb
+++ b/examples/01_intro_model_definition_methods.ipynb
@@ -333,8 +333,8 @@
    "source": [
     "dim = model.get_dim(\"nO\")\n",
     "W = model.get_param(\"W\")\n",
-    "model.set_attr(\"hello\", \"world\")\n",
-    "assert model.get_attr(\"hello\") == \"world\""
+    "model.attrs[\"hello\"] = \"world\"\n",
+    "model.attrs.get(\"foo\", \"bar\")"
    ]
   },
   {

--- a/examples/02_transformers_tagger_bert.ipynb
+++ b/examples/02_transformers_tagger_bert.ipynb
@@ -126,7 +126,7 @@
     "\n",
     "> 💡 Since we're adding type hints everywhere (and Thinc is fully typed, too), you can run your code through [`mypy`](https://mypy.readthedocs.io/en/stable/) to find type errors and inconsistencies. If you're using an editor like Visual Studio Code, you can enable `mypy` linting and type errors will be highlighted in real time as you write code.\n",
     "\n",
-    "To wrap the tokenizer, we register a new function that returns a Thinc `Model`. The function takes the name of the pretrained weights (e.g. `\"bert-base-multilingual-cased\"`) as an argument that can later be provided via the config. After loading the `AutoTokenizer`, we can stash it in the attributes. This lets us access it at any point later on via `model.get_attr(\"tokenizer\")`."
+    "To wrap the tokenizer, we register a new function that returns a Thinc `Model`. The function takes the name of the pretrained weights (e.g. `\"bert-base-multilingual-cased\"`) as an argument that can later be provided via the config. After loading the `AutoTokenizer`, we can stash it in the attributes. This lets us access it at any point later on via `model.attrs[\"tokenizer\"]`."
    ]
   },
   {
@@ -142,7 +142,7 @@
     "@thinc.registry.layers(\"transformers_tokenizer.v0\")\n",
     "def TransformersTokenizer(name: str) -> Model[List[List[str]], TokensPlus]:\n",
     "    def forward(model, texts: List[List[str]], is_train: bool):\n",
-    "        tokenizer = model.get_attr(\"tokenizer\")\n",
+    "        tokenizer = model.attrs[\"tokenizer\"]\n",
     "        token_data = tokenizer.batch_encode_plus(\n",
     "            [(text, None) for text in texts],\n",
     "            add_special_tokens=True,\n",

--- a/examples/transformers_tagger.py
+++ b/examples/transformers_tagger.py
@@ -121,7 +121,7 @@ def TransformersTokenizer(name: str) -> Model[List[List[str]], TokensPlus]:
     def forward(
         model, texts: List[List[str]], is_train: bool
     ) -> Tuple[TokensPlus, Callable]:
-        tokenizer = model.get_attr("tokenizer")
+        tokenizer = model.attrs["tokenizer"]
         token_data = tokenizer.batch_encode_plus(
             [(text, None) for text in texts],
             add_special_tokens=True,

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -324,7 +324,7 @@ class Ops:
             unpadded[indices[i]] = data[i, : lengths[i]]
         return cast(List[Array2d], unpadded)
 
-    def get_dropout_mask(self, shape: Shape, drop: float) -> Array:
+    def get_dropout_mask(self, shape: Shape, drop: Optional[float]) -> Array:
         """Create a random mask for applying dropout, with a certain percent of
         the mask (defined by `drop`) will contain zeros. The neurons at those
         positions will be deactivated during training, resulting in a more

--- a/thinc/layers/dropout.py
+++ b/thinc/layers/dropout.py
@@ -24,8 +24,8 @@ def Dropout(rate: float = 0.0) -> Model[InT, InT]:
 # I've relaxed the types for now, but it'd be good to understand what's wrong
 # here.
 def forward(model: Model, X, is_train: bool) -> Tuple[Any, Callable]:
-    rate = model.get_attr("rate")
-    is_enabled = model.get_attr("is_enabled")
+    rate = model.attrs["rate"]
+    is_enabled = model.attrs["is_enabled"]
     if rate == 0 or not is_enabled:
         return X, lambda dY: dY
     elif isinstance(X, Ragged):
@@ -41,7 +41,7 @@ def forward(model: Model, X, is_train: bool) -> Tuple[Any, Callable]:
 def _dropout_array(
     model: Model[ArrayT, ArrayT], X: ArrayT, is_train: bool
 ) -> Tuple[ArrayT, Callable]:
-    rate = model.get_attr("rate")
+    rate = model.attrs["rate"]
     mask = model.ops.get_dropout_mask(X.shape, rate)
 
     def backprop(dY: ArrayT) -> ArrayT:
@@ -54,7 +54,7 @@ def _dropout_padded(
     model: Model, Xp: Padded, is_train: bool
 ) -> Tuple[Padded, Callable]:
     X = Xp.data
-    mask = model.ops.get_dropout_mask(X.shape, model.get_attr("rate"))
+    mask = model.ops.get_dropout_mask(X.shape, model.attrs["rate"])
     Y = X * mask
 
     def backprop(dYp: Padded) -> Padded:
@@ -68,7 +68,7 @@ def _dropout_ragged(
 ) -> Tuple[Ragged, Callable]:
     X = Xr.data
     lengths = Xr.lengths
-    mask = model.ops.get_dropout_mask(X.shape, model.get_attr("rate"))
+    mask = model.ops.get_dropout_mask(X.shape, model.attrs["rate"])
     Y = X * mask
 
     def backprop(dYr: Ragged) -> Ragged:
@@ -80,7 +80,7 @@ def _dropout_ragged(
 def _dropout_lists(
     model: Model[ArrayT, ArrayT], Xs: List[ArrayT], is_train: bool
 ) -> Tuple[List[ArrayT], Callable]:
-    rate = model.get_attr("rate")
+    rate = model.attrs["rate"]
     masks = [model.ops.get_dropout_mask(X.shape, rate) for X in Xs]
     Ys = [X * mask for X, mask in zip(Xs, masks)]
 

--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -37,11 +37,8 @@ def Embed(
 def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Callable]:
     nV = model.get_dim("nV")
     vectors = model.get_param("E")
-    column = model.get_attr("column")
-    if model.has_attr("dropout_rate"):
-        dropout = model.get_attr("dropout_rate")
-    else:
-        dropout = None
+    column = model.attrs["column"]
+    dropout = model.attrs.get("dropout_rate")
     input_shape = tuple(ids.shape)
     if ids.ndim == 2:
         ids = ids[:, column]

--- a/thinc/layers/expand_window.py
+++ b/thinc/layers/expand_window.py
@@ -18,7 +18,7 @@ def expand_window(window_size: int = 1) -> Model[InT, OutT]:
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    nW = model.get_attr("window_size")
+    nW = model.attrs["window_size"]
     Y = model.ops.seq2col(X, nW)
 
     def backprop(dY: OutT) -> InT:

--- a/thinc/layers/featureextractor.py
+++ b/thinc/layers/featureextractor.py
@@ -17,7 +17,7 @@ def FeatureExtractor(columns: List[Union[int, str]]) -> Model[InT, OutT]:
 def forward(
     model: Model[InT, OutT], docs: InT, is_train: bool
 ) -> Tuple[OutT, Callable]:
-    columns = model.get_attr("columns")
+    columns = model.attrs["columns"]
     features: OutT = []
     for doc in docs:
         if hasattr(doc, "to_array"):

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -33,18 +33,15 @@ def HashEmbed(
         attrs=attrs,
     )
     if seed is None:
-        model.set_attr("seed", model.id)
+        model.attrs["seed"] = model.id
     return model
 
 
 def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    if model.has_attr("dropout_rate"):
-        dropout = model.get_attr("dropout_rate")
-    else:
-        dropout = None
+    dropout = model.attrs.get("dropout_rate")
     E = model.get_param("E")
-    seed = model.get_attr("seed")
-    column = model.get_attr("column")
+    seed = model.attrs["seed"]
+    column = model.attrs["column"]
     nV = E.shape[0]
     input_shape = tuple(ids.shape)
     if ids.ndim >= 2:

--- a/thinc/layers/multisoftmax.py
+++ b/thinc/layers/multisoftmax.py
@@ -28,7 +28,7 @@ def MultiSoftmax(nOs: Tuple[int, ...], nI: Optional[int] = None) -> Model[InT, O
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    nOs = model.get_attr("nOs")
+    nOs = model.attrs["nOs"]
     W = cast(Array2d, model.get_param("W"))
     b = model.get_param("b")
 

--- a/thinc/layers/pytorchwrapper.py
+++ b/thinc/layers/pytorchwrapper.py
@@ -72,8 +72,8 @@ def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
     """Return the output of the wrapped PyTorch model for the given input,
     along with a callback to handle the backward pass.
     """
-    convert_inputs = model.get_attr("convert_inputs")
-    convert_outputs = model.get_attr("convert_outputs")
+    convert_inputs = model.attrs["convert_inputs"]
+    convert_outputs = model.attrs["convert_outputs"]
 
     Xtorch, get_dX = convert_inputs(model, X, is_train)
     Ytorch, torch_backprop = model.shims[0](Xtorch, is_train)

--- a/thinc/layers/remap_ids.py
+++ b/thinc/layers/remap_ids.py
@@ -28,9 +28,9 @@ def remap_ids(
 def forward(
     model: Model[InT, OutT], inputs: InT, is_train: bool
 ) -> Tuple[OutT, Callable]:
-    table = model.get_attr("mapping_table")
-    default = model.get_attr("default")
-    dtype = model.get_attr("dtype")
+    table = model.attrs["mapping_table"]
+    default = model.attrs["default"]
+    dtype = model.attrs["dtype"]
     values = [table.get(x, default) for x in inputs]
     arr: Array = model.ops.asarray(values, dtype=dtype)
     output: Array2d = arr.reshape((-1, 1))

--- a/thinc/layers/staticvectors.py
+++ b/thinc/layers/staticvectors.py
@@ -34,13 +34,10 @@ def StaticVectors(
 
 
 def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    if model.has_attr("dropout_rate"):
-        dropout = model.get_attr("dropout_rate")
-    else:
-        dropout = None
-    column = model.get_attr("column")
+    dropout = model.attrs.get("dropout_rate")
+    column = model.attrs["column"]
     W = cast(Array2d, model.get_param("W"))
-    vector_table = model.get_attr("vectors").data
+    vector_table = model.attrs["vectors"].data
     if ids.ndim >= 2:
         ids = model.ops.as_contig(ids[:, column])
     vectors = vector_table[ids * (ids < vector_table.shape[0])]
@@ -60,7 +57,7 @@ def forward(model: Model[InT, OutT], ids: InT, is_train: bool) -> Tuple[OutT, Ca
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
 ) -> Model[InT, OutT]:
-    vector_table = model.get_attr("vectors").data
+    vector_table = model.attrs["vectors"].data
     model.set_dim("nV", vector_table.shape[0])
     model.set_dim("nM", vector_table.shape[1])
     W = model.ops.alloc_f2d(model.get_dim("nO"), model.get_dim("nM"))

--- a/thinc/layers/tensorflowwrapper.py
+++ b/thinc/layers/tensorflowwrapper.py
@@ -115,8 +115,8 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
     """Return the output of the wrapped TensorFlow model for the given input,
     along with a callback to handle the backward pass.
     """
-    convert_inputs = model.get_attr("convert_inputs")
-    convert_outputs = model.get_attr("convert_outputs")
+    convert_inputs = model.attrs["convert_inputs"]
+    convert_outputs = model.attrs["convert_outputs"]
     tensorflow_model = model.shims[0]
     X_tensorflow, get_dX = convert_inputs(model, X, is_train)
     if is_train:

--- a/thinc/layers/uniqued.py
+++ b/thinc/layers/uniqued.py
@@ -28,7 +28,7 @@ def uniqued(layer: Model, *, column: int = 0) -> Model[InT, OutT]:
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    column = model.get_attr("column")
+    column = model.attrs["column"]
     layer = model.layers[0]
     keys = X[:, column]
     if not isinstance(keys, numpy.ndarray):

--- a/thinc/layers/with_array.py
+++ b/thinc/layers/with_array.py
@@ -67,7 +67,7 @@ def _list_forward(
     model: Model[List[Array2d], List[Array2d]], Xs: List[Array2d], is_train: bool
 ) -> Tuple[List[Array2d], Callable]:
     layer = model.layers[0]
-    pad = model.get_attr("pad")
+    pad = model.attrs["pad"]
     lengths: Array1d = layer.ops.asarray([len(seq) for seq in Xs])
     Xf = layer.ops.flatten(Xs, pad=pad)
     Yf, get_dXf = layer(Xf, is_train)

--- a/thinc/layers/with_getitem.py
+++ b/thinc/layers/with_getitem.py
@@ -25,7 +25,7 @@ def with_getitem(idx: int, layer: Model) -> Model[InT, OutT]:
 def forward(
     model: Model[InT, OutT], items: InT, is_train: bool
 ) -> Tuple[OutT, Callable]:
-    idx = model.get_attr("idx")
+    idx = model.attrs["idx"]
     Y_i, backprop_item = model.layers[0](items[idx], is_train)
 
     def backprop(d_output: OutT) -> InT:
@@ -38,7 +38,7 @@ def forward(
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
 ) -> Model[InT, OutT]:
-    idx = model.get_attr("idx")
+    idx = model.attrs["idx"]
     X_i = X[idx] if X is not None else X
     Y_i = Y[idx] if Y is not None else Y
     model.layers[0].initialize(X=X_i, Y=Y_i)

--- a/thinc/tests/layers/test_linear.py
+++ b/thinc/tests/layers/test_linear.py
@@ -120,7 +120,7 @@ def test_dropout_gives_zero_gradients(W_b_input):
     W, b, input_ = W_b_input
     for node in model.walk():
         if node.name == "dropout":
-            node.set_attr("rate", 1.0)
+            node.attrs["rate"] = 1.0
     fwd_dropped, finish_update = model.begin_update(input_)
     grad_BO = numpy.ones((nr_batch, nr_out), dtype="f")
     grad_BI = finish_update(grad_BO)

--- a/thinc/tests/layers/test_pytorch_wrapper.py
+++ b/thinc/tests/layers/test_pytorch_wrapper.py
@@ -96,6 +96,6 @@ def test_convert_inputs(data, n_args, kwargs_keys):
     import torch.nn
 
     model = PyTorchWrapper(torch.nn.Linear(3, 4))
-    convert_inputs = model.get_attr("convert_inputs")
+    convert_inputs = model.attrs["convert_inputs"]
     Y, backprop = convert_inputs(model, data, is_train=True)
     check_input_converters(Y, backprop, data, n_args, kwargs_keys, torch.Tensor)

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -387,7 +387,7 @@ def test_tensorflow_wrapper_convert_inputs(data, n_args, kwargs_keys):
 
     keras_model = tf.keras.Sequential([tf.keras.layers.Dense(12, input_shape=(12,))])
     model = TensorFlowWrapper(keras_model)
-    convert_inputs = model.get_attr("convert_inputs")
+    convert_inputs = model.attrs["convert_inputs"]
     Y, backprop = convert_inputs(model, data, is_train=True)
     check_input_converters(Y, backprop, data, n_args, kwargs_keys, tf.Tensor)
 

--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -45,7 +45,7 @@ def test_uniqued_calls_init():
 
 @given(X=lists_of_integers(lo=0, hi=ROWS))
 def test_uniqued_doesnt_change_result(model, X):
-    umodel = uniqued(model, column=model.get_attr("column")).initialize()
+    umodel = uniqued(model, column=model.attrs["column"]).initialize()
     Y, bp_Y = model(X, is_train=True)
     Yu, bp_Yu = umodel(X, is_train=True)
     assert_allclose(Y, Yu)

--- a/thinc/tests/model/test_jax_model.py
+++ b/thinc/tests/model/test_jax_model.py
@@ -24,7 +24,7 @@ def get_batch(ops, nB, nO, nI):
 
 def make_linear(nO, nI):
     model = thinc.api.Linear(nO, nI).initialize()
-    model.set_attr("registry_name", "Linear.v0")
+    model.attrs["registry_name"] = "Linear.v0"
     return model
 
 

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -87,13 +87,12 @@ def test_model_init():
     assert model.get_ref("c").name == "a"
     with pytest.raises(ValueError):
         model.set_ref("c", create_model("c"))
-    assert model.has_attr("foo")
-    assert not model.has_attr("bar")
-    assert model.get_attr("foo") == "bar"
+    assert "foo" in model.attrs
+    assert "bar" not in model.attrs
+    assert model.attrs["foo"] == "bar"
     with pytest.raises(KeyError):
-        model.get_attr("bar")
-    model.set_attr("bar", "baz")
-    assert model.has_attr("bar")
+        model.attrs["bar"]
+    model.attrs["bar"] = "baz"
     model_copy = model.copy()
     assert model_copy.name == "test"
 
@@ -118,13 +117,6 @@ def test_grad_names():
 def test_dim_names():
     model = Linear(5, 3)
     assert model.dim_names == ("nO", "nI")
-
-
-def test_attr_names():
-    model = Linear(5, 3)
-    assert model.attr_names == tuple()
-    model.set_attr("hello", "world")
-    assert model.attr_names == ("hello",)
 
 
 def test_model_set_reference():
@@ -161,18 +153,18 @@ def test_model_can_load_from_disk(model_with_no_args):
 def test_change_attr_values(model_with_no_args):
     model = model_with_no_args
     model.name = "target"
-    model.set_attr("has_var", False)
+    model.attrs["has_var"] = False
     change_attr_values(model, {"target": {"has_var": True, "error": True}})
-    assert model.get_attr("has_var") is True
-    assert not model.has_attr("error")
+    assert model.attrs["has_var"] is True
+    assert "error" not in model.attrs
 
 
 def test_set_dropout(model_with_no_args):
     model = model_with_no_args
     model.name = "dropout"
-    model.set_attr("dropout_rate", 0.0)
+    model.attrs["dropout_rate"] = 0.0
     set_dropout_rate(model, 0.2)
-    assert model.get_attr("dropout_rate") == 0.2
+    assert model.attrs["dropout_rate"] == 0.2
 
 
 def test_bind_plus():

--- a/thinc/tests/test_serialize.py
+++ b/thinc/tests/test_serialize.py
@@ -72,8 +72,8 @@ def test_simple_model_roundtrip_bytes_serializable_attrs():
 
     model_bytes = model.to_bytes()
     model = model.from_bytes(model_bytes)
-    assert model.has_attr("test")
-    assert model.get_attr("test").value == "foo from bytes"
+    assert "test" in model.attrs
+    assert model.attrs["test"].value == "foo from bytes"
 
 
 def test_multi_model_roundtrip_bytes():
@@ -142,10 +142,10 @@ def test_serialize_attrs():
     fwd = lambda model, X, is_train: (X, lambda dY: dY)
     attrs = {"test": "foo"}
     model1 = Model("test", fwd, attrs=attrs).initialize()
-    bytes_attr = serialize_attr(model1.get_attr("test"), attrs["test"], "test", model1)
+    bytes_attr = serialize_attr(model1.attrs["test"], attrs["test"], "test", model1)
     assert bytes_attr == srsly.msgpack_dumps("foo")
     model2 = Model("test", fwd, attrs={"test": ""})
-    result = deserialize_attr(model2.get_attr("test"), bytes_attr, "test", model2)
+    result = deserialize_attr(model2.attrs["test"], bytes_attr, "test", model2)
     assert result == "foo"
 
     # Test objects with custom serialization functions
@@ -159,9 +159,9 @@ def test_serialize_attrs():
 
     attrs = {"test": SerializableAttr()}
     model3 = Model("test", fwd, attrs=attrs)
-    bytes_attr = serialize_attr(model3.get_attr("test"), attrs["test"], "test", model3)
+    bytes_attr = serialize_attr(model3.attrs["test"], attrs["test"], "test", model3)
     assert bytes_attr == b"foo"
     model4 = Model("test", fwd, attrs=attrs)
-    assert model4.get_attr("test").value == "foo"
-    result = deserialize_attr(model4.get_attr("test"), bytes_attr, "test", model4)
+    assert model4.attrs["test"].value == "foo"
+    result = deserialize_attr(model4.attrs["test"], bytes_attr, "test", model4)
     assert result.value == "foo from bytes"


### PR DESCRIPTION
As discussed:

* make `Model.attrs` a dict and a property to allow assigning to it directly
* remove `Model.get_attr`, `Model.set_attr`, `Model.has_attr`, `Model.attr_names`