### PR TITLE
Fixing StaticVectors

### DIFF
--- a/thinc/layers/staticvectors.py
+++ b/thinc/layers/staticvectors.py
@@ -76,8 +76,6 @@ def init(
     X: Optional[InT] = None,
     Y: Optional[OutT] = None,
 ) -> Model[InT, OutT]:
-    if Y is not None:
-        model.set_dim("nO", get_width(Y))
     # Assume the original 'vectors' object contains the actual data
     vectors = model.attrs["vectors"].obj
     if vectors is None:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -180,7 +180,7 @@ class Model(Generic[InT, OutT]):
     def set_dim(self, name: str, value: int) -> None:
         """Set a value for a dimension."""
         if name not in self._dims:
-            raise KeyError(f"Cannot set dimension '{name}' for model '{self.name}'.")
+            raise KeyError(f"Cannot set unknown dimension '{name}' for model '{self.name}'.")
         old_value = self._dims[name]
         if old_value is not None and old_value != value:
             err = f"Attempt to change dimension '{name}' for model '{self.name}' from {old_value} to {value}"


### PR DESCRIPTION
`StaticVectors` didn't work for me, it got the wrong output dimensions. I shuffled the code around, more or less as it used to be. This seems to at least fix the training step.

A review would be good because I'm not entirely confident.

Also, there's still quite a bit to do on the current spaCy `develop` branch with respect to `StaticVectors`, `cfg` passing, IO etc, so I haven't yet been able to test this end-to-end yet, which is why I'm suggesting to have this as WIP (see also https://github.com/svlandeg/spaCy/tree/feature/static-vectors).