### PR TITLE
Example: fix predict like terms dataset

### DIFF
--- a/examples/06_predicting_like_terms.ipynb
+++ b/examples/06_predicting_like_terms.ipynb
@@ -32,11 +32,11 @@
    "source": [
     "### Encode Text Inputs\n",
     "\n",
-    "Mathy generates ascii-math problem texts that we need to encode into scalar values for the model to process. We'll one-hot encode the text by individual characters to keep things simple.\n",
+    "Mathy generates ascii-math problems and we have to encode them into integers that the model can process. \n",
     "\n",
-    "For math problems our vocabulary will include all the characters of the alphabet, numbers 0-9, and the special characters used for operators like `*`, `/`, `.`, etc.\n",
+    "To do this we'll build a vocabulary of all the possible characters we'll see, and map each input character to its index in the list.\n",
     "\n",
-    "Thinc has a `to_categorical` helper that we can use for converting values into one-hot arrays. Let's use that to write a function that accepts an input string and returns a one-hot representation."
+    "For math problems our vocabulary will include all the characters of the alphabet, numbers 0-9, and special characters like `*`, `-`, `.`, etc."
    ]
   },
   {
@@ -46,14 +46,19 @@
    "outputs": [],
    "source": [
     "from thinc.types import Array2d\n",
-    "from thinc.api import Ops, get_current_ops, to_categorical\n",
+    "from thinc.api import Ops, get_current_ops\n",
     "\n",
     "vocab = \" .+-/^*()[]-01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n",
     "\n",
+    "\n",
     "def encode_input(text: str) -> Array2d:\n",
     "    ops: Ops = get_current_ops()\n",
-    "    vocab_indices: List[int] = [vocab.index(s) for s in text]\n",
-    "    return to_categorical(ops.asarray(vocab_indices), n_classes=len(vocab))\n"
+    "    indices: List[List[int]] = []\n",
+    "    for c in text:\n",
+    "        if c not in vocab:\n",
+    "            raise ValueError(f\"'{c}' missing from vocabulary in text: {text}\")\n",
+    "        indices.append([vocab.index(c)])\n",
+    "    return ops.asarray(indices)"
    ]
   },
   {
@@ -76,26 +81,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0.]\n",
-      " [0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0.]\n",
-      " [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0.]]\n"
+      "[[16]\n",
+      " [ 2]\n",
+      " [14]]\n"
      ]
     }
    ],
    "source": [
     "outputs = encode_input(\"4+2\")\n",
-    "assert outputs[0].argmax() == vocab.index(\"4\")\n",
-    "assert outputs[1].argmax() == vocab.index(\"+\")\n",
-    "assert outputs[2].argmax() == vocab.index(\"2\")\n",
+    "assert outputs[0][0] == vocab.index(\"4\")\n",
+    "assert outputs[1][0] == vocab.index(\"+\")\n",
+    "assert outputs[2][0] == vocab.index(\"2\")\n",
     "print(outputs)"
    ]
   },
@@ -118,18 +114,21 @@
     "import random\n",
     "from mathy.problems import gen_simplify_multiple_terms\n",
     "\n",
-    "\n",
     "def generate_problems(number: int, exclude: Optional[Set[str]] = None) -> List[str]:\n",
     "    if exclude is None:\n",
     "        exclude = set()\n",
     "    problems: List[str] = []\n",
     "    while len(problems) < number:\n",
-    "        text, _ = gen_simplify_multiple_terms(\n",
-    "            random.randint(3, 8), noise_probability=1.0, noise_terms=10\n",
+    "        text, complexity = gen_simplify_multiple_terms(\n",
+    "            random.randint(2, 6),\n",
+    "            noise_probability=1.0,\n",
+    "            noise_terms=random.randint(2, 10),\n",
+    "            op=[\"+\", \"-\"],\n",
     "        )\n",
     "        assert text not in exclude, \"duplicate problem generated!\"\n",
+    "        exclude.add(text)\n",
     "        problems.append(text)\n",
