### PR TITLE
chore: update mac os images on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
         imageName: 'vs2017-win2016'
         python.version: '3.6'
       Python36Mac:
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         python.version: '3.6'
       Python38Linux:
         imageName: 'ubuntu-16.04'
@@ -24,7 +24,7 @@ jobs:
         imageName: 'vs2017-win2016'
         python.version: '3.8'
       Python38Mac:
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         python.version: '3.8'
     maxParallel: 4
   pool:


### PR DESCRIPTION
It looks like Azure is deprecating old 10.13 mac images, so try updating them to 10.15

>This job was temporarily blocked because it uses a Microsoft hosted agent (MacOS-10.13) that will be permanently removed on March 23rd, 2020.  See https://aka.ms/blocked-hosted-agent for more information.
