### PR TITLE
Fix murmur hash on v7.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,13 +11,13 @@ jobs:
     matrix:
       Python27Linux:
         imageName: 'ubuntu-16.04'
-        python.version: '2.7.16'
+        python.version: '2.7.17'
       Python27Mac:
         imageName: 'macos-10.13'
         python.version: '2.7'
       Python35Linux:
         imageName: 'ubuntu-16.04'
-        python.version: '3.5.7'
+        python.version: '3.5.9'
       Python35Windows:
         imageName: 'vs2017-win2016'
         python.version: '3.5'

--- a/thinc/neural/_murmur3.cu
+++ b/thinc/neural/_murmur3.cu
@@ -12,12 +12,29 @@
  * and modified to work with CUDA.
  */
 // Including stdint.h is a pain in cupy, so just put the declarations in.
-typedef unsigned char                uint8_t;
-typedef unsigned int                uint32_t;
-typedef unsigned long int        uint64_t;
-typedef signed char                int8_t;
-typedef int                        int32_t;
-typedef long int                int64_t;
+// Beware that long int is not 64bit on all platforms!
+// e.g. Windows requires a 'long long' to get to 64 bit.
+
+typedef unsigned char           uint8_t;
+typedef unsigned int            uint32_t;
+typedef signed char             int8_t;
+typedef int                     int32_t;
+
+const unsigned long int test_var = 0;
+const int size = sizeof(test_var);
+
+#if size == 64
+
+typedef unsigned long int      uint64_t;
+typedef long int               int64_t;
+
+#else
+
+typedef unsigned long long      uint64_t;
+typedef long long               int64_t;
+
+#endif
+
 
 //-----------------------------------------------------------------------------
 // Platform-specific functions and macros


### PR DESCRIPTION
Add fix for GPU/Windows processing from PR https://github.com/explosion/thinc/pull/149, so we can include it in the release of spaCy 2.2.4