### PR TITLE
Example Notebook: Make sure data is on the right device after loading from config

### DIFF
--- a/examples/00_intro_to_thinc.ipynb
+++ b/examples/00_intro_to_thinc.ipynb
@@ -532,6 +532,12 @@
     "batch_size = loaded_config[\"training\"][\"batch_size\"]\n",
     "(train_X, train_Y), (dev_X, dev_Y) = loaded_config[\"training\"][\"data\"]\n",
     "\n",
+    "# After loading the data from config, they might still need to be moved to the right device\n",
+    "train_X = model.ops.asarray(train_X)\n",
+    "train_Y = model.ops.asarray(train_Y)\n",
+    "dev_X = model.ops.asarray(dev_X)\n",
+    "dev_Y = model.ops.asarray(dev_Y)\n",
+    "\n",
     "model.initialize(X=train_X[:5], Y=train_Y[:5])\n",
     "train_model(((train_X, train_Y), (dev_X, dev_Y)), model, optimizer, n_iter, batch_size)"
    ]


### PR DESCRIPTION
When running the example notebook *00_intro_to_thinc.ipynb* on a Colab GPU runtime, the section that loads the data from config will fail with the following error:
```
<ipython-input-21-be6cf6a02f24> in <module>()
      5 (train_X, train_Y), (dev_X, dev_Y) = loaded_config["training"]["data"]
      6 
----> 7 model.initialize(X=train_X[:5], Y=train_Y[:5])
      8 train_model(((train_X, train_Y), (dev_X, dev_Y)), model, optimizer, n_iter, batch_size)

ValueError: Encountered a numpy array when processing with cupy. Did you call model.ops.asarray on your data?
```

To solve this issue, we simply need to explicitly assure that the data is on the correct device, as done earlier in the notebook when first building the dataset.

Another way could be to implicitly move the data to the right device when calling `registry.make_from_config(config)` but this is obviously a further stretch than fixing the notebook for now.