-    "    return problems\n"
+    "    return problems"
    ]
   },
   {
@@ -147,16 +146,16 @@
     {
      "data": {
       "text/plain": [
-       "['12f + -6624y + 11.8x + 5x + 6.7x + -3139x + 10q + 948s + -8685o^4 + 5.8u^2 + -2833f + 7j + 5.9f + 12n + -8291l + 11.8f + 10d^4 + -736t',\n",
-       " '11p^4 + 1811d + 3z^4 + 9.0h + -648o + 0.8z^4 + 6p^4 + 4.7a + 7.0y^3 + -678m^4 + 11f + 3.2b + 3061p^4 + 2t + 9s + -28z^4',\n",
-       " '10r + 2h + -6335b + 5597f + -5569p^3 + 8.2l^2 + 6.6c + 2844.4n + 4.2w + -4266q + 1431.4p^3 + 1.5k^3 + 11.4v',\n",
-       " '5n + 3q + 6.7s^2 + 1k + 5.8g + 8192.0w + 7.5a + 1.1u + 6c + 3z + 6m^2 + 1487z + -3267m^2 + 4.2z + 2313.0m^2 + -5745z + 12f^4',\n",
-       " '4147.9p + -7487m + -6963.9t^4 + 1.8q + -7945r^3 + -7471.8t^4 + 11.5l + 5.6l + 10l + 0.3z + 5.4y^2 + 7.8n + -8982t^4 + 2.4l + 2.7s + 1o + 6.6v',\n",
-       " '6j^4 + 1.9s + -6310r^3 + 11.4a + -995d + 8969v^2 + 5.5s + 1m^2 + 1007u^4 + 9879g^4 + 4.9s + 8x + 3u^4 + 6754o + 2.5n^4 + 10.5u^4',\n",
-       " '8.6f + 7.3d + 5n + 9d + 9.1z^3 + 9164y + 0.9d + 7663u^3 + -4640a^2 + -2512j + 3604n + 10b^3 + 5.9n + 10w + 5217d + -4344t + 10q + -1014n',\n",
-       " '12a^2 + 6t^2 + 11w^2 + -7833x + 2b + 7.4h^3 + 4z^3 + 2q^4 + -7406o + 8.8y + -6884r + 6525y + 5r + 7219y + 4147s^4',\n",
-       " '-848r^2 + 10h^3 + 5818o + 0.1f + 50t + 1p + 5207z + 7.4k^3 + 6.2w + 7g + 2.5q + 6o + 2c',\n",
-       " '-8324w + 7447.1o + 8h + 6b^3 + 8219u + -498g + 11y^4 + 9b^3 + 7.6l + -6996r + 2d + 3w + 11q + 3.2m + -2805b^3']"
+       "['6r^2 - 6812u + 11.7v + 2j - -8954j - -323w - 159x',\n",
+       " '6z^4 + 5391h - -7335r + 7080c - 12a^2 - 4008n^3 + -3311c - 1o^3 - 4145.0v^4 - 9.9z^4 - -7421t + 9z^4 - -7614c - 9261p',\n",
+       " '3.9n - -1527z - 2u + 9327q^4 + 11s^4 - 1m + 2v - 8.1o - 8.2r - 10.0q^4 - 11z + 4.1h',\n",
+       " '-6726s + 7401.4n + 6y + 656.0x + 5x - 10q + 6r',\n",
+       " '3.8l + 5q - 6u^3 - 2.2y - 5n + -6488l + 7489z',\n",
+       " '1439h - -584u + -3858.5g^3 - -2485k^4 - 3x^4 + 11.2a + 3597f - -4273y^4 - 2m - 10d + 2.0d',\n",
+       " '-487o - 7q - -7447c + -6131l^2 + 6a^4 + 7.5a^4',\n",
+       " '6863z - 3v - 3143q + 6.0u - -8699j^3 + 0.8k^2 + 3j^3 + -4087k^2 + 8.9j^3 - 2b - 1d',\n",
+       " '7239.4y^4 - -8988y^4 + -9201w + 9c - 1c + -8147.8f + 4487c + 2.6y^4 + 11l^2',\n",
+       " '-4180q^3 - -775f^3 - 3.7h + -8275.1a + 4w - 3851d + 10w']"
       ]
      },
      "execution_count": 5,
@@ -197,7 +196,7 @@
     "    node_groups: Dict[str, List[int]] = {}\n",
     "    for term_node in term_nodes:\n",
     "        ex: Optional[TermEx] = get_term_ex(term_node)\n",
-    "        assert ex is not None, f\"invalid expression {ex}\"\n",
+    "        assert ex is not None, f\"invalid expression {term_node}\"\n",
     "        key = mathy_term_string(variable=ex.variable, exponent=ex.exponent)\n",
     "        if key == \"\":\n",
     "            key = \"const\"\n",
@@ -226,9 +225,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert count_like_terms(\"4x + 2y + q\") == 0\n",
+    "assert count_like_terms(\"4x - 2y + q\") == 0\n",
     "assert count_like_terms(\"x + x + z\") == 2\n",
-    "assert count_like_terms(\"4x + 2x + x + 7\") == 3"
+    "assert count_like_terms(\"4x + 2x - x + 7\") == 3"
    ]
   },
   {
@@ -252,9 +251,9 @@
     "from thinc.types import Array2d\n",
     "\n",
     "def to_example(input_problem: str) -> Tuple[str, Array2d, List[int]]:\n",
-    "    one_hot = encode_input(input_problem)\n",
+    "    encoded_input = encode_input(input_problem)\n",
     "    like_terms = count_like_terms(input_problem)\n",
-    "    return input_problem, one_hot, [like_terms]"
+    "    return input_problem, encoded_input, [like_terms]"
    ]
   },
   {
@@ -266,29 +265,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "x+2x [[0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0.]\n",
-      " [0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0.]\n",
-      " [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0.]\n",
-      " [0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0.\n",
-      "  0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
-      "  0. 0. 0.]] [2]\n"
+      "x+2x [[46]\n",
+      " [ 2]\n",
+      " [14]\n",
+      " [46]] [2]\n"
      ]
     }
    ],
