### PR TITLE
String formatting precision fails when run on GPU.

### DIFF
--- a/examples/00_intro_to_thinc.ipynb
+++ b/examples/00_intro_to_thinc.ipynb
@@ -138,7 +138,7 @@
     "        correct += (Yh.argmax(axis=1) == Y.argmax(axis=1)).sum()\n",
     "        total += Yh.shape[0]\n",
     "    score = correct / total\n",
-    "    print(f\" {i} {score:.3f}\")"
+    "    print(f\" {i} {float(score):.3f}\")"
    ]
   },
   {
@@ -171,7 +171,7 @@
     "            correct += (Yh.argmax(axis=1) == Y.argmax(axis=1)).sum()\n",
     "            total += Yh.shape[0]\n",
     "        score = correct / total\n",
-    "        print(f\" {i} {score:.3f}\")"
+    "        print(f\" {i} {float(score):.3f}\")"
    ]
   },
   {


### PR DESCRIPTION
If you run the [00_intro_to_thinc.ipynb](https://github.com/explosion/thinc/blob/master/examples/00_intro_to_thinc.ipynb) notebook on a GPU, you get the following error when you execute the cell where you create an optimizer and do several passes over the data.

```
TypeError                                 Traceback (most recent call last)

<ipython-input-27-c7aae9724b89> in <module>()
     21         total += Yh.shape[0]
     22     score = correct / total
---> 23     print(f" {i} {score:.3f}")

TypeError: unsupported format string passed to cupy.core.core.ndarray.__format__

```
Also see the related open NumPy issue: [ndarray should offer `__format__` that can adjust precision #5543 ](https://github.com/numpy/numpy/issues/5543).

This pull request proposes a simple fix/workaround.