### PR TITLE
with_cpu

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a2"
+__version__ = "8.0.0a3"
 __release__ = True

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -30,8 +30,7 @@ from .layers import residual, uniqued, siamese, list2ragged, ragged2list
 from .layers import with_array, with_padded, with_list, with_ragged, with_flatten
 from .layers import with_reshape, with_getitem, strings2arrays, list2array
 from .layers import list2ragged, ragged2list, list2padded, padded2list, remap_ids
-from .layers import array_getitem
-from .layers import with_debug
+from .layers import array_getitem, with_cpu, with_debug
 
 from .layers import reduce_max, reduce_mean, reduce_sum
 

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -50,6 +50,7 @@ from .padded2list import padded2list
 from .remap_ids import remap_ids
 from .strings2arrays import strings2arrays
 from .with_array import with_array
+from .with_cpu import with_cpu
 from .with_flatten import with_flatten
 from .with_padded import with_padded
 from .with_list import with_list
@@ -101,6 +102,7 @@ __all__ = [
     "with_reshape",
     "with_getitem",
     "with_array",
+    "with_cpu",
     "with_list",
     "with_ragged",
     "with_padded",

--- a/thinc/layers/sparselinear.pyx
+++ b/thinc/layers/sparselinear.pyx
@@ -22,15 +22,13 @@ OutT = ArrayXd
 def SparseLinear(nO: Optional[int] = None, length: int = 2 ** 18):
     # NB: We can't have generic return type annotation if we want function to
     # be bound (and inspectable): https://github.com/cython/cython/issues/2753
-    model: Model[InT, OutT] = Model(
+    return Model(
         "sparse_linear",
         forward,
         init=init,
         params={"W": None, "b": None},
         dims={"nO": nO, "length": length},
-        ops=NumpyOps()
     )
-    return model
 
 
 @cython.binding(True)

--- a/thinc/layers/with_cpu.py
+++ b/thinc/layers/with_cpu.py
@@ -1,0 +1,50 @@
+from typing import Tuple, Callable, Any
+
+import numpy
+from thinc.backends import Ops
+
+from ..model import Model
+from ..config import registry
+
+
+@registry.layers("with_cpu.v1")
+def with_cpu(layer: Model, ops: Ops) -> Model:
+    layer.to_cpu()
+    return Model(f"with_cpu", forward, layers=[layer], ops=ops, init=init)
+
+
+def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
+    cpu_outputs, backprop = model.layers[0].begin_update(_to_cpu(X))
+    gpu_outputs = _to_device(model.ops, cpu_outputs)
+
+    def with_cpu_backprop(d_outputs):
+        cpu_d_outputs = _to_cpu(d_outputs)
+        return backprop(cpu_d_outputs)
+
+    return gpu_outputs, with_cpu_backprop
+
+
+def init(model: Model, X: Any, Y: Any) -> Model:
+    return model.layers[0].initialize(X, Y)
+
+
+def _to_cpu(X):
+    if isinstance(X, numpy.ndarray):
+        return X
+    elif isinstance(X, tuple):
+        return tuple([_to_cpu(x) for x in X])
+    elif isinstance(X, list):
+        return [_to_cpu(x) for x in X]
+    elif hasattr(X, "get"):
+        return X.get()
+    else:
+        return X
+
+
+def _to_device(ops, X):
+    if isinstance(X, tuple):
+        return tuple([_to_device(ops, x) for x in X])
+    elif isinstance(X, list):
+        return [_to_device(ops, x) for x in X]
+    else:
+        return ops.asarray(X)

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -299,13 +299,16 @@ class Model(Generic[InT, OutT]):
         with each parameter and gradient of the model.
         """
         for node in self.walk():
+            orig_ops = node.ops
             for name in node.param_names:
                 if node.has_grad(name):
                     param = node.get_param(name)
                     grad = node.get_grad(name)
-                    param, grad = optimizer((node.id, name), param, grad)
-                    node.set_param(name, param)
-                    node.set_grad(name, grad)
+                    param, grad = optimizer((node.id, name),
+                                            optimizer.ops.xp.asarray(param),
+                                            optimizer.ops.xp.asarray(grad))
+                    node.set_param(name, orig_ops.asarray(param))
+                    node.set_grad(name, orig_ops.asarray(grad))
             for shim in node.shims:
                 shim.finish_update(optimizer)
 

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -305,8 +305,8 @@ class Model(Generic[InT, OutT]):
                     param = node.get_param(name)
                     grad = node.get_grad(name)
                     if hasattr(optimizer, 'ops'):
-                        param = optimizer.ops.asarray(param)
-                        grad = optimizer.ops.asarray(grad)
+                        param = optimizer.ops.asarray(param)        # type: ignore
+                        grad = optimizer.ops.asarray(grad)          # type: ignore
                     param, grad = optimizer((node.id, name), param, grad)
                     node.set_param(name, orig_ops.asarray(param))   # type: ignore
                     node.set_grad(name, orig_ops.asarray(grad))     # type: ignore

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -308,8 +308,8 @@ class Model(Generic[InT, OutT]):
                         param = optimizer.ops.xp.asarray(param)
                         optimizer.ops.xp.asarray(grad)
                     param, grad = optimizer((node.id, name), param, grad)
-                    node.set_param(name, orig_ops.asarray(param))
-                    node.set_grad(name, orig_ops.asarray(grad))
+                    node.set_param(name, orig_ops.asarray(param))   # type: ignore
+                    node.set_grad(name, orig_ops.asarray(grad))     # type: ignore
             for shim in node.shims:
                 shim.finish_update(optimizer)
 

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -304,9 +304,10 @@ class Model(Generic[InT, OutT]):
                 if node.has_grad(name):
                     param = node.get_param(name)
                     grad = node.get_grad(name)
-                    param, grad = optimizer((node.id, name),
-                                            optimizer.ops.xp.asarray(param),
-                                            optimizer.ops.xp.asarray(grad))
+                    if hasattr(optimizer,'ops'):
+                        param = optimizer.ops.xp.asarray(param)
+                        optimizer.ops.xp.asarray(grad)
+                    param, grad = optimizer((node.id, name), param, grad)
                     node.set_param(name, orig_ops.asarray(param))
                     node.set_grad(name, orig_ops.asarray(grad))
             for shim in node.shims:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -304,9 +304,9 @@ class Model(Generic[InT, OutT]):
                 if node.has_grad(name):
                     param = node.get_param(name)
                     grad = node.get_grad(name)
-                    if hasattr(optimizer,'ops'):
+                    if hasattr(optimizer, 'ops'):
                         param = optimizer.ops.xp.asarray(param)
-                        optimizer.ops.xp.asarray(grad)
+                        grad = optimizer.ops.xp.asarray(grad)
                     param, grad = optimizer((node.id, name), param, grad)
                     node.set_param(name, orig_ops.asarray(param))   # type: ignore
                     node.set_grad(name, orig_ops.asarray(grad))     # type: ignore

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -305,8 +305,8 @@ class Model(Generic[InT, OutT]):
                     param = node.get_param(name)
                     grad = node.get_grad(name)
                     if hasattr(optimizer, 'ops'):
-                        param = optimizer.ops.xp.asarray(param)
-                        grad = optimizer.ops.xp.asarray(grad)
+                        param = optimizer.ops.asarray(param)
+                        grad = optimizer.ops.asarray(grad)
                     param, grad = optimizer((node.id, name), param, grad)
                     node.set_param(name, orig_ops.asarray(param))   # type: ignore
                     node.set_grad(name, orig_ops.asarray(grad))     # type: ignore


### PR DESCRIPTION
To accomodate for the spaCy BOW text categorizer, I transferred the `with_cpu` code from spaCy 2.X to here.

There was trouble with running `finish_update` though, because the optimizer couldn't deal with the Numpy weights from the layers on CPU. Not sure how that used to work. Probably I'm missing an easier/prettier fix, but for now this seems to work.