@@ -297,7 +284,7 @@
     "# text is preserved for debugging/visualization\n",
     "assert text == \"x+2x\"\n",
     "# X contains one-hot vectors\n",
-    "assert X[0].argmax() == vocab.index(\"x\")\n",
+    "assert X[0] == vocab.index(\"x\")\n",
     "# Y is the number of like terms\n",
     "assert Y[0] == 2\n",
     "print(text, X, Y)"
@@ -316,35 +303,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
     "from typing import List\n",
     "from thinc.model import Model\n",
     "from thinc.types import Array2d, Array1d\n",
-    "from thinc.api import chain, list2ragged, reduce_sum, ReLu\n",
-    "\n",
+    "from thinc.api import chain, clone, list2ragged, reduce_sum, Mish, with_array, Embed, residual\n",
     "\n",
     "def to_ints():\n",
-    "    def forward(model: Model[Array2d, Array1d], Y: Array2d, is_train: bool):\n",
+    "    def forward(model: Model[Array1d, Array1d], Y: Array2d, is_train: bool):\n",
     "        Y = Y.astype(\"i\")\n",
     "        return Y, lambda dY: dY.astype(\"f\")\n",
-    "\n",
     "    return Model(\"toint\", forward)\n",
     "\n",
     "\n",
-    "def CountLikeTerms(n_hidden: int, dropout: float = 0.5) -> Model[List[Array2d], Array2d]:\n",
-    "    return chain(\n",
+    "def build_model(n_hidden: int, dropout: float = 0.1) -> Model[List[Array2d], Array2d]:\n",
+    "    model: Model[List[Array2d], Array2d] = chain(\n",
     "        list2ragged(),\n",
+    "        with_array(chain(Embed(n_hidden, len(vocab)), Mish(n_hidden, dropout=dropout))),\n",
     "        reduce_sum(),\n",
-    "        ReLu(n_hidden, dropout=dropout),\n",
-    "        ReLu(n_hidden),\n",
-    "        ReLu(n_hidden),\n",
-    "        ReLu(n_hidden),\n",
-    "        ReLu(1),\n",
+    "        clone(residual(Mish(n_hidden, normalize=True)), 4),\n",
+    "        Mish(1),\n",
     "        to_ints(),\n",
-    "    )"
+    "    )\n",
+    "    return model"
    ]
   },
   {
@@ -358,13 +342,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
     "text, X, Y = to_example(\"14x + 2y - 3x + 7x\")\n",
-    "m = CountLikeTerms(12)\n",
-    "m.initialize([X], Y)\n",
+    "m = build_model(12)\n",
+    "m.initialize([X], m.ops.asarray(Y, dtype=\"f\"))\n",
     "assert m.predict([X]).shape == (1, 1)"
    ]
   },
