### PR TITLE
Use site (site-packages) to detect how to run mypy tests

### DIFF
--- a/thinc/tests/mypy/test_mypy.py
+++ b/thinc/tests/mypy/test_mypy.py
@@ -2,6 +2,7 @@ import os
 import re
 from pathlib import Path
 import shutil
+import site
 
 import pytest
 
@@ -19,9 +20,14 @@ cases = [
 
 
 @pytest.mark.parametrize("config_filename,python_filename,output_filename", cases)
-def test_mypy_results(config_filename, python_filename, output_filename, tmpdir):
+def test_mypy_results(config_filename, python_filename, output_filename, tmpdir, monkeypatch):
     os.chdir(tmpdir)
     root_dir = Path(__file__).parent
+    thinc_root_dir = Path(__file__).parent.parent.parent.parent
+    # Support testing installed package
+    if str(thinc_root_dir) not in site.getsitepackages():
+        # Support testing source package
+        monkeypatch.setenv("MYPYPATH", str(thinc_root_dir))
     tmpdir_path = Path(tmpdir)
 
     full_config_path: Path = root_dir / f"configs/{config_filename}"

--- a/thinc/tests/mypy/test_mypy.py
+++ b/thinc/tests/mypy/test_mypy.py
@@ -2,11 +2,11 @@ import os
 import re
 from pathlib import Path
 import shutil
-import site
 
 import pytest
 
 from mypy import api as mypy_api
+from mypy.sitepkgs import getsitepackages
 
 # You can change the following variable to True during development to overwrite expected output with generated output
 GENERATE = False
@@ -20,13 +20,13 @@ cases = [
 
 
 @pytest.mark.parametrize("config_filename,python_filename,output_filename", cases)
-def test_mypy_results(config_filename, python_filename, output_filename, tmpdir, monkeypatch):
+def test_mypy_results(
+    config_filename, python_filename, output_filename, tmpdir, monkeypatch
+):
     os.chdir(tmpdir)
     root_dir = Path(__file__).parent
     thinc_root_dir = Path(__file__).parent.parent.parent.parent
-    # Support testing installed package
-    if str(thinc_root_dir) not in site.getsitepackages():
-        # Support testing source package
+    if str(thinc_root_dir) not in getsitepackages():
         monkeypatch.setenv("MYPYPATH", str(thinc_root_dir))
     tmpdir_path = Path(tmpdir)
 

--- a/thinc/tests/mypy/test_mypy.py
+++ b/thinc/tests/mypy/test_mypy.py
@@ -2,11 +2,11 @@ import os
 import re
 from pathlib import Path
 import shutil
+import sys
 
 import pytest
 
 from mypy import api as mypy_api
-from mypy.sitepkgs import getsitepackages
 
 # You can change the following variable to True during development to overwrite expected output with generated output
 GENERATE = False
@@ -26,7 +26,7 @@ def test_mypy_results(
     os.chdir(tmpdir)
     root_dir = Path(__file__).parent
     thinc_root_dir = Path(__file__).parent.parent.parent.parent
-    if str(thinc_root_dir) not in getsitepackages():
+    if "--pyargs" not in sys.argv:
         monkeypatch.setenv("MYPYPATH", str(thinc_root_dir))
     tmpdir_path = Path(tmpdir)
 


### PR DESCRIPTION
:green_heart: Use `site` (site-packages) to detect how to run mypy tests.

This should allow running tests in CI with the package installed:

```console
$ python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
```

But also with source code without having to install it first:

```console
$ pytest thinc
```

This supersedes #247 