### PR TITLE
Remove type from fwd in FeatureExtractor

### DIFF
--- a/thinc/layers/featureextractor.py
+++ b/thinc/layers/featureextractor.py
@@ -15,7 +15,7 @@ def FeatureExtractor(columns: List[Union[int, str]]) -> Model[InT, OutT]:
 
 
 def forward(
-    model: Model[InT, OutT], docs: InT, is_train: bool
+    model: Model[InT, OutT], docs, is_train: bool
 ) -> Tuple[OutT, Callable]:
     columns = model.attrs["columns"]
     features: OutT = []


### PR DESCRIPTION
I'm not sure this is the "fix" we want, but the current `docs` type in `FeatureExtractor.forward()` does not match with the `begin_training(X=...)` arguments we're giving in spaCy, making the unit tests fail if we type it as `List[Doc]`. 

I don't think I know the historic trail here, and why we're also having this check of `if hasattr(doc, "to_array")` in this layer. Could be that the type should be as currently stated, and we need to refactor elsewhere? I'm not sure.