@@ -381,23 +365,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import Optional, Set, List\n",
+    "from typing import Callable, Optional, Set, List\n",
     "from thinc.types import Array2d\n",
     "\n",
+    "# A function that takes in a size and outputs a list generated problems\n",
+    "ProblemsFunction = Callable[[int, Optional[Set[str]]], List[str]]\n",
+    "\n",
+    "# A tuple of (texts, X, Y)\n",
+    "DatasetTuple = Tuple[List[str], List[Array2d], List[Array1d]]\n",
+    "\n",
+    "\n",
     "def generate_dataset(\n",
-    "    size: int, exclude: Optional[Set[str]] = None\n",
-    ") -> Tuple[List[str], List[Array2d], List[List[int]]]:\n",
-    "    texts: List[str] = generate_problems(size)\n",
+    "    size: int,\n",
+    "    exclude: Optional[Set[str]] = None,\n",
+    "    problems_fn: ProblemsFunction = generate_problems,\n",
+    ") -> DatasetTuple:\n",
+    "    ops: Ops = get_current_ops()\n",
+    "    texts: List[str] = generate_problems(size, exclude=exclude)\n",
     "    examples: List[Array2d] = []\n",
-    "    labels: List[List[int]] = []\n",
+    "    labels: List[Array1d] = []\n",
     "    for i, text in enumerate(texts):\n",
     "        text, x, y = to_example(text)\n",
-    "        examples.append(x)\n",
-    "        labels.append(y)\n",
+    "        examples.append(ops.asarray(x))\n",
+    "        labels.append(ops.asarray(y))\n",
     "\n",
     "    return texts, examples, labels"
    ]
@@ -413,46 +407,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(['4453j + -7872q + -1522.0o + 0.9n + 4a + 6k^4 + 8l + 11t + 9l + 12t + 9097s^2 + 10u + 1g^2 + 5290f^4',\n",
-       "  '2078z^3 + 7a + 0.1l + -1658k^3 + 8.4a + -1487.6z^3 + 8.9o^2 + -6395a + 9225a + 4938.2r^2 + 1g + 5663z^3 + 5x + 8733w + 10m + 9n^4 + 10y',\n",
-       "  '3177p^3 + 7730.4f^3 + 9.3f^3 + -901y^4 + 8.5c^2 + 7b + 5f^3 + 1p^3 + 7p^3 + 1g + 3071f^3 + 7a + 3t + 1978n^3 + 5.4k^2 + 11o^2 + 7h^4'],\n",
-       " [array([[0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         ...,\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.]], dtype=float32),\n",
-       "  array([[0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         ...,\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.]], dtype=float32),\n",
-       "  array([[0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         ...,\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.],\n",
-       "         [0., 0., 0., ..., 0., 0., 0.]], dtype=float32)],\n",
-       " [[4], [7], [7]])"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "generate_dataset(3)"
+    "texts, x, y = generate_dataset(10)\n",
+    "assert len(texts) == 10\n",
+    "assert len(x) == 10\n",
+    "assert len(y) == 10"
    ]
   },
   {
@@ -468,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,14 +439,13 @@
     "from thinc.types import Array2d, Array1d\n",
     "from wasabi import msg\n",
     "\n",
-    "\n",
     "def evaluate_model(\n",
-    "    model: Model[Array2d, Array1d],\n",
+    "    model: Model[List[Array2d], Array2d],\n",
     "    *,\n",
     "    print_problems: bool = False,\n",
     "    texts: List[str],\n",
-    "    X: Array2d,\n",
-    "    Y: List[int],\n",
+    "    X: List[Array2d],\n",
+    "    Y: List[Array1d],\n",
     "):\n",
     "    Yeval = model.predict(X)\n",
     "    correct_count = 0\n",
@@ -501,7 +462,9 @@
     "        if print_problems and print_n > 0:\n",
     "            print_n -= 1\n",
     "            print_fn(f\"Answer[{y_answer[0]}] Guess[{y_guess}] Text: {text}\")\n",
-    "    return correct_count / len(X)\n"
+    "    if print_problems:\n",
+    "        print(f\"Model predicted {correct_count} out of {len(X)} correctly.\")\n",
+    "    return correct_count / len(X)"
    ]
   },
   {
@@ -515,13 +478,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "texts, X, Y = generate_dataset(128)\n",
-    "m = CountLikeTerms(12)\n",
-    "m.initialize(X, Y)\n",
+    "m = build_model(12)\n",
+    "m.initialize(X, m.ops.asarray(Y, dtype=\"f\"))\n",
     "# Assume the model should do so poorly as to round down to 0\n",
     "assert round(evaluate_model(m, texts=texts, X=X, Y=Y)) == 0"
    ]
