### PR TITLE
Feature: MXNet shim

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,7 @@ jobs:
 
   - script: |
       pip install tensorflow
+      pip install mxnet
       pip install torch -f -https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,8 @@ tensorflow =
 jax =
     jax>=0.1.57
     jaxlib>=0.1.37
+mxnet =
+    mxnet>=1.5.1,<1.6.0
 
 [bdist_wheel]
 universal = false

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -4,7 +4,7 @@ from .loss import CategoricalCrossentropy, L2Distance, CosineDistance
 from .loss import SequenceCategoricalCrossentropy
 from .model import Model, serialize_attr, deserialize_attr
 from .model import set_dropout_rate, change_attr_values
-from .shims import Shim, PyTorchShim, TensorFlowShim, keras_model_fns
+from .shims import Shim, PyTorchShim, TensorFlowShim, keras_model_fns, MXNetShim
 from .shims import maybe_handshake_model
 from .optimizers import Adam, RAdam, SGD, Optimizer
 from .schedules import cyclic_triangular, warmup_linear, constant, constant_then
@@ -13,7 +13,7 @@ from .types import Ragged, Padded, ArgsKwargs
 from .util import fix_random_seed, is_cupy_array, set_active_gpu
 from .util import prefer_gpu, require_gpu, DataValidationError
 from .util import to_categorical, get_width, get_array_module
-from .util import torch2xp, xp2torch, tensorflow2xp, xp2tensorflow
+from .util import torch2xp, xp2torch, tensorflow2xp, xp2tensorflow, mxnet2xp, xp2mxnet
 from .backends import get_ops, set_current_ops, get_current_ops, use_ops
 from .backends import Ops, CupyOps, NumpyOps, JaxOps, has_cupy, has_jax
 from .backends import use_pytorch_for_gpu_memory, use_tensorflow_for_gpu_memory
@@ -23,7 +23,7 @@ from .layers import Maxout, Mish, MultiSoftmax, ReLu, Softmax, LSTM
 from .layers import CauchySimilarity, ParametricAttention, Logistic
 from .layers import SparseLinear, StaticVectors, FeatureExtractor
 from .layers import PyTorchWrapper, PyTorchRNNWrapper, PyTorchLSTM
-from .layers import TensorFlowWrapper, keras_subclass
+from .layers import TensorFlowWrapper, keras_subclass, MXNetWrapper, MXNetRNNWrapper
 
 from .layers import add, bidirectional, chain, clone, concatenate, noop
 from .layers import residual, uniqued, siamese, list2ragged, ragged2list

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -23,7 +23,7 @@ from .layers import Maxout, Mish, MultiSoftmax, ReLu, Softmax, LSTM
 from .layers import CauchySimilarity, ParametricAttention, Logistic
 from .layers import SparseLinear, StaticVectors, FeatureExtractor
 from .layers import PyTorchWrapper, PyTorchRNNWrapper, PyTorchLSTM
-from .layers import TensorFlowWrapper, keras_subclass, MXNetWrapper, MXNetRNNWrapper
+from .layers import TensorFlowWrapper, keras_subclass, MXNetWrapper
 
 from .layers import add, bidirectional, chain, clone, concatenate, noop
 from .layers import residual, uniqued, siamese, list2ragged, ragged2list

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -19,7 +19,7 @@ from .sparselinear import SparseLinear
 from .staticvectors import StaticVectors
 from .lstm import LSTM, PyTorchLSTM
 from .tensorflowwrapper import TensorFlowWrapper, keras_subclass
-from .mxnetwrapper import MXNetWrapper, MXNetRNNWrapper
+from .mxnetwrapper import MXNetWrapper
 
 # Combinators
 from .add import add

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -19,6 +19,7 @@ from .sparselinear import SparseLinear
 from .staticvectors import StaticVectors
 from .lstm import LSTM, PyTorchLSTM
 from .tensorflowwrapper import TensorFlowWrapper, keras_subclass
+from .mxnetwrapper import MXNetWrapper, MXNetRNNWrapper
 
 # Combinators
 from .add import add

