### PR TITLE
Add tests for notebook examples

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,15 +19,15 @@ jobs:
       Python36Mac:
         imageName: 'macos-10.15'
         python.version: '3.6'
-      # Python38Linux:
-      #   imageName: 'ubuntu-16.04'
-      #   python.version: '3.8'
-      # Python38Windows:
-      #   imageName: 'vs2017-win2016'
-      #   python.version: '3.8'
-      # Python38Mac:
-      #   imageName: 'macos-10.15'
-      #   python.version: '3.8'
+      Python38Linux:
+        imageName: 'ubuntu-16.04'
+        python.version: '3.8'
+      Python38Windows:
+        imageName: 'vs2017-win2016'
+        python.version: '3.8'
+      Python38Mac:
+        imageName: 'macos-10.15'
+        python.version: '3.8'
     maxParallel: 4
   pool:
     vmImage: $(imageName)
@@ -70,9 +70,9 @@ jobs:
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
     
   - script: |
-      # pip install tensorflow
-      # pip install "mxnet; sys_platform != 'win32'"
-      # pip install torch -f https://download.pytorch.org/whl/torch_stable.html
+      pip install tensorflow
+      pip install "mxnet; sys_platform != 'win32'"
+      pip install torch -f https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib 
       pip install ipykernel pydot graphviz 
       python -m ipykernel install --name thinc-notebook-tests --user

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
     displayName: 'Install graphviz (Linux)'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-    - script: 'brew install graphviz'
+  - script: 'brew install graphviz'
     displayName: 'Install graphviz (MacOS)'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,8 +63,9 @@ jobs:
       pip install tensorflow
       pip install "mxnet; sys_platform != 'win32'"
       pip install torch -f https://download.pytorch.org/whl/torch_stable.html
