### PR TITLE
init instead of _init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,44 +1,137 @@
-*.egg-info/
-dist/
-*.dat
-build/
-.env/
-.python/
-*.pyc
-*.swp
-*.swo
+# File extensions
+*.pdf
+*.aux
+*.orig
+*.pyo
+*.pickle
+*.dvi
+*.o
+*.sqlite
 .*.s*
+*.dat
+
+# Varia
+_paths.py
+.mypy_cache
+.hypothesis/
+version.cc
+version.pl
+
+# Tests
+tests/model/*
+tests/model/
+
+# Website
+website/.cache/
+website/public/
+website/node_modules
+website/.npm
+website/logs
+*.log
+npm-debug.log*
+website/www/
+website/_deploy.sh
+*.html
+
+# Cython / C extensions
+cythonize.json
 *.cpp
 *.so
 *.so.1
-*.sqlite
-.ropeproject/
-*.o
-*.log
-version.cc
-version.pl
+
+# Vim / VSCode / editors
+*.swp
+*.swo
+*.sw*
+Profile.prof
+.vscode
+.sass-cache
+
+# Python
+.Python
+.python-version
+__pycache__/
+.pytest_cache
+*.py[cod]
+.env/
+.env*
+.~env/
+.venv
+env3.*/
+venv/
+.dev
+.denv
+.pypyenv
+.pytest_cache/
+
+# Distribution / packaging
+env/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+pip-wheel-metadata/
+Pipfile.lock
+.installed.cfg
+*.egg
+.eggs
+MANIFEST
+
+# Temporary files
+*.~*
+tmp/
 predict
 train
-*.dvi
-*.pdf
-*.aux
-*.html
-Profile.prof
-_paths.py
-tests/model/*
-tests/model/
-*.orig
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
 .coverage
-.cache/
-.hypothesis/
-*.pyo
-tmp/
-*.pickle
-*.dat
-.eggs/
-.pytest_cache/
-.vscode/
-.mypy_cache
-env3.*/
+.cache
+nosetests.xml
 coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Windows
+*.bat
+Thumbs.db
+Desktop.ini
+
+# Mac OS X
+*.DS_Store
+
+# Komodo project files
+*.komodoproject
+
+# Other
+*.tgz
+
+# Pycharm project files
+*.idea
+
+# IPython
 .ipynb_checkpoints/

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -39,7 +39,7 @@ class Model(Generic[InT, OutT]):
     ops: Ops
     id: int
     _func: Callable
-    _init: Callable
+    init: Callable
     _params: ParamServer
     _dims: Dict[str, Optional[int]]
     _layers: List["Model"]
@@ -54,7 +54,7 @@ class Model(Generic[InT, OutT]):
         "id",
         "ops",
         "_func",
-        "_init",
+        "init",
         "_params",
         "_dims",
         "_attrs",
@@ -84,7 +84,7 @@ class Model(Generic[InT, OutT]):
             init = partial(empty_init, self)
         # Assign to callable attrs: https://github.com/python/mypy/issues/2427
         setattr(self, "_func", forward)
-        setattr(self, "_init", init)
+        setattr(self, "init", init)
         self.ops = ops if ops is not None else get_current_ops()
         self._params = ParamServer()
         self._dims = dict(dims)
@@ -248,7 +248,7 @@ class Model(Generic[InT, OutT]):
     def get_ref(self, name: str) -> "Model":
         """Retrieve the value of a reference of the given name."""
         if name not in self._refs:
-            raise KeyError(f"Cannot get reference '{name} for model '{self.name}'.")
+            raise KeyError(f"Cannot get reference '{name}' for model '{self.name}'.")
         value = self._refs[name]
         if value is None:
             err = f"Cannot get reference '{name}' for model '{self.name}': value unset."
@@ -275,8 +275,8 @@ class Model(Generic[InT, OutT]):
         example input and output data to perform shape inference."""
         if DATA_VALIDATION.get():
             validate_fwd_input_output(self.name, self._func, X, Y)
-        if self._init is not None:
-            self._init(self, X=X, Y=Y)
+        if self.init is not None:
+            self.init(self, X=X, Y=Y)
         return self
 
     def begin_update(self, X: InT) -> Tuple[OutT, Callable[[InT], OutT]]:
@@ -388,7 +388,7 @@ class Model(Generic[InT, OutT]):
         copied: Model[InT, OutT] = Model(
             self.name,
             self._func,
-            init=self._init,
+            init=self.init,
             params=copy.deepcopy(params),
             dims=copy.deepcopy(self._dims),
             attrs=copy.deepcopy(self._attrs),

--- a/thinc/tests/layers/test_feed_forward.py
+++ b/thinc/tests/layers/test_feed_forward.py
@@ -114,9 +114,9 @@ def test_init_functions_are_called():
     layer1 = Linear(5)
     layer2 = Linear(5)
     layer3 = Linear(5)
-    layer1._init = partial(register_init, "one")
-    layer2._init = partial(register_init, "two")
-    layer3._init = partial(register_init, "three")
+    layer1.init = partial(register_init, "one")
+    layer2.init = partial(register_init, "two")
+    layer3.init = partial(register_init, "three")
     # This is the nesting we'll get from operators.
     model = chain(layer1, chain(layer2, layer3))
     assert not init_was_called

--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -35,7 +35,7 @@ def model(nO=128):
 def test_uniqued_calls_init():
     calls = []
     embed = Embed(5, 5, column=0)
-    embed._init = lambda *args, **kwargs: calls.append(True)
+    embed.init = lambda *args, **kwargs: calls.append(True)
     embed.initialize()
     assert calls == [True]
     uembed = uniqued(embed)


### PR DESCRIPTION
As we may need to copy/set the `Model`'s `init` function in downstream applications, renaming from `_init` to `init`.

Also expanded / structured the `gitignore` file, similar as how we're doing it in spaCy. Nothing was removed from the original list.