@@ -530,101 +493,226 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Train the Model\n"
+    "### Train/Evaluate a Model\n",
+    "\n",
+    "The final helper function we need is one to train and evaluate a model given two input datasets. \n",
+    "\n",
+    "This function does a few things:\n",
+    "\n",
+    " 1. Create an Adam optimizer we can use for minimizing the model's prediction error.\n",
+    " 2. Loop over the given training dataset (epoch) number of times.\n",
+    " 3. For each epoch, make batches of (batch_size) examples. For each batch(X), predict the number of like terms (Yh) and subtract the known answers (Y) to get the prediction error. Update the model using the optimizer with the calculated error.\n",
+    " 5. After each epoch, check the model performance against the evaluation dataset.\n",
+    " 6. Save the model weights for the best score out of all the training epochs.\n",
+    " 7. After all training is done, restore the best model and print results from the evaluation set."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Set, TypeVar\n",
+    "from thinc.api import Adam, fix_random_seed\n",
+    "from thinc.model import Model\n",
+    "from wasabi import msg\n",
+    "import numpy\n",
+    "\n",
+    "ModelInput = TypeVar(\"ModelInput\", bound=Model)\n",
+    "\n",
+    "\n",
+    "def train_and_evaluate(\n",
+    "    model: ModelInput,\n",
+    "    train_tuple: DatasetTuple,\n",
+    "    eval_tuple: DatasetTuple,\n",
+    "    *,\n",
+    "    lr: float = 3e-3,\n",
+    "    batch_size: int = 64,\n",
+    "    epochs: int = 48,\n",
+    ") -> float:\n",
+    "    (train_texts, train_X, train_y) = train_tuple\n",
+    "    (eval_texts, eval_X, eval_y) = eval_tuple\n",
+    "    msg.divider(\"Train and Evaluate Model\")\n",
+    "    msg.info(f\"Batch size = {batch_size}\\tEpochs = {epochs}\\tLearning Rate = {lr}\")\n",
+    "\n",
+    "    optimizer = Adam(lr)\n",
+    "    best_score: float = 0.0\n",
+    "    best_model: Optional[bytes] = None\n",
+    "    for n in range(epochs):\n",
+    "        loss = 0.0\n",
+    "        batches = model.ops.multibatch(batch_size, train_X, train_y, shuffle=True)\n",
+    "        for X, Y in batches:\n",
+    "            Y = model.ops.asarray(Y, dtype=\"float32\")\n",
+    "            Yh, backprop = model.begin_update(X)\n",
+    "            err = Yh - Y\n",
+    "            backprop(err)\n",
+    "            loss += (err ** 2).sum()\n",
+    "            model.finish_update(optimizer)\n",
+    "        score = evaluate_model(model, texts=eval_texts, X=eval_X, Y=eval_y)\n",
+    "        if score > best_score:\n",
+    "            best_model = model.to_bytes()\n",
+    "            best_score = score\n",
+    "        print(f\"{n}\\t{score:.2f}\\t{loss:.2f}\")\n",
+    "\n",
+    "    if best_model is not None:\n",
+    "        model.from_bytes(best_model)\n",
+    "    print(f\"Evaluating with best model\")\n",
+    "    score = evaluate_model(\n",
+    "        model, texts=eval_texts, print_problems=True, X=eval_X, Y=eval_y\n",
+    "    )\n",
+    "    print(f\"Final Score: {score}\")\n",
+    "    return score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll generate the dataset first, so we can iterate on the model without having to spend time generating examples for each run. This also ensures we have the same dataset across different model runs, to make it easier to compare performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[2Knerating train dataset with 50000 examples...\u001b[38;5;2m✔ Train set created with 50000 examples.\u001b[0m\n",
-      "\u001b[2Knerating eval dataset with 128 examples...\u001b[38;5;2m✔ Eval set created with 128 examples.\u001b[0m\n",
-      "0\t0.58\t89694.00\n",
-      "1\t0.59\t29407.00\n",
-      "2\t0.66\t21025.00\n",
-      "3\t0.66\t16449.00\n",
-      "4\t0.77\t13958.00\n",
-      "5\t0.79\t11970.00\n",
-      "6\t0.85\t11160.00\n",
-      "7\t0.81\t10352.00\n",
-      "8\t0.80\t9941.00\n",
-      "9\t0.84\t9795.00\n",
-      "10\t0.80\t9465.00\n",
-      "11\t0.86\t9249.00\n",
-      "\u001b[1m\n",
-      "============================ eval samples max(10) ============================\u001b[0m\n",
-      "\u001b[38;5;2m✔ Answer[[4]] Guess[4] Text: 6.9k + -4124l^4 + 4d + 10m^3 + 0.2x + 6q +\n",
-      "-7098p^2 + 7.3l^4 + 4o + 4r + 5975v^4 + 11s^2 + 0.4g^3 + 10.4g^3\u001b[0m\n",
-      "\u001b[38;5;2m✔ Answer[[4]] Guess[4] Text: 2510g + -8759m + 12t + 9y + 0.5c + 1880a +\n",
-      "10.9j^4 + 1q + 1143.9c + 4.0n^4 + 3.7y + 8356s + 5u^3 + 5.0x\u001b[0m\n",
-      "\u001b[38;5;2m✔ Answer[[2]] Guess[2] Text: 9h + 1.8n^3 + 11.0z + 7969w^4 + -4606j +\n",
-      "3604v^3 + 5573.4g + -8408u + 4s^4 + 2u + 6f + 10x^2 + 6p^2\u001b[0m\n",
-      "\u001b[38;5;2m✔ Answer[[7]] Guess[7] Text: 8z + 9m + 6.4y + -7238.6d^2 + 9.0z + 11f +\n",
-      "6u^4 + 2w^4 + 12l + 1022d^2 + 4t + 8335x + 7.6z + 8430n + -6979z + 9004c^2 +\n",
-      "-6079d^2\u001b[0m\n",
-      "\u001b[38;5;2m✔ Answer[[4]] Guess[4] Text: 3374x^3 + 1.4d + 4r + 8.3y + 6l^2 + 0.7c^3\n",
-      "+ 1.6x^3 + 5t + 2.4d + 11.3n^4 + -9231p + 7g + 1134o + -8447f\u001b[0m\n",
-      "\u001b[38;5;2m✔ Answer[[6]] Guess[6] Text: 7l^2 + 583.6n + 685.8a + -5088.8p + 9.8b^3\n",
-      "+ 5.5j + 524n + 1.4y^2 + 9x + -3710b^3 + 7484h^2 + 2b^3 + 1.6n + 1839m + 4d^2 +\n",
-      "-3209u\u001b[0m\n",
-      "\u001b[38;5;1m✘ Answer[[4]] Guess[3] Text: 4p + 9181b + 11.1s + -7624g + 3.9u + 10.3q\n",
-      "+ -6195.1m + -9391l^3 + 11p + 4.4h + 0.2a + 10.1k^4 + 5.4j + 6.5q\u001b[0m\n",
-      "\u001b[38;5;2m✔ Answer[[2]] Guess[2] Text: 6863h + -7685x + 8559u + -457j + 6.2k +\n",
-      "11z + 1o^3 + -9991m + 12f + 6m + 2.1b + 4.6t + 8.4y\u001b[0m\n",
-      "\u001b[38;5;1m✘ Answer[[2]] Guess[3] Text: -1092o + 7080n^2 + 8.8k^3 + 6.0a + 3.7b^4\n",
-      "+ 7d + 5.2g + 6694f^3 + -7673z + 4h + 9y + -4915.6r + 5y\u001b[0m\n",
-      "\u001b[38;5;2m✔ Answer[[6]] Guess[6] Text: 3.8t^3 + 5161d^2 + 1f + -6482o + -8956n^4\n",
-      "+ 10.4r + 7999.7m + 4542h^4 + 1.2u + 4448s + -576u + 12s + -7281u + 5906s +\n",
-      "2468y + 7993v\u001b[0m\n",
-      "Score: 0.8515625\n"
+      "\u001b[2Knerating train dataset with 8192 examples...\u001b[38;5;2m✔ Train set created with 8192 examples.\u001b[0m\n",
+      "\u001b[2Knerating eval dataset with 2048 examples...\u001b[38;5;2m✔ Eval set created with 2048 examples.\u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "from typing import Set\n",
-    "from thinc.api import Adam, fix_random_seed\n",
-    "from wasabi import msg\n",
-    "import numpy\n",
-    "\n",
-    "# Set the random seed to make results more reproducible\n",
-    "fix_random_seed(1234)\n",
-    "batch_size = 12\n",
-    "num_iters = 12\n",
-    "train_size = 50000\n",
-    "test_size = 128\n",
+    "train_size = 1024 * 8\n",
+    "test_size = 2048\n",
     "seen_texts: Set[str] = set()\n",
     "with msg.loading(f\"Generating train dataset with {train_size} examples...\"):\n",
