### PR TITLE
Remove model's ThreadState class, no longer used

### DIFF
--- a/thinc/model.py
+++ b/thinc/model.py
@@ -26,13 +26,6 @@ def empty_init(model: "Model", *args, **kwargs) -> "Model":
     return model
 
 
-class ModelThreadState(threading.local):
-    operators: Dict[str, Callable[["Model", "Model"], "Model"]]
-
-    def __init__(self):
-        self.operators = {}
-
-
 class Model(Generic[InT, OutT]):
     """Class for implementing Thinc models and layers."""
 


### PR DESCRIPTION
:fire: Remove model's ThreadState class, as it's replaced with context vars and is no longer used.