### PR TITLE
Fix CPU/GPU IO by checking the layer before setting the param

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a3"
+__version__ = "8.0.0a4"
 __release__ = True

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -548,7 +548,8 @@ class Model(Generic[InT, OutT]):
                 loaded_value = deserialize_attr(default_value, value, attr, node)
                 node.attrs[attr] = loaded_value
             for param_name, value in msg["params"][i].items():
-                value = node.ops.asarray(value)
+                if value is not None:
+                    value = node.ops.asarray(value)
                 node.set_param(param_name, value)
             for i, shim_bytes in enumerate(msg["shims"][i]):
                 node.shims[i].from_bytes(shim_bytes)

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -548,6 +548,7 @@ class Model(Generic[InT, OutT]):
                 loaded_value = deserialize_attr(default_value, value, attr, node)
                 node.attrs[attr] = loaded_value
             for param_name, value in msg["params"][i].items():
+                value = node.ops.asarray(value)
                 node.set_param(param_name, value)
             for i, shim_bytes in enumerate(msg["shims"][i]):
                 node.shims[i].from_bytes(shim_bytes)

--- a/thinc/tests/test_serialize.py
+++ b/thinc/tests/test_serialize.py
@@ -54,6 +54,19 @@ def test_simple_model_roundtrip_bytes():
     assert model.get_param("b")[0, 0] == 1
 
 
+def test_simple_model_roundtrip_bytes_length():
+    """ Ensure that serialization of non-initialized weight matrices goes fine """
+    model1 = Maxout(5, 10, nP=2)
+    model2 = Maxout(5, 10, nP=2)
+
+    data1 = model1.to_bytes()
+    model2 = model2.from_bytes(data1)
+    data2 = model2.to_bytes()
+
+    assert data1 == data2
+    assert len(data1) == len(data2)
+
+
 def test_simple_model_roundtrip_bytes_serializable_attrs():
     fwd = lambda model, X, is_train: (X, lambda dY: dY)
     attr = SerializableAttr()


### PR DESCRIPTION
If we have a mixed model with CPU & GPU layers, the current IO doesn't work because `model.from_bytes` [converts](https://github.com/explosion/thinc/blob/master/thinc/model.py#L507) the read data with `msg = convert_recursive(is_xp_array, self.ops.asarray, msg)` which results in all-cupy or all-numpy arrays across the model.

We used to have layer-specific conversions though, cf. https://github.com/explosion/thinc/blob/v7.x/thinc/neural/_classes/model.py#L357, but this has gotten a bit more tricky with the current design using `convert_recursive`.

This PR has a quick hack that does the conversion of a `param` once more before actually setting it. It feels a little inefficient, because an array may be converted from `numpy` to `cupy` and back... But this keeps the code change minimal. Happy to discuss other options!