-      pip install jax jaxlib
-      python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
+      pip install jax jaxlib ipykernel pydot
+      python -m ipykernel install --name thinc-notebook-tests
+      NOTEBOOK_KERNEL="thinc-notebook-tests" python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
     displayName: 'Run tests'
 
   - bash: bash <(curl -s https://codecov.io/bash)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,12 +11,12 @@ jobs:
       # Python36Linux:
       #   imageName: 'ubuntu-16.04'
       #   python.version: '3.6'
-      # Python36Windows:
-      #   imageName: 'vs2017-win2016'
-      #   python.version: '3.6'
-      Python36Mac:
-        imageName: 'macos-10.15'
+      Python36Windows:
+        imageName: 'vs2017-win2016'
         python.version: '3.6'
+      # Python36Mac:
+      #   imageName: 'macos-10.15'
+      #   python.version: '3.6'
       # Python38Linux:
       #   imageName: 'ubuntu-16.04'
       #   python.version: '3.8'
@@ -59,14 +59,12 @@ jobs:
       pip install dist/$SDIST
     displayName: 'Install from sdist'
 
-  # Install graphviz
   - script: 'sudo apt-get -yq install graphviz'
-    displayName: 'Install graphviz on Linux'
+    displayName: 'Install graphviz (Linux)'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-    
-  # Install graphviz
-  - script: 'brew install graphviz'
-    displayName: 'Install graphviz on MacOS'
+
+    - script: 'brew install graphviz'
+    displayName: 'Install graphviz (MacOS)'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
     
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,10 +59,15 @@ jobs:
       pip install dist/$SDIST
     displayName: 'Install from sdist'
 
-  # Install graphviz programmatically on Linux
+  # Install graphviz
   - script: 'sudo apt-get -yq install graphviz'
     displayName: 'Install graphviz on Linux'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    
+  # Install graphviz
+  - script: 'brew install graphviz'
+    displayName: 'Install graphviz on MacOS'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
     
   - script: |
       # pip install tensorflow

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,12 +14,12 @@ jobs:
       # Python36Windows:
       #   imageName: 'vs2017-win2016'
       #   python.version: '3.6'
-      # Python36Mac:
-      #   imageName: 'macos-10.15'
-      #   python.version: '3.6'
-      Python38Linux:
-        imageName: 'ubuntu-16.04'
-        python.version: '3.8'
+      Python36Mac:
+        imageName: 'macos-10.15'
+        python.version: '3.6'
+      # Python38Linux:
+      #   imageName: 'ubuntu-16.04'
+      #   python.version: '3.8'
       # Python38Windows:
       #   imageName: 'vs2017-win2016'
       #   python.version: '3.8'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,17 +6,19 @@ trigger:
 
 jobs:
 - job: 'Test'
+  variables:
+    NOTEBOOK_KERNEL: "thinc-notebook-tests"
   strategy:
     matrix:
-      # Python36Linux:
-      #   imageName: 'ubuntu-16.04'
-      #   python.version: '3.6'
+      Python36Linux:
+        imageName: 'ubuntu-16.04'
+        python.version: '3.6'
       Python36Windows:
         imageName: 'vs2017-win2016'
         python.version: '3.6'
-      # Python36Mac:
-      #   imageName: 'macos-10.15'
-      #   python.version: '3.6'
+      Python36Mac:
+        imageName: 'macos-10.15'
+        python.version: '3.6'
       # Python38Linux:
       #   imageName: 'ubuntu-16.04'
       #   python.version: '3.8'
@@ -74,7 +76,7 @@ jobs:
       pip install jax jaxlib 
       pip install ipykernel pydot graphviz 
       python -m ipykernel install --name thinc-notebook-tests --user
-      NOTEBOOK_KERNEL="thinc-notebook-tests" python -m pytest --pyargs thinc --cov=thinc --cov-report=xml -k "test_ipython_notebooks"
+      python -m pytest --pyargs thinc --cov=thinc --cov-report=xml -k "test_ipython_notebooks"
     displayName: 'Run tests'
 
   - bash: bash <(curl -s https://codecov.io/bash)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,24 +8,24 @@ jobs:
 - job: 'Test'
   strategy:
     matrix:
-      Python36Linux:
-        imageName: 'ubuntu-16.04'
-        python.version: '3.6'
-      Python36Windows:
-        imageName: 'vs2017-win2016'
-        python.version: '3.6'
-      Python36Mac:
-        imageName: 'macos-10.15'
-        python.version: '3.6'
+      # Python36Linux:
+      #   imageName: 'ubuntu-16.04'
+      #   python.version: '3.6'
+      # Python36Windows:
+      #   imageName: 'vs2017-win2016'
+      #   python.version: '3.6'
+      # Python36Mac:
+      #   imageName: 'macos-10.15'
+      #   python.version: '3.6'
       Python38Linux:
         imageName: 'ubuntu-16.04'
         python.version: '3.8'
-      Python38Windows:
-        imageName: 'vs2017-win2016'
-        python.version: '3.8'
-      Python38Mac:
-        imageName: 'macos-10.15'
-        python.version: '3.8'
+      # Python38Windows:
+      #   imageName: 'vs2017-win2016'
+      #   python.version: '3.8'
+      # Python38Mac:
+      #   imageName: 'macos-10.15'
+      #   python.version: '3.8'
     maxParallel: 4
   pool:
     vmImage: $(imageName)
@@ -64,7 +64,7 @@ jobs:
       pip install "mxnet; sys_platform != 'win32'"
       pip install torch -f https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib ipykernel pydot
-      python -m ipykernel install --name thinc-notebook-tests
+      sudo python -m ipykernel install --name thinc-notebook-tests
       NOTEBOOK_KERNEL="thinc-notebook-tests" python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
     displayName: 'Run tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,11 @@ jobs:
       pip install dist/$SDIST
     displayName: 'Install from sdist'
 
+  # Install graphviz programmatically on Linux
+  - script: 'sudo apt-get -yq install graphviz'
+    displayName: 'Install graphviz on Linux'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    
   - script: |
       # pip install tensorflow
       # pip install "mxnet; sys_platform != 'win32'"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
       pip install jax jaxlib 
       pip install ipykernel pydot graphviz 
       python -m ipykernel install --name thinc-notebook-tests --user
-      python -m pytest --pyargs thinc --cov=thinc --cov-report=xml -k "test_ipython_notebooks"
+      python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
     displayName: 'Run tests'
 
   - bash: bash <(curl -s https://codecov.io/bash)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,11 +60,11 @@ jobs:
     displayName: 'Install from sdist'
 
   - script: |
-      pip install tensorflow
-      pip install "mxnet; sys_platform != 'win32'"
-      pip install torch -f https://download.pytorch.org/whl/torch_stable.html
+      # pip install tensorflow
+      # pip install "mxnet; sys_platform != 'win32'"
+      # pip install torch -f https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib ipykernel pydot
-      sudo python -m ipykernel install --name thinc-notebook-tests
+      python -m ipykernel install --name thinc-notebook-tests --user
       NOTEBOOK_KERNEL="thinc-notebook-tests" python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
     displayName: 'Run tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,9 +63,10 @@ jobs:
       # pip install tensorflow
       # pip install "mxnet; sys_platform != 'win32'"
       # pip install torch -f https://download.pytorch.org/whl/torch_stable.html
-      pip install jax jaxlib ipykernel pydot
+      pip install jax jaxlib 
+      pip install ipykernel pydot graphviz 
       python -m ipykernel install --name thinc-notebook-tests --user
-      NOTEBOOK_KERNEL="thinc-notebook-tests" python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
+      NOTEBOOK_KERNEL="thinc-notebook-tests" python -m pytest --pyargs thinc --cov=thinc --cov-report=xml -k "test_ipython_notebooks"
     displayName: 'Run tests'
 
   - bash: bash <(curl -s https://codecov.io/bash)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ pytest-cov
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
 mypy
+# Executing notebook tests
 ipykernel>=5.1.4,<5.2.0
 nbconvert==5.6.1,<5.7.0
 nbformat==5.0.4,<5.1.0
+pydot>=1.4.1,<1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,3 @@ mypy
 ipykernel>=5.1.4,<5.2.0
 nbconvert==5.6.1,<5.7.0
 nbformat==5.0.4,<5.1.0
-pydot>=1.4.1,<1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,6 @@ pytest-cov
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
 mypy
-ipykernel>=5.1.4
+ipykernel>=5.1.4,<5.2.0
+nbconvert==5.6.1,<5.7.0
+nbformat==5.0.4,<5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pytest-cov
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
 mypy
+ipykernel>=5.1.4

--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a3"
+__version__ = "8.0.0a4"
 __release__ = True

--- a/thinc/layers/add.py
+++ b/thinc/layers/add.py
@@ -55,12 +55,11 @@ def init(
     model: Model[InT, InT], X: Optional[InT] = None, Y: Optional[InT] = None
 ) -> Model[InT, InT]:
     if X is not None:
-        if model.has_dim("nI"):
-            X_width = get_width(X)
-            model.set_dim("nI", X_width)
-            for layer in model.layers:
-                if layer.has_dim("nI"):
-                    layer.set_dim("nI", X_width)
+        if model.has_dim("nI") is not False:
+            model.set_dim("nI", get_width(X))
+        for layer in model.layers:
+            if layer.has_dim("nI") is not False:
+                layer.set_dim("nI", get_width(X))
     for layer in model.layers:
         layer.initialize(X=X, Y=Y)
     model.set_dim("nO", model.layers[0].get_dim("nO"))

--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -97,12 +97,11 @@ def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
 ) -> Model[InT, OutT]:
     if X is not None:
-        if model.has_dim("nI"):
-            X_width = get_width(X)
-            model.set_dim("nI", X_width)
-            for layer in model.layers:
-                if layer.has_dim("nI"):
-                    layer.set_dim("nI", X_width)
+        if model.has_dim("nI") is not False:
+            model.set_dim("nI", get_width(X))
+        for layer in model.layers:
+            if layer.has_dim("nI") is not False:
+                layer.set_dim("nI", get_width(X))
     for layer in model.layers:
         layer.initialize(X=X, Y=Y)
     if all([layer.has_dim("nO") for layer in model.layers]):

--- a/thinc/tests/test_examples.py
+++ b/thinc/tests/test_examples.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import nbformat
 import pytest
@@ -22,6 +23,7 @@ def test_files(nb_file):
                 raise Exception(f"{output.ename}: {output.evalue}")
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="graphviz missing on windows CI")
 @pytest.mark.parametrize(
     "nb_file",
     (
@@ -34,6 +36,7 @@ def test_ipython_notebooks(test_files: None):
     ...
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="graphviz missing on windows CI")
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "nb_file",

--- a/thinc/tests/test_examples.py
+++ b/thinc/tests/test_examples.py
@@ -1,0 +1,49 @@
+import pytest
+
+
+@pytest.fixture
+def test_files(nb_file):
+    import nbformat
+    from nbconvert.preprocessors import ExecutePreprocessor
+
+    with open(nb_file) as f:
+        nb = nbformat.read(f, as_version=4)
+    proc = ExecutePreprocessor(timeout=600, kernel_name="python3")
+    proc.allow_errors = True
+    proc.preprocess(nb, {"metadata": {"path": "/"}})
+    cells_with_outputs = [c for c in nb.cells if "outputs" in c]
+    for cell in cells_with_outputs:
+        for output in cell["outputs"]:
+            if output.output_type == "error":
+                for l in output.traceback:
+                    print(l)
+                raise Exception(f"{output.ename}: {output.evalue}")
+
+
+@pytest.mark.parametrize(
+    "nb_file",
+    (
+        "examples/01_intro_model_definition_methods.ipynb",
+        "examples/05_benchmarking_layers.ipynb",
+        "examples/05_visualizing_models.ipynb",
+    ),
+)
+def test_ipython_notebooks(test_files: None):
+    ...
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "nb_file",
+    (
+        "examples/00_intro_to_thinc.ipynb",
+        "examples/02_transformers_tagger_bert.ipynb",
+        "examples/03_pos_tagger_basic_cnn.ipynb",
+        "examples/03_textcat_basic_neural_bow.ipynb",
+        "examples/04_configure_gpu_memory.ipynb",
+        "examples/04_parallel_training_ray.ipynb",
+        "examples/06_predicting_like_terms.ipynb",
+    ),
+)
+def test_ipython_notebooks_slow(test_files: None):
+    ...

--- a/thinc/tests/test_examples.py
+++ b/thinc/tests/test_examples.py
@@ -1,14 +1,16 @@
+import os
+
+import nbformat
 import pytest
+from nbconvert.preprocessors import ExecutePreprocessor
 
 
 @pytest.fixture
 def test_files(nb_file):
-    import nbformat
-    from nbconvert.preprocessors import ExecutePreprocessor
-
+    kernel_name = os.environ.get("NOTEBOOK_KERNEL", "python3")
     with open(nb_file) as f:
         nb = nbformat.read(f, as_version=4)
-    proc = ExecutePreprocessor(timeout=600, kernel_name="python3")
+    proc = ExecutePreprocessor(timeout=600, kernel_name=kernel_name)
     proc.allow_errors = True
     proc.preprocess(nb, {"metadata": {"path": "/"}})
     cells_with_outputs = [c for c in nb.cells if "outputs" in c]


### PR DESCRIPTION
I think I figured out how we can test our ipython notebooks in the `examples` folder! The `nbconvert` package provides [a way to execute notebooks](https://nbconvert.readthedocs.io/en/latest/execute_api.html#executing-notebooks-using-the-python-api-interface)

When there's an error it looks like this:
![Screen Shot 2020-03-31 at 1 21 48 PM](https://user-images.githubusercontent.com/101493/78073517-e6cf9680-7355-11ea-9f3a-b2ac194efc65.png)

The downside to these tests is that they can be slow, or break if you don't have the right system configuration (e.g. no GPU for config notebook). I put the notebooks that execute quickly in one test, and the others in one that is wrapped with `@pytest.mark.slow`

Changes
 - run notebooks files in `examples` folder and assert that there are no errors in cell outputs
 - add a slow test for the notebooks that take a long time to run