### PR TITLE
Support for additional initializers from keras

### DIFF
--- a/thinc/initializers.py
+++ b/thinc/initializers.py
@@ -15,9 +15,31 @@ from .util import partial
 # It's especially helpful for JAX, which has a pretty intrincate PRNG scheme I
 # haven't figured out yet.
 
+
+def lecun_normal_init(ops: Ops, shape: Shape) -> FloatsXd:
+    scale = numpy.sqrt(1.0 / shape[1])
+    return ops.asarray_f(numpy.random.normal(0, scale, shape))
+
+
+@registry.initializers("lecun_normal_init.v1")
+def configure_lecun_normal_init() -> Callable[[Shape], FloatsXd]:
+    return partial(lecun_normal_init)
+
+
+def he_normal_init(ops: Ops, shape: Shape) -> FloatsXd:
+    scale = numpy.sqrt(2.0 / shape[1])
+    return ops.asarray_f(numpy.random.normal(0, scale, shape))
+
+
+@registry.initializers("he_normal_init.v1")
+def configure_he_normal_init() -> Callable[[Shape], FloatsXd]:
+    return partial(he_normal_init)
+
+
 def glorot_normal_init(ops: Ops, shape: Shape) -> FloatsXd:
     scale = numpy.sqrt(2.0 / (shape[1] + shape[0]))
     return ops.asarray_f(numpy.random.normal(0, scale, shape))
+
 
 @registry.initializers("glorot_normal_init.v1")
 def configure_glorot_normal_init() -> Callable[[Shape], FloatsXd]:
@@ -28,6 +50,7 @@ def he_uniform_init(ops: Ops, shape: Shape) -> FloatsXd:
     scale = numpy.sqrt(6.0 / shape[1])
     return ops.asarray_f(numpy.random.uniform(-scale, scale, shape))
 
+
 @registry.initializers("he_uniform_init.v1")
 def configure_he_uniform_init() -> Callable[[Shape], FloatsXd]:
     return partial(he_uniform_init)
@@ -36,6 +59,7 @@ def configure_he_uniform_init() -> Callable[[Shape], FloatsXd]:
 def lecun_uniform_init(ops: Ops, shape: Shape) -> FloatsXd:
     scale = numpy.sqrt(3.0 / shape[1])
     return ops.asarray_f(numpy.random.uniform(-scale, scale, shape))
+
 
 @registry.initializers("lecun_uniform_init.v1")
 def configure_lecun_uniform_init() -> Callable[[Shape], FloatsXd]:
@@ -46,6 +70,7 @@ def glorot_uniform_init(ops: Ops, shape: Shape) -> FloatsXd:
     scale = numpy.sqrt(6.0 / (shape[0] + shape[1]))
     return ops.asarray_f(numpy.random.uniform(-scale, scale, shape))
 
+
 @registry.initializers("glorot_uniform_init.v1")
 def configure_glorot_uniform_init() -> Callable[[Shape], FloatsXd]:
     return partial(glorot_uniform_init)
@@ -53,6 +78,7 @@ def configure_glorot_uniform_init() -> Callable[[Shape], FloatsXd]:
 
 def zero_init(ops: Ops, shape: Shape) -> FloatsXd:
     return ops.alloc(shape)
+
 
 @registry.initializers("zero_init.v1")
 def configure_zero_init() -> Callable[[FloatsXd], FloatsXd]:
@@ -64,6 +90,7 @@ def uniform_init(
 ) -> FloatsXd:
     values = numpy.random.uniform(lo, hi, shape)
     return ops.asarray_f(values.astype("float32"))