--- a/thinc/layers/mxnetwrapper.py
+++ b/thinc/layers/mxnetwrapper.py
@@ -5,7 +5,7 @@ from ..shims import MXNetShim
 from ..config import registry
 from ..util import is_xp_array, is_mxnet_array
 from ..util import xp2mxnet, mxnet2xp, convert_recursive
-from ..types import Array3d, ArgsKwargs, Padded
+from ..types import ArgsKwargs, Padded, Floats3d
 
 
 @registry.layers("MXNetRNNWrapper.v1")
@@ -52,7 +52,7 @@ def MXNetWrapper(
         Y, get_dYmxnet = convert_outputs(Ymxnet)
 
     To allow maximum flexibility, the MXNetShim expects ArgsKwargs objects
-    on the way into the forward and backward passed. The ArgsKwargs objects
+    on the way into the forward and backward passes. The ArgsKwargs objects
     will be passed straight into the model in the forward pass, and straight
     into `mxnet.autograd.backward` during the backward pass.
     """
@@ -159,6 +159,6 @@ def convert_rnn_outputs(model: Model, inputs_outputs: Tuple, is_train):
         dYmxnet = xp2mxnet(dYp.data, requires_grad=True)
         return ArgsKwargs(args=(Ymxnet,), kwargs={"head_grads": dYmxnet})
 
-    Y = cast(Array3d, mxnet2xp(Ymxnet))
+    Y = cast(Floats3d, mxnet2xp(Ymxnet))
     Yp = Padded(Y, Xp.size_at_t, Xp.lengths, Xp.indices)
     return Yp, convert_for_mxnet_backward

--- a/thinc/layers/mxnetwrapper.py
+++ b/thinc/layers/mxnetwrapper.py
@@ -1,0 +1,164 @@
+from typing import Callable, Tuple, Optional, Any, cast, Type
+
+from ..model import Model
+from ..shims import MXNetShim
+from ..config import registry
+from ..util import is_xp_array, is_mxnet_array
+from ..util import xp2mxnet, mxnet2xp, convert_recursive
+from ..types import Array3d, ArgsKwargs, Padded
+
+
+@registry.layers("MXNetRNNWrapper.v1")
+def MXNetRNNWrapper(
+    mxnet_model,
+    convert_inputs: Optional[Callable] = None,
+    convert_outputs: Optional[Callable] = None,
+) -> Model[Padded, Padded]:
+    """Wrap a MXNet RNN model for use in Thinc."""
+    if convert_inputs is None:
+        convert_inputs = convert_rnn_inputs
+    if convert_outputs is None:
+        convert_outputs = convert_rnn_outputs
+    return cast(
+        Model[Padded, Padded],
+        MXNetWrapper(
+            mxnet_model, convert_inputs=convert_inputs, convert_outputs=convert_outputs,
+        ),
+    )
+
+
+@registry.layers("MXNetWrapper.v1")
+def MXNetWrapper(
+    mxnet_model,
+    convert_inputs: Optional[Callable] = None,
+    convert_outputs: Optional[Callable] = None,
+    model_class: Type[Model] = Model,
+    model_name: str = "mxnet",
+) -> Model[Any, Any]:
+    """Wrap a MXNet model, so that it has the same API as Thinc models.
+    To optimize the model, you'll need to create a MXNet optimizer and call
+    optimizer.step() after each batch.
+
+    Your MXNet model's forward method can take arbitrary args and kwargs,
+    but must return either a single tensor as output or a tuple. You may find the
+    MXNet register_forward_hook helpful if you need to adapt the output.
+
+    The convert functions are used to map inputs and outputs to and from your
+    MXNet model. Each function should return the converted output, and a callback
+    to use during the backward pass. So:
+
+        Xmxnet, get_dX = convert_inputs(X)
+        Ymxnet, mxnet_backprop = model.shims[0](Xmxnet, is_train)
+        Y, get_dYmxnet = convert_outputs(Ymxnet)
+
+    To allow maximum flexibility, the MXNetShim expects ArgsKwargs objects
+    on the way into the forward and backward passed. The ArgsKwargs objects
+    will be passed straight into the model in the forward pass, and straight
+    into `mxnet.autograd.backward` during the backward pass.
+    """
+    if convert_inputs is None:
+        convert_inputs = convert_mxnet_default_inputs
+    if convert_outputs is None:
+        convert_outputs = convert_mxnet_default_outputs
+    return model_class(
+        model_name,
+        forward,
+        attrs={"convert_inputs": convert_inputs, "convert_outputs": convert_outputs},
+        shims=[MXNetShim(mxnet_model)],
+    )
+
+
+def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
+    """Return the output of the wrapped MXNet model for the given input,
+    along with a callback to handle the backward pass.
+    """
+    convert_inputs = model.attrs["convert_inputs"]
+    convert_outputs = model.attrs["convert_outputs"]
+
+    Xmxnet, get_dX = convert_inputs(model, X, is_train)
+    Ymxnet, mxnet_backprop = model.shims[0](Xmxnet, is_train)
+    Y, get_dYmxnet = convert_outputs(model, (X, Ymxnet), is_train)
+
+    def backprop(dY: Any) -> Any:
+        dYmxnet = get_dYmxnet(dY)
+        dXmxnet = mxnet_backprop(dYmxnet)
+        dX = get_dX(dXmxnet)
+        return dX
+
+    return Y, backprop
+
+
+# Default conversion functions
+
+
+def convert_mxnet_default_inputs(
+    model: Model, X: Any, is_train: bool
+) -> Tuple[ArgsKwargs, Callable[[ArgsKwargs], Any]]:
+    xp2mxnet_ = lambda x: xp2mxnet(x, requires_grad=is_train)
+    converted = convert_recursive(is_xp_array, xp2mxnet_, X)
+    if isinstance(converted, ArgsKwargs):
+
+        def reverse_conversion(dXmxnet):
+            return convert_recursive(is_mxnet_array, mxnet2xp, dXmxnet)
+
+        return converted, reverse_conversion
+    elif isinstance(converted, dict):
+
+        def reverse_conversion(dXmxnet):
+            dX = convert_recursive(is_mxnet_array, mxnet2xp, dXmxnet)
+            return dX.kwargs
+
+        return ArgsKwargs(args=tuple(), kwargs=converted), reverse_conversion
+    elif isinstance(converted, (tuple, list)):
+
+        def reverse_conversion(dXmxnet):
+            dX = convert_recursive(is_mxnet_array, mxnet2xp, dXmxnet)
+            return dX.args
+
+        return ArgsKwargs(args=tuple(converted), kwargs={}), reverse_conversion
+    else:
+
+        def reverse_conversion(dXmxnet):
+            dX = convert_recursive(is_mxnet_array, mxnet2xp, dXmxnet)
+            return dX.args[0]
+
+        return ArgsKwargs(args=(converted,), kwargs={}), reverse_conversion
+
+
+def convert_mxnet_default_outputs(model: Model, X_Ymxnet: Any, is_train: bool):
+    X, Ymxnet = X_Ymxnet
+    Y = convert_recursive(is_mxnet_array, mxnet2xp, Ymxnet)
+
+    def reverse_conversion(dY: Any) -> ArgsKwargs:
+        dYmxnet = convert_recursive(is_xp_array, xp2mxnet, dY)
+        return ArgsKwargs(args=((Ymxnet,),), kwargs={"head_grads": dYmxnet})
+
+    return Y, reverse_conversion
+
+
+# BiLSTM conversion functions
+
+
+def convert_rnn_inputs(model: Model, Xp: Padded, is_train: bool):
+    size_at_t = Xp.size_at_t
+    lengths = Xp.lengths
+    indices = Xp.indices
+
+    def convert_from_mxnet_backward(d_inputs: ArgsKwargs) -> Padded:
+        dX = mxnet2xp(d_inputs.args[0])
+        return Padded(dX, size_at_t, lengths, indices)  # type: ignore
+
+    output = ArgsKwargs(args=(xp2mxnet(Xp.data, requires_grad=True), None), kwargs={})
+    return output, convert_from_mxnet_backward
+
+
+def convert_rnn_outputs(model: Model, inputs_outputs: Tuple, is_train):
+    Xp, (Ymxnet, _) = inputs_outputs
+
+    def convert_for_mxnet_backward(dYp: Padded) -> ArgsKwargs:
+        dYmxnet = xp2mxnet(dYp.data, requires_grad=True)
+        return ArgsKwargs(args=(Ymxnet,), kwargs={"head_grads": dYmxnet})
+
+    Y = cast(Array3d, mxnet2xp(Ymxnet))
+    Yp = Padded(Y, Xp.size_at_t, Xp.lengths, Xp.indices)
+    return Yp, convert_for_mxnet_backward

--- a/thinc/shims/__init__.py
+++ b/thinc/shims/__init__.py
@@ -1,3 +1,4 @@
 from .shim import Shim
 from .pytorch import PyTorchShim
 from .tensorflow import keras_model_fns, TensorFlowShim, maybe_handshake_model
+from .mxnet import MXNetShim

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -12,7 +12,7 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-from ..util import mxnet2xp, xp2mxnet, convert_recursive
+from ..util import mxnet2xp, xp2mxnet, convert_recursive, make_tempfile
 from ..backends import get_current_ops
 from ..types import ArgsKwargs
 from .shim import Shim
@@ -118,7 +118,7 @@ class MXNetShim(Shim):
 
     def to_bytes(self):
         # MXNet doesn't implement save/load without a filename
-        with tempfile.NamedTemporaryFile() as temp:
+        with make_tempfile("w+b") as temp:
             self._model.save_parameters(temp.name)
             temp.seek(0)
             weights_bytes = temp.read()
@@ -133,6 +133,6 @@ class MXNetShim(Shim):
 
     def _load_params(self, params):
         # MXNet doesn't implement save/load without a filename :(
-        with tempfile.NamedTemporaryFile() as temp:
+        with make_tempfile("w+b") as temp:
             temp.write(params)
             self._model.load_parameters(temp.name, ctx=mx.current_context())

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -136,4 +136,3 @@ class MXNetShim(Shim):
         with tempfile.NamedTemporaryFile() as temp:
             temp.write(params)
             self._model.load_parameters(temp.name, ctx=mx.current_context())
-

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -1,0 +1,143 @@
+from typing import Any
+import contextlib
+from io import BytesIO
+import srsly
+import tempfile
+
+try:
+    import mxnet.autograd
+    import mxnet.optimizer
+    import mxnet as mx
+except ImportError:  # pragma: no cover
+    pass
+
+from ..util import mxnet2xp, xp2mxnet, convert_recursive
+from ..backends import get_current_ops
+from ..types import ArgsKwargs
+from .shim import Shim
+
+
+class MXNetShim(Shim):
+    """Interface between a MXNet model and a Thinc Model. This container is
+    *not* a Thinc Model subclass itself.
+    """
+
+    def __call__(self, inputs, is_train):
+        if is_train:
+            return self.begin_update(inputs)
+        else:
+            return self.predict(inputs), lambda a: ...
+
+    def predict(self, inputs: ArgsKwargs) -> Any:
+        """Pass inputs through to the underlying MXNet model, and return the
+        output. No conversions are performed. The MXNet model is set into
+        evaluation mode.
+        """
+        mx.autograd.set_training(train_mode=False)
+        with mxnet.autograd.pause():
+            outputs = self._model(*inputs.args, **inputs.kwargs)
+        mx.autograd.set_training(train_mode=True)
+        return outputs
+
+    def begin_update(self, inputs: ArgsKwargs):
+        """Pass the inputs through to the underlying MXNet model, keeping
+        track of which items in the input are tensors requiring gradients.
+        If the model returns a single value, it is converted into a one-element
+        tuple. Return the outputs and a callback to backpropagate.
+        """
+        mx.autograd.set_training(train_mode=True)
+        mx.autograd.set_recording(True)
+        output = self._model(*inputs.args, **inputs.kwargs)
+
+        def backprop(grads):
+            mx.autograd.set_recording(False)
+            mxnet.autograd.backward(*grads.args, **grads.kwargs)
+            return convert_recursive(
+                lambda x: hasattr(x, "grad"), lambda x: x.grad, inputs
+            )
+
+        return output, backprop
+
+    def finish_update(self, optimizer):
+        if self._optimizer is None:
+            self._optimizer, self._trainer = self._create_optimizer(optimizer)
+        if getattr(optimizer, "max_grad_norm", None):
+            mxnet.gluon.utils.clip_global_norm(
+                self._model.parameters(), optimizer.max_grad_norm
+            )
+        self._trainer.step(1)
+        for param in self._model.collect_params().values():
+            param.zero_grad()
+        self._update_mxnet_averages(optimizer)
+
+    def _create_optimizer(self, sgd):
+        if sgd.b1 != 0 and sgd.b2 != 0:
+            optimizer = mxnet.optimizer.Adam(
+                learning_rate=sgd.learn_rate, beta1=sgd.b1, beta2=sgd.b2
+            )
+        elif sgd.b2 == 0:
+            optimizer = mxnet.optimizer.SGD(
+                learning_rate=sgd.learn_rate, momentum=sgd.b1
+            )
+        else:
+            raise NotImplementedError
+
+        from mxnet import gluon
+
+        return optimizer, gluon.Trainer(self._model.collect_params(), optimizer)
+
+    @contextlib.contextmanager
+    def use_params(self, params):
+        key_prefix = f"mxnet_{self.id}_"
+        state_dict = {}
+        for k, v in params.items():
+            if hasattr(k, "startswith") and k.startswith(key_prefix):
+                state_dict[k.replace(key_prefix, "")] = xp2mxnet(v)
+        # TODO: state_dict equiv in mxnet? collect_params().copy() maybe?
+        if state_dict:
+            backup = {k: v.clone() for k, v in self._model.state_dict().items()}
+            self._model.load_state_dict(state_dict)
+            yield
+            self._model.load_state_dict(backup)
+        else:
+            yield
+
+    def _update_mxnet_averages(self, sgd, *, init_steps=1):
+        if getattr(sgd, "averages", None) is None:
+            return
+        # Collect parameters if we don't have them
+        for name, param in self._model.collect_params().items():
+            key = f"mxnet_{self.id}_{name}"
+            sgd.nr_update[key] += 1
+            xp_param = mxnet2xp(param.grad())
+            if key in sgd.averages:
+                sgd.ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
+            else:
+                sgd.averages[key] = xp_param.copy()
+                sgd.nr_update[key] = init_steps
+
+    def to_device(self, device):  # pragma: no cover
+        raise NotImplementedError("todo: test this with GPU system")
+        if device == "cpu":
+            self._model.cpu()
+        else:
+            self._model.cuda(device)
+
+    def to_bytes(self):
+        # MXNet doesn't implement save/load without a filename
+        with tempfile.NamedTemporaryFile() as temp:
+            self._model.save_parameters(temp.name)
+            temp.seek(0)
+            weights_bytes = temp.read()
+        msg = {"config": self.cfg, "state": weights_bytes}
+        return srsly.msgpack_dumps(msg)
+
+    def from_bytes(self, bytes_data):
+        msg = srsly.msgpack_loads(bytes_data)
+        self.cfg = msg["config"]
+        # MXNet doesn't implement save/load without a filename :(
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(msg["state"])
+            self._model.load_parameters(temp.name, ctx=mx.current_context())
+        return self
+

--- a/thinc/tests/layers/test_mxnet_wrapper.py
+++ b/thinc/tests/layers/test_mxnet_wrapper.py
@@ -115,7 +115,8 @@ def test_mxnet_wrapper_train_overfits(
 
 
 @pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
-def test_mxnet_wrapper_can_copy_model(model: Model[Array2d, Array2d]):
+def test_mxnet_wrapper_can_copy_model(model: Model[Array2d, Array2d], X: Array2d):
+    model.predict(X)
     copy: Model[Array2d, Array2d] = model.copy()
     assert copy is not None
 
@@ -148,25 +149,9 @@ def test_mxnet_wrapper_from_bytes(model: Model[Array2d, Array2d], X: Array2d):
 
 
 @pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
-def test_mxnet_wrapper_use_params(
-    model: Model[Array2d, Array2d], X: Array2d, Y: Array2d, answer: int
-):
-    optimizer = Adam()
-    with model.use_params(optimizer.averages):
-        assert model.predict(X).argmax() is not None
-    for i in range(10):
-        guesses, backprop = model.begin_update(X)
-        d_guesses = (guesses - Y) / guesses.shape[0]
-        backprop(d_guesses)
-        model.finish_update(optimizer)
-    with model.use_params(optimizer.averages):
-        predicted = model.predict(X).argmax()
-    assert predicted == answer
-
-
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
-def test_mxnet_wrapper_to_cpu(mx_model):
+def test_mxnet_wrapper_to_cpu(mx_model, X: Array2d):
     model = MXNetWrapper(mx_model)
+    model.predict(X)
     model.to_cpu()
 
 

--- a/thinc/tests/layers/test_mxnet_wrapper.py
+++ b/thinc/tests/layers/test_mxnet_wrapper.py
@@ -1,0 +1,238 @@
+import numpy
+import pytest
+from thinc.api import Adam, ArgsKwargs, Linear, Model, Ops, MXNetWrapper
+from thinc.api import get_current_ops, mxnet2xp, xp2mxnet
+from thinc.api import chain, Mish
+from thinc.types import Array, Array1d, Array2d
+from thinc.util import has_mxnet, to_categorical
+
+from ..util import check_input_converters, make_tempdir
+
+
+@pytest.fixture
+def n_hidden() -> int:
+    return 12
+
+
+@pytest.fixture
+def input_size() -> int:
+    return 784
+
+
+@pytest.fixture
+def n_classes() -> int:
+    return 10
+
+
+@pytest.fixture
+def answer() -> int:
+    return 1
+
+
+@pytest.fixture
+def X(input_size: int) -> Array:
+    ops: Ops = get_current_ops()
+    return ops.alloc(shape=(1, input_size))
+
+
+@pytest.fixture
+def Y(answer: int, n_classes: int) -> Array:
+    ops: Ops = get_current_ops()
+    return to_categorical(ops.asarray([answer]), n_classes=n_classes)
+
+
+@pytest.fixture
+def mx_model(n_hidden: int, input_size: int):
+    import mxnet as mx
+
+    mx_model = mx.gluon.nn.Sequential()
+    mx_model.add(
+        mx.gluon.nn.Dense(n_hidden),
+        mx.gluon.nn.LayerNorm(),
+        mx.gluon.nn.Dense(n_hidden, activation="relu"),
+        mx.gluon.nn.LayerNorm(),
+        mx.gluon.nn.Dense(10, activation="softrelu"),
+    )
+    mx_model.initialize()
+    return mx_model
+
+
+@pytest.fixture
+def model(mx_model) -> Model[Array, Array]:
+    return MXNetWrapper(mx_model)
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_roundtrip_conversion():
+    import mxnet as mx
+
+    xp_tensor = numpy.zeros((2, 3), dtype="f")
+    mx_tensor = xp2mxnet(xp_tensor)
+    assert isinstance(mx_tensor, mx.nd.NDArray)
+    new_xp_tensor = mxnet2xp(mx_tensor)
+    assert numpy.array_equal(xp_tensor, new_xp_tensor)
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_gluon_sequential():
+    import mxnet as mx
+
+    mx_model = mx.gluon.nn.Sequential()
+    mx_model.add(mx.gluon.nn.Dense(12))
+    wrapped = MXNetWrapper(mx_model)
+    assert isinstance(wrapped, Model)
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_built_model(model: Model[Array, Array], X: Array, Y: Array):
+    # built models are validated more and can perform useful operations:
+    assert model.predict(X) is not None
+    # They can de/serialized
+    assert model.from_bytes(model.to_bytes()) is not None
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_predict(model: Model[Array, Array], X: Array):
+    model.predict(X)
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_train_overfits(
+    model: Model[Array, Array], X: Array, Y: Array, answer: int
+):
+    optimizer = Adam()
+    for i in range(100):
+        guesses, backprop = model(X, is_train=True)
+        d_guesses = (guesses - Y) / guesses.shape[0]
+        backprop(d_guesses)
+        model.finish_update(optimizer)
+    predicted = model.predict(X).argmax()
+    assert predicted == answer
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_accepts_optimizer(
+    model: Model[Array, Array], mx_model, X: Array, Y: Array, answer: int
+):
+    # Update the optimizer weights
+    optimizer = Adam()
+    for i in range(10):
+        guesses, backprop = model(X, is_train=True)
+        d_guesses = (guesses - Y) / guesses.shape[0]
+        backprop(d_guesses)
+        model.finish_update(optimizer)
+
+    # Pass the existing optimizer to a new wrapper shim
+    wrapped: Model[Array, Array] = MXNetWrapper(
+        mx_model, optimizer=model.shims[0]._optimizer
+    )
+    assert model.shims[0]._optimizer is not None
+    assert wrapped.shims[0]._optimizer is not None
+    weights_model = model.shims[0]._optimizer.get_weights()
+    weights_wrapped = wrapped.shims[0]._optimizer.get_weights()
+    for w1, w2 in zip(weights_model, weights_wrapped):
+        assert numpy.array_equal(w1, w2)
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_can_copy_model(model: Model[Array, Array]):
+    copy: Model[Array, Array] = model.copy()
+    assert copy is not None
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_to_bytes(model: Model[Array, Array], X: Array):
+    # And can be serialized
+    model_bytes = model.to_bytes()
+    assert model_bytes is not None
+    model.from_bytes(model_bytes)
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_to_from_disk(
+    model: Model[Array, Array], X: Array, Y: Array, answer: int
+):
+    with make_tempdir() as tmp_path:
+        model_file = tmp_path / "model.h5"
+        model.to_disk(model_file)
+        another_model = model.from_disk(model_file)
+        assert another_model is not None
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_from_bytes(model: Model[Array, Array], X: Array):
+    model.predict(X)
+    model_bytes = model.to_bytes()
+    another_model = model.from_bytes(model_bytes)
+    assert another_model is not None
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_use_params(
+    model: Model[Array, Array], X: Array, Y: Array, answer: int
+):
+    optimizer = Adam()
+    with model.use_params(optimizer.averages):
+        assert model.predict(X).argmax() is not None
+    for i in range(10):
+        guesses, backprop = model.begin_update(X)
+        d_guesses = (guesses - Y) / guesses.shape[0]
+        backprop(d_guesses)
+        model.finish_update(optimizer)
+    with model.use_params(optimizer.averages):
+        predicted = model.predict(X).argmax()
+    assert predicted == answer
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_to_cpu(mx_model):
+    model = MXNetWrapper(mx_model)
+    model.to_cpu()
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_to_gpu(model: Model[Array, Array], X: Array):
+    # Raises while failing to import cupy
+    with pytest.raises(ImportError):
+        model.to_gpu(0)
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.parametrize(
+    "data,n_args,kwargs_keys",
+    [
+        # fmt: off
+        (numpy.zeros((2, 3), dtype="f"), 1, []),
+        ([numpy.zeros((2, 3), dtype="f"), numpy.zeros((2, 3), dtype="f")], 2, []),
+        ((numpy.zeros((2, 3), dtype="f"), numpy.zeros((2, 3), dtype="f")), 2, []),
+        ({"a": numpy.zeros((2, 3), dtype="f"), "b": numpy.zeros((2, 3), dtype="f")}, 0, ["a", "b"]),
+        (ArgsKwargs((numpy.zeros((2, 3), dtype="f"), numpy.zeros((2, 3), dtype="f")), {"c": numpy.zeros((2, 3), dtype="f")}), 2, ["c"]),
+        # fmt: on
+    ],
+)
+def test_mxnet_wrapper_convert_inputs(data, n_args, kwargs_keys):
+    import mxnet as mx
+
+    mx_model = mx.gluon.nn.Sequential()
+    mx_model.add(mx.gluon.nn.Dense(12))
+    model = MXNetWrapper(mx_model)
+    convert_inputs = model.attrs["convert_inputs"]
+    Y, backprop = convert_inputs(model, data, is_train=True)
+    check_input_converters(Y, backprop, data, n_args, kwargs_keys, mx.nd.NDArray)
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_thinc_model_subclass(mx_model):
+    class CustomModel(Model):
+        def fn(self) -> int:
+            return 1337
+
+    model = MXNetWrapper(mx_model, model_class=CustomModel)
+    assert isinstance(model, CustomModel)
+    assert model.fn() == 1337
+
+
+@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+def test_mxnet_wrapper_thinc_set_model_name(mx_model):
+    model = MXNetWrapper(mx_model, model_name="cool")
+    assert model.name == "cool"

--- a/thinc/tests/layers/test_mxnet_wrapper.py
+++ b/thinc/tests/layers/test_mxnet_wrapper.py
@@ -1,9 +1,11 @@
+from typing import cast
+
 import numpy
 import pytest
 from thinc.api import Adam, ArgsKwargs, Linear, Model, Ops, MXNetWrapper
 from thinc.api import get_current_ops, mxnet2xp, xp2mxnet
 from thinc.api import chain, Mish
-from thinc.types import Array2d, Array1d, Array2d
+from thinc.types import Array2d, Array1d, IntsXd
 from thinc.util import has_mxnet, to_categorical
 
 from ..util import check_input_converters, make_tempdir
@@ -38,7 +40,7 @@ def X(input_size: int) -> Array2d:
 @pytest.fixture
 def Y(answer: int, n_classes: int) -> Array2d:
     ops: Ops = get_current_ops()
-    return to_categorical(ops.asarray([answer]), n_classes=n_classes)
+    return to_categorical(cast(IntsXd, ops.asarray([answer])), n_classes=n_classes)
 
 
 @pytest.fixture

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -6,6 +6,9 @@ import functools
 from wasabi import table
 from pydantic import create_model, ValidationError
 import inspect
+import os
+import tempfile
+import contextlib
 
 try:  # pragma: no cover
     import cupy
@@ -414,6 +417,14 @@ def validate_fwd_input_output(
         raise DataValidationError(name, X, Y, e.errors())
 
 
+@contextlib.contextmanager
+def make_tempfile(mode="r"):
+    f = tempfile.NamedTemporaryFile(mode=mode, delete=False)
+    yield f
+    f.close()
+    os.remove(f.name)
+
+
 __all__ = [
     "get_array_module",
     "fix_random_seed",
@@ -431,4 +442,5 @@ __all__ = [
     "xp2tensorflow",
     "validate_fwd_input_output",
     "DataValidationError",
+    "make_tempfile",
 ]

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -327,7 +327,7 @@ def tensorflow2xp(tensorflow_tensor: "tf.Tensor") -> ArrayXd:  # pragma: no cove
 
 
 def xp2mxnet(
-    xp_tensor: Array, requires_grad: bool = False
+    xp_tensor: ArrayXd, requires_grad: bool = False
 ) -> "torch.Tensor":  # pragma: no cover
     """Convert a numpy or cupy tensor to a MXNet tensor."""
     if hasattr(xp_tensor, "toDlpack"):
@@ -340,7 +340,7 @@ def xp2mxnet(
     return mx_tensor
 
 
-def mxnet2xp(mx_tensor: "mx.nd.NDArray") -> Array:  # pragma: no cover
+def mxnet2xp(mx_tensor: "mx.nd.NDArray") -> ArrayXd:  # pragma: no cover
     """Convert a MXNet tensor to a numpy or cupy tensor."""
     if mx_tensor.context.device_type != "cpu":
         return cupy.fromDlpack(mx_tensor.to_dlpack_for_write())


### PR DESCRIPTION
Add support for wrapping MXNet models:

```python
from thinc.api import MXNetWrapper
import mxnet as mx

mx_model = mx.gluon.nn.Sequential()
mx_model.add(
    mx.gluon.nn.Dense(n_hidden),
    mx.gluon.nn.LayerNorm(),
    mx.gluon.nn.Dense(n_hidden, activation="relu"),
    mx.gluon.nn.LayerNorm(),
    mx.gluon.nn.Dense(10, activation="softrelu"),
)
thinc_model = MXNetWrapper(mx_model)
X = thinc_model.ops.alloc2f(1, 784)
Y = thinc_model.predict(X)
assert list(Y.shape) == [1, 10]
```