### PR TITLE
fix rename to dropout_rate

### DIFF
--- a/thinc/layers/dropout.py
+++ b/thinc/layers/dropout.py
@@ -15,7 +15,7 @@ def Dropout(rate: float = 0.0) -> Model[InT, InT]:
     during training.  Specifically, cells of the input are zeroed with
     probability determined by the `rate` argument.
     """
-    return Model("dropout", forward, attrs={"rate": rate, "is_enabled": True})
+    return Model("dropout", forward, attrs={"dropout_rate": rate, "is_enabled": True})
 
 
 # We're getting type hell here, I think because of the instance checks?
@@ -24,7 +24,7 @@ def Dropout(rate: float = 0.0) -> Model[InT, InT]:
 # I've relaxed the types for now, but it'd be good to understand what's wrong
 # here.
 def forward(model: Model, X, is_train: bool) -> Tuple[Any, Callable]:
-    rate = model.attrs["rate"]
+    rate = model.attrs["dropout_rate"]
     is_enabled = model.attrs["is_enabled"]
     if rate == 0 or not is_enabled:
         return X, lambda dY: dY
@@ -41,7 +41,7 @@ def forward(model: Model, X, is_train: bool) -> Tuple[Any, Callable]:
 def _dropout_array(
     model: Model[ArrayT, ArrayT], X: ArrayT, is_train: bool
 ) -> Tuple[ArrayT, Callable]:
-    rate = model.attrs["rate"]
+    rate = model.attrs["dropout_rate"]
     mask = model.ops.get_dropout_mask(X.shape, rate)
 
     def backprop(dY: ArrayT) -> ArrayT:
@@ -54,7 +54,7 @@ def _dropout_padded(
     model: Model, Xp: Padded, is_train: bool
 ) -> Tuple[Padded, Callable]:
     X = Xp.data
-    mask = model.ops.get_dropout_mask(X.shape, model.attrs["rate"])
+    mask = model.ops.get_dropout_mask(X.shape, model.attrs["dropout_rate"])
     Y = X * mask
 
     def backprop(dYp: Padded) -> Padded:
@@ -68,7 +68,7 @@ def _dropout_ragged(
 ) -> Tuple[Ragged, Callable]:
     X = Xr.data
     lengths = Xr.lengths
-    mask = model.ops.get_dropout_mask(X.shape, model.attrs["rate"])
+    mask = model.ops.get_dropout_mask(X.shape, model.attrs["dropout_rate"])
     Y = X * mask
 
     def backprop(dYr: Ragged) -> Ragged:
@@ -80,7 +80,7 @@ def _dropout_ragged(
 def _dropout_lists(
     model: Model[ArrayT, ArrayT], Xs: List[ArrayT], is_train: bool
 ) -> Tuple[List[ArrayT], Callable]:
-    rate = model.attrs["rate"]
+    rate = model.attrs["dropout_rate"]
     masks = [model.ops.get_dropout_mask(X.shape, rate) for X in Xs]
     Ys = [X * mask for X, mask in zip(Xs, masks)]
 

--- a/thinc/tests/layers/test_linear.py
+++ b/thinc/tests/layers/test_linear.py
@@ -120,7 +120,7 @@ def test_dropout_gives_zero_gradients(W_b_input):
     W, b, input_ = W_b_input
     for node in model.walk():
         if node.name == "dropout":
-            node.attrs["rate"] = 1.0
+            node.attrs["dropout_rate"] = 1.0
     fwd_dropped, finish_update = model.begin_update(input_)
     grad_BO = numpy.ones((nr_batch, nr_out), dtype="f")
     grad_BI = finish_update(grad_BO)

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -2,7 +2,7 @@ import pytest
 import threading
 import time
 import ml_datasets
-from thinc.api import CupyOps, prefer_gpu, Linear, Model, Shim, change_attr_values
+from thinc.api import CupyOps, prefer_gpu, Linear, Dropout, Model, Shim, change_attr_values
 from thinc.api import set_dropout_rate, chain, ReLu, Softmax, Adam
 import numpy
 
@@ -159,7 +159,14 @@ def test_change_attr_values(model_with_no_args):
     assert "error" not in model.attrs
 
 
-def test_set_dropout(model_with_no_args):
+def test_set_dropout():
+    model = Dropout()
+    assert model.attrs["dropout_rate"] == 0.0
+    set_dropout_rate(model, 0.2)
+    assert model.attrs["dropout_rate"] == 0.2
+
+
+def test_set_dropout_2(model_with_no_args):
     model = model_with_no_args
     model.name = "dropout"
     model.attrs["dropout_rate"] = 0.0


### PR DESCRIPTION
PR https://github.com/explosion/thinc/pull/266 didn't actually change the `attr` name of the `Dropout` layer from `rate` to `dropout_rate`, which meant that `set_dropout_rate` didn't work anymore.