### PR TITLE
Fix CI build on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
 
   - script: |
       pip install tensorflow
-      pip install mxnet
+      pip install mxnet==1.6.0b20200219
       pip install torch -f https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
 
   - script: |
       pip install tensorflow
-      pip install mxnet==1.6.0b20200219
+      pip install mxnet; sys_platform != 'win32'
       pip install torch -f https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
   - script: |
       pip install tensorflow
       pip install mxnet
-      pip install torch -f -https://download.pytorch.org/whl/torch_stable.html
+      pip install torch -f https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
     displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
 
   - script: |
       pip install tensorflow
-      pip install mxnet; sys_platform != 'win32'
+      pip install "mxnet; sys_platform != 'win32'"
       pip install torch -f https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml


### PR DESCRIPTION
Only install mxnet on non-windows platforms where it has a valid wheel. The project specifies a generic wheel for the `1.6.0` release that fails to install on our Windows CI build.