### PR TITLE
fixed breaking bug in Embed

### DIFF
--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -50,7 +50,9 @@ def forward(
     vectors = cast(Floats2d, model.get_param("E"))
     nO = vectors.shape[1]
     nN = ids.shape[0]
+    nV = vectors.shape[0]
     dropout: Optional[float] = model.attrs.get("dropout_rate")
+    ids = ids % nV 
     output = vectors[ids]
     drop_mask = cast(Floats1d, model.ops.get_dropout_mask((nO,), dropout))
     output *= drop_mask


### PR DESCRIPTION
**What was the Bug?**
Embed was breaking in the previous version due to indexes out of bounds error. #306 

**Reproduction**
Replace HashEmbed in Example 3 pos_tagger_basic_cnn.ipynb of thinc documentation with Embed. 

**How was it fixed?**
A modulo operation with the vocabulary size was needed to keep it within range (Similar to the implementation in hashEmbed)

**Additional Comments**
Documentation for Embed needs to be updated and further discussion is needed on the input Parameter nV. It does not make sense to default it to 1. nV typically needs to be the size of the vocabulary of the corpus to reduce collisions. 

**Why does HashEmbed work with small nV values then?** 
Given the way the hashing has been implemented in HashEmbed, it technically generates nV^4 different combinations for the word to embedding mapping. Hence, even an nV of 16 was sufficient to cover the entire vocabulary. The same does not happen in Embed, hence the need to set nV to size of the vocab. Even in the case of HashEmbed, if someone sets nV too small such that nV^4 << vocab size then the collisions would be high and model accuracy takes a big hit.

**Future Discussions**
Why is ids parameter generating such large and sparse numbers in the first place? Why dont we have a continuous mapping of the numbers there? It would do away with the need for a modulo operation. In fact the modulo operation is not entirely reliable in handling collisions. 