+
 
 @registry.initializers("uniform_init.v1")
 def configure_uniform_init(
@@ -81,8 +108,20 @@ def normal_init(ops: Ops, shape: Shape, *, fan_in: int = -1) -> FloatsXd:
     inits = ops.reshape_f(inits, shape)
     return ops.asarray_f(inits)
 
+
 @registry.initializers("normal_init.v1")
 def configure_normal_init(*, fan_in: int = -1) -> Callable[[FloatsXd], FloatsXd]:
     return partial(normal_init, fan_in=fan_in)
 
-__all__ = ["normal_init", "uniform_init", "glorot_uniform_init", "zero_init", "lecun_uniform_init","he_uniform_init","glorot_normal_init"]
+
+__all__ = [
+    "normal_init",
+    "uniform_init",
+    "glorot_uniform_init",
+    "zero_init",
+    "lecun_uniform_init",
+    "he_uniform_init",
+    "glorot_normal_init",
+    "he_normal_init",
+    "lecun_normal_init",
+]

--- a/thinc/initializers.py
+++ b/thinc/initializers.py
@@ -15,7 +15,13 @@ from .util import partial
 # It's especially helpful for JAX, which has a pretty intrincate PRNG scheme I
 # haven't figured out yet.
 
+def glorot_normal_init(ops: Ops, shape: Shape) -> FloatsXd:
+    scale = numpy.sqrt(2.0 / (shape[1] + shape[0]))
+    return ops.asarray_f(numpy.random.normal(0, scale, shape))
 
+@registry.initializers("glorot_normal_init.v1")
+def configure_glorot_normal_init() -> Callable[[Shape], FloatsXd]:
+    return partial(glorot_normal_init)
 
 
 def he_uniform_init(ops: Ops, shape: Shape) -> FloatsXd:
@@ -79,4 +85,4 @@ def normal_init(ops: Ops, shape: Shape, *, fan_in: int = -1) -> FloatsXd:
 def configure_normal_init(*, fan_in: int = -1) -> Callable[[FloatsXd], FloatsXd]:
     return partial(normal_init, fan_in=fan_in)
 
-__all__ = ["normal_init", "uniform_init", "glorot_uniform_init", "zero_init", "lecun_uniform_init","he_uniform_init"]
+__all__ = ["normal_init", "uniform_init", "glorot_uniform_init", "zero_init", "lecun_uniform_init","he_uniform_init","glorot_normal_init"]

--- a/thinc/initializers.py
+++ b/thinc/initializers.py
@@ -16,10 +16,29 @@ from .util import partial
 # haven't figured out yet.
 
 
+
+
+def he_uniform_init(ops: Ops, shape: Shape) -> FloatsXd:
+    scale = numpy.sqrt(6.0 / shape[1])
+    return ops.asarray_f(numpy.random.uniform(-scale, scale, shape))
+
+@registry.initializers("he_uniform_init.v1")
+def configure_he_uniform_init() -> Callable[[Shape], FloatsXd]:
+    return partial(he_uniform_init)
+
+
+def lecun_uniform_init(ops: Ops, shape: Shape) -> FloatsXd:
+    scale = numpy.sqrt(3.0 / shape[1])
+    return ops.asarray_f(numpy.random.uniform(-scale, scale, shape))
+
+@registry.initializers("lecun_uniform_init.v1")
+def configure_lecun_uniform_init() -> Callable[[Shape], FloatsXd]:
+    return partial(lecun_uniform_init)
+
+
 def glorot_uniform_init(ops: Ops, shape: Shape) -> FloatsXd:
     scale = numpy.sqrt(6.0 / (shape[0] + shape[1]))
     return ops.asarray_f(numpy.random.uniform(-scale, scale, shape))
-
 
 @registry.initializers("glorot_uniform_init.v1")
 def configure_glorot_uniform_init() -> Callable[[Shape], FloatsXd]:
@@ -28,7 +47,6 @@ def configure_glorot_uniform_init() -> Callable[[Shape], FloatsXd]:
 
 def zero_init(ops: Ops, shape: Shape) -> FloatsXd:
     return ops.alloc(shape)
-
 
 @registry.initializers("zero_init.v1")
 def configure_zero_init() -> Callable[[FloatsXd], FloatsXd]:
@@ -40,7 +58,6 @@ def uniform_init(
 ) -> FloatsXd:
     values = numpy.random.uniform(lo, hi, shape)
     return ops.asarray_f(values.astype("float32"))
-
 
 @registry.initializers("uniform_init.v1")
 def configure_uniform_init(
@@ -58,10 +75,8 @@ def normal_init(ops: Ops, shape: Shape, *, fan_in: int = -1) -> FloatsXd:
     inits = ops.reshape_f(inits, shape)
     return ops.asarray_f(inits)
 
-
 @registry.initializers("normal_init.v1")
 def configure_normal_init(*, fan_in: int = -1) -> Callable[[FloatsXd], FloatsXd]:
     return partial(normal_init, fan_in=fan_in)
 
-
-__all__ = ["normal_init", "uniform_init", "glorot_uniform_init", "zero_init"]
+__all__ = ["normal_init", "uniform_init", "glorot_uniform_init", "zero_init", "lecun_uniform_init","he_uniform_init"]

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -180,7 +180,9 @@ class Model(Generic[InT, OutT]):
     def set_dim(self, name: str, value: int) -> None:
         """Set a value for a dimension."""
         if name not in self._dims:
-            raise KeyError(f"Cannot set unknown dimension '{name}' for model '{self.name}'.")
+            raise KeyError(
+                f"Cannot set unknown dimension '{name}' for model '{self.name}'."
+            )
         old_value = self._dims[name]
         if old_value is not None and old_value != value:
             err = f"Attempt to change dimension '{name}' for model '{self.name}' from {old_value} to {value}"

--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -13,7 +13,7 @@ ROWS = 10
 # used to. The key feature is this composite decorator. It injects a function,
 # 'draw'.
 @composite
-def lists_of_integers(draw, columns=2, lo=0, hi=ROWS-1):
+def lists_of_integers(draw, columns=2, lo=0, hi=ROWS - 1):
     # We call draw to get example values, which we can manipulate.
     # Here we get a list of integers, where each member of the list
     # should be between a min and max value.
@@ -43,7 +43,7 @@ def test_uniqued_calls_init():
     assert calls == [True, True]
 
 
-@given(X=lists_of_integers(lo=0, hi=ROWS-1))
+@given(X=lists_of_integers(lo=0, hi=ROWS - 1))
 def test_uniqued_doesnt_change_result(model, X):
     umodel = uniqued(model, column=model.attrs["column"]).initialize()
     Y, bp_Y = model(X, is_train=True)


### PR DESCRIPTION
Includes Lecun_Unfiorm, He_Uniform and Glorot_Normal initializers - Reference - https://keras.io/initializers/ 

Completes - 
TODO: Harmonize naming with Keras, and fill in missing entries https://keras.io/initializers/ We should also have He normal/uniform and probably lecun normal/uniform.

Will add Lecun and He Normal once Glorot normal is approved