-    "    (train_texts, train_X, train_y) = generate_dataset(train_size, seen_texts)\n",
+    "    train_dataset = generate_dataset(train_size, seen_texts)\n",
     "msg.good(f\"Train set created with {train_size} examples.\")\n",
     "with msg.loading(f\"Generating eval dataset with {test_size} examples...\"):\n",
-    "    (eval_texts, eval_X, eval_y) = generate_dataset(test_size, seen_texts)\n",
+    "    eval_dataset = generate_dataset(test_size, seen_texts)\n",
     "msg.good(f\"Eval set created with {test_size} examples.\")\n",
-    "model = CountLikeTerms(512)\n",
-    "model.initialize(train_X[:2], model.ops.asarray(train_y[:2]))\n",
-    "optimizer = Adam(2e-3)\n",
-    "for n in range(num_iters):\n",
-    "    loss = 0.0\n",
-    "    batches = model.ops.multibatch(batch_size, train_X, train_y, shuffle=True)\n",
-    "    for X, Y in batches:\n",
-    "        Y = model.ops.asarray(Y, dtype=\"float32\")\n",
-    "        Yh, backprop = model.begin_update(X)\n",
-    "        err = Yh - Y\n",
-    "        backprop(err)\n",
-    "        loss += (err ** 2).sum()\n",
-    "        model.finish_update(optimizer)\n",
-    "    score = evaluate_model(model, texts=eval_texts, X=eval_X, Y=eval_y)\n",
-    "    print(f\"{n}\\t{score:.2f}\\t{loss:.2f}\")\n",
+    "init_x = train_dataset[1][:2]\n",
+    "init_y = train_dataset[2][:2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we can create our model and test it with some hyperparameters!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\n",
+      "========================== Train and Evaluate Model ==========================\u001b[0m\n",
+      "\u001b[38;5;4mℹ Batch size = 64      Epochs = 16     Learning Rate = 0.002\u001b[0m\n",
+      "0\t0.21\t24853.00\n",
+      "1\t0.25\t18502.00\n",
+      "2\t0.26\t17255.00\n",
+      "3\t0.27\t17137.00\n",
+      "4\t0.19\t16353.00\n",
+      "5\t0.27\t15548.00\n",
+      "6\t0.18\t14738.00\n",
+      "7\t0.25\t14619.00\n",
+      "8\t0.27\t13296.00\n",
+      "9\t0.27\t13176.00\n",
+      "10\t0.30\t12516.00\n",
+      "11\t0.31\t11760.00\n",
+      "12\t0.32\t11211.00\n",
+      "13\t0.33\t10498.00\n",
+      "14\t0.32\t10465.00\n",
+      "15\t0.33\t10046.00\n",
+      "Evaluating with best model\n",
+      "\u001b[1m\n",
+      "============================ eval samples max(10) ============================\u001b[0m\n",
+      "\u001b[38;5;1m✘ Answer[2] Guess[5] Text: -4578.3z + 9105.5u + 8.8k^2 - 9r^3 + 5.0q +\n",
+      "1j^4 + 1q - -3363d\u001b[0m\n",
+      "\u001b[38;5;1m✘ Answer[2] Guess[4] Text: 0.6l - 3.2p^3 - 2.7c + -6226y^2 + 8281.8z +\n",
+      "2k - 2.3z + 4149o - 1543g - 2n - 3880b + 1932m^3\u001b[0m\n",
+      "\u001b[38;5;1m✘ Answer[6] Guess[5] Text: 8.7n^3 - 0.7c + 12g^3 + 5x + 11.4v -\n",
+      "-8389g^3 - 3.7m + 10.1n^3 - 12g^3 + 6.6n^3\u001b[0m\n",
+      "\u001b[38;5;2m✔ Answer[2] Guess[2] Text: 1522n^2 + 8h + 4379p - -7007.9m - 2238.8y -\n",
+      "11n^2 - 8.8t^3\u001b[0m\n",
+      "\u001b[38;5;1m✘ Answer[2] Guess[4] Text: 960q - 8.7c + 5.4f^4 + 7247h^4 - 2461y -\n",
+      "10.2m + 4481m + 10l - 7s + 7.5a + 4.4g\u001b[0m\n",
+      "\u001b[38;5;2m✔ Answer[4] Guess[4] Text: -3939f - -9597w + -246t + -5388p^4 - 9385d^3\n",
+      "+ 9989r + 628w + 1.4z - -2942x - 2z\u001b[0m\n",
+      "\u001b[38;5;2m✔ Answer[5] Guess[5] Text: 3.4o + 3694n - 286v - 4870y + 5c^4 - -6982h\n",
+      "+ 4717m - 5k + 9578f^4 - -2007.1l^4 + 7f^4 + -5476l^4 - -2997f^4 + 8s\u001b[0m\n",
+      "\u001b[38;5;1m✘ Answer[5] Guess[4] Text: -7940j^2 + -6694y + 7o + 11.5w - 12n + 2g -\n",
+      "8u^3 + -5402k + 12f + 1.6k - 823f - -7952k - 10q^4\u001b[0m\n",
+      "\u001b[38;5;1m✘ Answer[2] Guess[3] Text: -9532.7w - 90o^3 + 11l^3 - 3262z^4 -\n",
+      "2o^3\u001b[0m\n",
+      "\u001b[38;5;2m✔ Answer[2] Guess[2] Text: 9.9w^4 - 0.7v + 8t - -189a + 1t + 3866u\u001b[0m\n",
+      "Model predicted 682 out of 2048 correctly.\n",
+      "Final Score: 0.3330078125\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.3330078125"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = build_model(64)\n",
+    "model.initialize(init_x, init_y)\n",
+    "train_and_evaluate(\n",
+    "    model, train_dataset, eval_dataset, lr=2e-3, batch_size=64, epochs=16\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Intermediate Exercise\n",
     "\n",
