### PR TITLE
Set Embed shape to (nV, nO)

### DIFF
--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -74,6 +74,6 @@ def init(
 ) -> Model[InT, OutT]:
     if Y is not None:
         model.set_dim("nO", get_width(Y))
-    shape = (model.get_dim("nV") + 1, model.get_dim("nO"))
+    shape = (model.get_dim("nV"), model.get_dim("nO"))
     model.set_param("E", initializer(model.ops, shape))
     return model

--- a/thinc/tests/layers/test_layers_api.py
+++ b/thinc/tests/layers/test_layers_api.py
@@ -103,8 +103,8 @@ TEST_CASES = [
     # fmt: off
     # Other
     ("expand_window.v1", {}, array2d, array2d),
-    ("Embed.v1", {"nO": 4, "nV": array2dint.max(), "column": 0}, array2dint, array2d),
-    ("Embed.v1", {"nO": 4, "nV": array1dint.max()}, array1dint, array2d),
+    ("Embed.v1", {"nO": 4, "nV": array2dint.max() + 1, "column": 0}, array2dint, array2d),
+    ("Embed.v1", {"nO": 4, "nV": array1dint.max() + 1}, array1dint, array2d),
     ("HashEmbed.v1", {"nO": 1, "nV": array2dint.max(), "column": 0}, array2dint, array2d),
     ("HashEmbed.v1", {"nO": 1, "nV": 2}, array1dint, array2d),
     ("MultiSoftmax.v1", {"nOs": (1, 3)}, array2d, array2d),

--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -13,7 +13,7 @@ ROWS = 10
 # used to. The key feature is this composite decorator. It injects a function,
 # 'draw'.
 @composite
-def lists_of_integers(draw, columns=2, lo=0, hi=ROWS):
+def lists_of_integers(draw, columns=2, lo=0, hi=ROWS-1):
     # We call draw to get example values, which we can manipulate.
     # Here we get a list of integers, where each member of the list
     # should be between a min and max value.
@@ -43,7 +43,7 @@ def test_uniqued_calls_init():
     assert calls == [True, True]
 
 
-@given(X=lists_of_integers(lo=0, hi=ROWS))
+@given(X=lists_of_integers(lo=0, hi=ROWS-1))
 def test_uniqued_doesnt_change_result(model, X):
     umodel = uniqued(model, column=model.attrs["column"]).initialize()
     Y, bp_Y = model(X, is_train=True)


### PR DESCRIPTION
Use `nV` rather than `nV + 1` to remove all whiffs of OOV handling from `Embed`.