### PR TITLE
Rename Unserializable 'data' field

### DIFF
--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -36,7 +36,7 @@ def concatenate(*layers: Model) -> Model[InT, XY_XY_OutT]:
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    Ys, callbacks = zip(*[lyr(X, is_train=is_train) for lyr in model.layers])
+    Ys, callbacks = zip(*[layer(X, is_train=is_train) for layer in model.layers])
     if isinstance(Ys[0], list):
         return _list_forward(model, X, Ys, callbacks, is_train)
     else:

--- a/thinc/layers/staticvectors.py
+++ b/thinc/layers/staticvectors.py
@@ -46,37 +46,37 @@ def StaticVectors(
 def forward(
     model: Model[InT, OutT], ids: Ints1d, is_train: bool
 ) -> Tuple[OutT, Callable]:
-    # Assume the original 'vectors' object has a 'data' attribute that is compatible with Floats2d
-    vector_table = cast(Floats2d, model.attrs["vectors"].wrapped_object.data)
-    nO = vector_table.shape[1]
+    # Assume the original 'vectors' object contains the actual data and is compatible with Floats2d
+    vectors = cast(Floats2d, model.attrs["vectors"].wrapped_object)
+    nO = vectors.shape[1]
     nN = ids.shape[0]
     dropout: Optional[float] = model.attrs.get("dropout_rate")
-    output = vector_table[ids]
+    output = vectors[ids]
     drop_mask = cast(Floats1d, model.ops.get_dropout_mask((nO,), dropout))
     output *= drop_mask
     W = cast(Floats2d, model.get_param("W"))
-    vec = vector_table[ids * (ids < vector_table.shape[0])]
+    vec = vectors[ids * (ids < vectors.shape[0])]
     vec = model.ops.as_contig(vec)
     assert vec.shape[0] == ids.shape[0]
 
     def backprop(d_output: OutT) -> Ints1d:
-        model.inc_grad("W", model.ops.gemm(d_output, vector_table, trans1=True))
+        model.inc_grad("W", model.ops.gemm(d_output, vectors, trans1=True))
         dX = model.ops.alloc1i(nN)
         return dX
 
-    output = model.ops.gemm(vector_table, W, trans2=True)
+    output = model.ops.gemm(vectors, W, trans2=True)
     return output, backprop
 
 
 def init(
     model: Model[InT, OutT], X: Optional[Ints1d] = None, Y: Optional[OutT] = None
 ) -> Model[InT, OutT]:
-    # Assume the original 'vectors' object has a 'data' attribute that contains the actual vectors
-    vector_table = model.attrs["vectors"].wrapped_object.data
-    if vector_table is None:
+    # Assume the original 'vectors' object contains the actual data
+    vectors = model.attrs["vectors"].wrapped_object
+    if vectors is None:
         raise ValueError("Can't initialize: vectors attribute unset")
-    model.set_dim("nV", vector_table.shape[0] + 1)
-    model.set_dim("nM", vector_table.shape[1])
+    model.set_dim("nV", vectors.shape[0] + 1)
+    model.set_dim("nM", vectors.shape[1])
     W = model.ops.alloc2f(model.get_dim("nO"), model.get_dim("nM"))
     model.set_param("W", W)
     return model

--- a/thinc/layers/staticvectors.py
+++ b/thinc/layers/staticvectors.py
@@ -47,7 +47,8 @@ def forward(
     model: Model[InT, OutT], ids: Ints1d, is_train: bool
 ) -> Tuple[OutT, Callable]:
     # Assume the original 'vectors' object contains the actual data and is compatible with Floats2d
-    vectors = cast(Floats2d, model.attrs["vectors"].wrapped_object)
+    vectors = cast(Floats2d, model.attrs["vectors"].obj)
+
     nO = vectors.shape[1]
     nN = ids.shape[0]
     dropout: Optional[float] = model.attrs.get("dropout_rate")
@@ -72,7 +73,7 @@ def init(
     model: Model[InT, OutT], X: Optional[Ints1d] = None, Y: Optional[OutT] = None
 ) -> Model[InT, OutT]:
     # Assume the original 'vectors' object contains the actual data
-    vectors = model.attrs["vectors"].wrapped_object
+    vectors = model.attrs["vectors"].obj
     if vectors is None:
         raise ValueError("Can't initialize: vectors attribute unset")
     model.set_dim("nV", vectors.shape[0] + 1)

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -940,7 +940,7 @@ class ArgsKwargs:
 class Unserializable:
     """Wrap a value to prevent it from being serialized by msgpack."""
 
-    data: Any
+    wrapped_object: Any
 
 
 def validate_array(obj, ndim=None, dtype=None):

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -940,7 +940,7 @@ class ArgsKwargs:
 class Unserializable:
     """Wrap a value to prevent it from being serialized by msgpack."""
 
-    wrapped_object: Any
+    obj: Any
 
 
 def validate_array(obj, ndim=None, dtype=None):


### PR DESCRIPTION
This was a cute little bug:
* `Unserializable` has a `data` field
* `StaticVectors` expects a `vectors` argument (e.g. spaCy's `Vectors` object) that has a `data` field
* So you'd need to do `model.attrs["vectors"].data.data` to get to the actual data, but I renamed it instead to avoid future confusion