### PR TITLE
Update to Pydantic v1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wasabi>=0.4.0,<1.1.0
 catalogue>=0.2.0,<3.0.0
 ml_datasets>=0.1.5
 # Third-party dependencies
-pydantic>=1.3.0,<2.0.0
+pydantic>=1.4.0,<2.0.0
 numpy>=1.7.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     # Third-party dependencies
     setuptools
     numpy>=1.7.0
-    pydantic>=1.3.0,<2.0.0
+    pydantic>=1.4.0,<2.0.0
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"
     typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -278,7 +278,7 @@ class registry(object):
                     final[key] = list(final[key].values())
             else:
                 filled[key] = value
-                # TODO: unhack this fix to prevent pydantic from consuming generator
+                # Prevent pydantic from consuming generator if part of a union
                 validation[key] = value if not isinstance(value, GeneratorType) else []
                 final[key] = value
         # Now that we've filled in all of the promises, update with defaults
@@ -369,10 +369,6 @@ class registry(object):
         for param in inspect.signature(func).parameters.values():
             # If no annotation is specified assume it's anything
             annotation = param.annotation if param.annotation != param.empty else Any
-            # TODO: Bad hack to work around generic types in pydantic (until next release)
-            # Details: https://github.com/samuelcolvin/pydantic/issues/1158
-            if str(annotation).startswith("thinc.model.Model["):
-                annotation = Callable
             # If no default value is specified assume that it's required
             default = param.default if param.default != param.empty else ...
             # Handle spread arguments and use their annotation as Sequence[whatever]

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -11,11 +11,7 @@ OutT = TypeVar("OutT")
 MidT = TypeVar("MidT")
 
 
-# TODO: Unhack this when we can
-# We currently have an issue with Pydantic when arguments have generic types.
-# https://github.com/samuelcolvin/pydantic/issues/1158
-# For now we work around the issue by applying the decorator to this blander
-# version of the function.
+# Keep this function so we can provide variable arguments via the config
 @registry.layers("chain.v1")
 def chain_no_types(*layer: Model) -> Model:
     return chain(*layer)

--- a/thinc/optimizers.py
+++ b/thinc/optimizers.py
@@ -1,6 +1,6 @@
 import math
 
-from typing import Dict, Optional, Union, Tuple, List, cast
+from typing import Dict, Optional, Union, Tuple, List, cast, Iterator
 from collections import defaultdict
 
 from .backends import Ops, NumpyOps, CupyOps, get_current_ops
@@ -8,13 +8,9 @@ from .types import Array, Generator
 from .config import registry
 
 
-# We need to use the custom Generator type for schedules to work around pydantic
-# not supporting Iterator / Iterable
-ScheduleT = Generator
-
 KeyT = Tuple[int, str]
-FloatOrSeq = Union[float, List[float], Generator]
-IntOrSeq = Union[int, List[int], Generator]
+FloatOrSeq = Union[float, List[float], Generator[float]]
+IntOrSeq = Union[int, List[int], Generator[int]]
 
 SGD_DEFAULTS: Dict[str, Union[float, bool, int]] = {
     "L2": 0.0,
@@ -116,7 +112,7 @@ class Optimizer(object):
     mom1: Dict[KeyT, Array]
     mom2: Dict[KeyT, Array]
     averages: Optional[Dict[KeyT, Array]]
-    schedules: Dict[str, Generator]
+    schedules: Dict[str, Iterator[float]]
     nr_update: Dict[KeyT, int]
     last_seen: Dict[KeyT, int]
     grad_clip: float

--- a/thinc/optimizers.py
+++ b/thinc/optimizers.py
@@ -9,8 +9,8 @@ from .config import registry
 
 
 KeyT = Tuple[int, str]
-FloatOrSeq = Union[float, List[float], Generator[float]]
-IntOrSeq = Union[int, List[int], Generator[int]]
+FloatOrSeq = Union[float, List[float], Generator]
+IntOrSeq = Union[int, List[int], Generator]
 
 SGD_DEFAULTS: Dict[str, Union[float, bool, int]] = {
     "L2": 0.0,

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -628,8 +628,6 @@ def test_validate_generator():
 def test_handle_generic_model_type():
     """Test that validation can handle checks against arbitrary generic
     types in function argument annotations."""
-    # TODO: Unhack and extend once this is implemented in pydantic
-    #  https://github.com/samuelcolvin/pydantic/issues/1158
 
     @my_registry.layers("my_transform.v1")
     def my_transform(model: Model[int, int]):


### PR DESCRIPTION
We still need to leave in the `Generator` workarounds in the config to prevent consuming generators if they're part of a union with `Iterator`. But we get to remove the ugly hacks around the generics.