### PR TITLE
max_grad_norm was renamed to grad_clip

### DIFF
--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -62,9 +62,9 @@ class MXNetShim(Shim):
     def finish_update(self, optimizer):
         if self._optimizer is None:
             self._optimizer, self._trainer = self._create_optimizer(optimizer)
-        if getattr(optimizer, "max_grad_norm", None):
+        if getattr(optimizer, "grad_clip", None):
             mxnet.gluon.utils.clip_global_norm(
-                self._model.parameters(), optimizer.max_grad_norm
+                self._model.parameters(), optimizer.grad_clip
             )
         self._trainer.step(1)
         for param in self._model.collect_params().values():

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -66,7 +66,8 @@ class MXNetShim(Shim):
             mxnet.gluon.utils.clip_global_norm(
                 self._model.parameters(), optimizer.grad_clip
             )
-        self._trainer.step(1)
+        if self._trainer:
+            self._trainer.step(1)
         for param in self._model.collect_params().values():
             param.zero_grad()
         self._update_mxnet_averages(optimizer)

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -63,9 +63,8 @@ class MXNetShim(Shim):
         if self._optimizer is None:
             self._optimizer, self._trainer = self._create_optimizer(optimizer)
         if getattr(optimizer, "grad_clip", None):
-            mxnet.gluon.utils.clip_global_norm(
-                self._model.parameters(), optimizer.grad_clip
-            )
+            grads = [i.grad(self._model.ctx) for i in self._model.collect_params().values() if i._grad is not None]
+            mxnet.gluon.utils.clip_global_norm(grads, optimizer.grad_clip)
         if self._trainer:
             self._trainer.step(1)
         for param in self._model.collect_params().values():

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -63,7 +63,8 @@ class MXNetShim(Shim):
         if self._optimizer is None:
             self._optimizer, self._trainer = self._create_optimizer(optimizer)
         if getattr(optimizer, "grad_clip", None):
-            grads = [i.grad(self._model.ctx) for i in self._model.collect_params().values() if i._grad is not None]
+            ctx = mx.current_context()
+            grads = [i.grad(ctx) for i in self._model.collect_params().values() if i._grad is not None]
             mxnet.gluon.utils.clip_global_norm(grads, optimizer.grad_clip)
         if self._trainer:
             self._trainer.step(1)

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -58,9 +58,9 @@ class PyTorchShim(Shim):
     def finish_update(self, optimizer):
         if not self._optimizer:
             self._optimizer = self._create_optimizer(optimizer)
-        if getattr(optimizer, "max_grad_norm", None):
+        if getattr(optimizer, "grad_clip", None):
             torch.nn.utils.clip_grad_norm_(
-                self._model.parameters(), optimizer.max_grad_norm
+                self._model.parameters(), optimizer.grad_clip
             )
         self._optimizer.step()
         self._optimizer.zero_grad()


### PR DESCRIPTION
Found 2 cases where the renaming of the old `max_grad_norm` to the new `grad_clip` was not done yet.