-    "Yeval = model.predict(eval_X)\n",
-    "score = evaluate_model(\n",
-    "    model, print_problems=True, texts=eval_texts, X=eval_X, Y=eval_y\n",
-    ")\n",
-    "print(f\"Score: {score}\")\n"
+    "The model we built can train up to ~80% given 100 or more epochs. Improve the model architecture so that it trains to a similar accuracy while requiring fewer epochs or a smaller dataset size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List\n",
+    "from thinc.model import Model\n",
+    "from thinc.types import Array2d, Array1d\n",
+    "from thinc.api import chain, clone, list2ragged, reduce_mean, Mish, with_array, Embed, residual\n",
+    "\n",
+    "def custom_model(n_hidden: int, dropout: float = 0.1) -> Model[List[Array2d], Array2d]:\n",
+    "    return chain(\n",
+    "        list2ragged(),\n",
+    "        with_array(Embed(n_hidden, len(vocab))),\n",
+    "        reduce_sum(),\n",
+    "        Mish(1),\n",
+    "        to_ints(),\n",
+    "    )\n",
+    "model = custom_model(64)\n",
+    "model.initialize(init_x, init_y)\n",
+    "train_and_evaluate(\n",
+    "    model, train_dataset, eval_dataset, lr=2e-3, batch_size=64, epochs=16\n",
+    ")"
    ]
   },
   {
@@ -663,13 +751,6 @@
     "    two classes, True and False.\"\"\"\n",
     "    ...\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
 - I thought it was suspicious that it trained to 98% accuracy, and it turns out I was right! :sob:
 - the dataset included a constant 10 noise terms in its expressions, and the model seemed to be learning to count terms and subtract 10. Maybe it only learned to count " + "?
 - update dataset to remove one-hot encoding after review with @honnibal
 - add model defaults that can train to ~80% accuracy if given 100 or more epochs.
 - add intermediate exercise to improve the model training performance by tweaking the architecture.

Related to: #258 