### PR TITLE
Fix ordering in list2padded op

### DIFF
--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -308,8 +308,12 @@ class Ops:
         indices_ = [i for length, i in lengths_indices]
         lengths_ = [length for length, i in lengths_indices]
         nS = max([len(seq) for seq in seqs])
+        # Reorder the sequences, by length. This looks the same in either
+        # direction: you're swapping elements between their original and sorted
+        # position.
+        seqs = [seqs[x] for x in indices_]
         arr: Floats3d = self.pad(seqs)
-        arr = arr.transpose((1, 0, 2))
+        arr = self.as_contig(arr.transpose((1, 0, 2)))
         # Build a lookup table so we can find how big the batch is at point t.
         batch_size_at_t_ = self.alloc1i(nS)
         batch_size_at_t_ += 1


### PR DESCRIPTION
The `list2padded` operation didn't reorder the sequences, so the batches were entirely incorrect.