### PR TITLE
Merge pull request #278 from svlandeg/fix/tests

### DIFF
--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -229,9 +229,8 @@ def test_backprop_reduce_sum(ops, X):
     assert out.shape == (sum(lengths), X.shape[1])
     start = 0
     for i, length in enumerate(lengths):
-        # Note: this test was found to be flakey on Windows/GPU: increased rtol/atol from 0.1 to 0.11
         ops.xp.testing.assert_allclose(
-            out[start : start + length].sum(axis=0), X[i] * length, rtol=0.11, atol=0.11
+            out[start : start + length].sum(axis=0), X[i] * length, rtol=0.01, atol=0.01
         )
         start += length
 

--- a/thinc/tests/layers/test_mnist.py
+++ b/thinc/tests/layers/test_mnist.py
@@ -68,7 +68,7 @@ def create_model(request):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(("width", "nb_epoch", "min_score"), [(32, 10, 0.2)])
+@pytest.mark.parametrize(("width", "nb_epoch", "min_score"), [(32, 20, 0.8)])
 def test_small_end_to_end(width, nb_epoch, min_score, create_model, mnist):
     batch_size = 128
     dropout = 0.2

--- a/thinc/tests/strategies.py
+++ b/thinc/tests/strategies.py
@@ -46,7 +46,7 @@ def ndarrays(min_len=0, max_len=10, min_val=-10.0, max_val=10.0):
 
 
 def arrays_BI(min_B=1, max_B=10, min_I=1, max_I=100):
-    shapes = tuples(lengths(lo=min_B, hi=max_B), lengths(lo=min_B, hi=max_I))
+    shapes = tuples(lengths(lo=min_B, hi=max_B), lengths(lo=min_I, hi=max_I))
     return shapes.flatmap(ndarrays_of_shape)
 
 


### PR DESCRIPTION
- Require MNIST example on TF to achieve at least 0.8 in 20 iterations
- Fix typo in `arrays_BI` definition. This seems to have caused flakey behaviour in `test_backprop_reduce_sum`, which seems to be fixed now, so I lowered the threshold (let's see what the CI thinks)