### PR TITLE
Remove ops attribute from Optimizer

### DIFF
--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -10,6 +10,7 @@ from .jax_ops import JaxOps, has_jax, jax_jit
 from ._cupy_allocators import cupy_tensorflow_allocator, cupy_pytorch_allocator
 from ._param_server import ParamServer
 from ..util import assert_tensorflow_installed, assert_pytorch_installed
+from ..util import is_cupy_array, is_jax_array
 from ..types import OpsNames
 
 
@@ -56,6 +57,16 @@ def get_ops(name: OpsNames, **kwargs) -> Ops:
         raise ValueError(f"Invalid backend: {name}")
     cls = ops[name]
     return cls(**kwargs)
+
+
+def get_array_ops(arr):
+    """Return an Ops object to match the array's device and backend."""
+    if is_cupy_array(arr):
+        return CupyOps()
+    elif is_jax_array(arr):
+        return JaxOps()
+    else:
+        return NumpyOps()
 
 
 @contextlib.contextmanager

--- a/thinc/layers/add.py
+++ b/thinc/layers/add.py
@@ -27,9 +27,7 @@ def add(
     if all(node.has_dim("nI") in [True, None] for node in layers):
         dims = {"nO": None, "nI": None}
 
-    return Model(
-        "add", forward, init=init, dims=dims, layers=layers
-    )
+    return Model("add", forward, init=init, dims=dims, layers=layers)
 
 
 def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callable]:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -306,9 +306,6 @@ class Model(Generic[InT, OutT]):
                 if node.has_grad(name):
                     param = node.get_param(name)
                     grad = node.get_grad(name)
-                    if hasattr(optimizer, "ops"):
-                        param = optimizer.ops.asarray(param)  # type: ignore
-                        grad = optimizer.ops.asarray(grad)  # type: ignore
                     param, grad = optimizer((node.id, name), param, grad)
                     node.set_param(name, orig_ops.asarray(param))  # type: ignore
                     node.set_grad(name, orig_ops.asarray(grad))  # type: ignore

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -180,7 +180,9 @@ class Model(Generic[InT, OutT]):
     def set_dim(self, name: str, value: int) -> None:
         """Set a value for a dimension."""
         if name not in self._dims:
-            raise KeyError(f"Cannot set unknown dimension '{name}' for model '{self.name}'.")
+            raise KeyError(
+                f"Cannot set unknown dimension '{name}' for model '{self.name}'."
+            )
         old_value = self._dims[name]
         if old_value is not None and old_value != value:
             err = f"Attempt to change dimension '{name}' for model '{self.name}' from {old_value} to {value}"
@@ -304,12 +306,12 @@ class Model(Generic[InT, OutT]):
                 if node.has_grad(name):
                     param = node.get_param(name)
                     grad = node.get_grad(name)
-                    if hasattr(optimizer, 'ops'):
-                        param = optimizer.ops.asarray(param)        # type: ignore
-                        grad = optimizer.ops.asarray(grad)          # type: ignore
+                    if hasattr(optimizer, "ops"):
+                        param = optimizer.ops.asarray(param)  # type: ignore
+                        grad = optimizer.ops.asarray(grad)  # type: ignore
                     param, grad = optimizer((node.id, name), param, grad)
-                    node.set_param(name, orig_ops.asarray(param))   # type: ignore
-                    node.set_grad(name, orig_ops.asarray(grad))     # type: ignore
+                    node.set_param(name, orig_ops.asarray(param))  # type: ignore
+                    node.set_grad(name, orig_ops.asarray(grad))  # type: ignore
             for shim in node.shims:
                 shim.finish_update(optimizer)
 

--- a/thinc/optimizers.py
+++ b/thinc/optimizers.py
@@ -3,7 +3,7 @@ import math
 from typing import Dict, Optional, Union, Tuple, List, cast
 from collections import defaultdict
 
-from .backends import Ops, NumpyOps, CupyOps, get_current_ops
+from .backends import get_array_ops
 from .types import Generator, FloatsXd
 from .config import registry
 
@@ -41,7 +41,6 @@ def RAdam(
     L2_is_weight_decay: bool = cast(bool, ADAM_DEFAULTS["L2_is_weight_decay"]),
     grad_clip: FloatOrSeq = ADAM_DEFAULTS["grad_clip"],
     use_averages: bool = True,
-    ops: Optional[Ops] = None,
 ):
     return Optimizer(
         learn_rate,
@@ -53,7 +52,6 @@ def RAdam(
         L2=L2,
         use_averages=use_averages,
         use_radam=True,
-        ops=ops,
     )
 
 
@@ -68,7 +66,6 @@ def Adam(
     grad_clip: FloatOrSeq = ADAM_DEFAULTS["grad_clip"],
     L2_is_weight_decay: bool = cast(bool, ADAM_DEFAULTS["L2_is_weight_decay"]),
     use_averages: bool = True,
-    ops: Optional[Ops] = None,
 ):
     return Optimizer(
         learn_rate,
@@ -80,7 +77,6 @@ def Adam(
         L2_is_weight_decay=L2_is_weight_decay,
         use_averages=use_averages,
         use_radam=False,
-        ops=ops,
     )
 
 
@@ -92,7 +88,6 @@ def SGD(
     grad_clip: FloatOrSeq = SGD_DEFAULTS["grad_clip"],
     L2_is_weight_decay: bool = cast(bool, SGD_DEFAULTS["L2_is_weight_decay"]),
     use_averages: bool = True,
-    ops: Optional[Ops] = None,
 ):
     return Optimizer(
         learn_rate,
@@ -102,7 +97,6 @@ def SGD(
         beta1=0.0,
         beta2=0.0,
         use_averages=use_averages,
-        ops=ops,
     )
 
 
@@ -130,7 +124,6 @@ class Optimizer(object):
     # This "locks" the class, so we get an error if you try to assign to
     # an unexpected variable.
     __slots__ = [
-        "ops",
         "mom1",
         "mom2",
         "averages",
@@ -152,7 +145,6 @@ class Optimizer(object):
         self,
         learn_rate: FloatOrSeq,
         *,
-        ops: Optional[Ops] = None,
         L2: FloatOrSeq = ADAM_DEFAULTS["L2"],
         beta1: FloatOrSeq = ADAM_DEFAULTS["beta1"],
         beta2: FloatOrSeq = ADAM_DEFAULTS["beta2"],
@@ -166,7 +158,6 @@ class Optimizer(object):
         Initialize an optimizer.
 
         learn_rate (float): The initial learning rate.
-        ops (Ops): A backend object. Defaults to the currently selected backend.
         L2 (float): The L2 regularization term.
         beta1 (float): First-order momentum.
         beta2 (float): Second-order momentum.
@@ -177,7 +168,6 @@ class Optimizer(object):
         L2_is_weight_decay (bool): Whether to interpret the L2 parameter as a
             weight decay term, in the style of the AdamW optimizer.
         """
-        self.ops = ops if ops is not None else get_current_ops()
         self.mom1 = {}
         self.mom2 = {}
         if use_averages:
@@ -210,19 +200,6 @@ class Optimizer(object):
                 err = f"Invalid schedule for '{name}' ({type(value)})\n{e}"
                 raise ValueError(err)
 
-    def to_gpu(self):  # pragma: no cover
-        self.ops = CupyOps()
-        for params in (self.mom1, self.mom2, self.averages):
-            for key, value in params.items():
-                params[key] = self.ops.xp.asarray(value, dtype=value.dtype)
-
-    def to_cpu(self):  # pragma: no cover
-        self.ops = NumpyOps()
-        for params in (self.mom1, self.mom2, self.averages):
-            for key, value in params.items():
-                if hasattr(value, "get"):
-                    params[key] = value.get()
-
     def step_schedules(self):
         for key, schedule in self.schedules.items():
             try:
@@ -244,19 +221,21 @@ class Optimizer(object):
         """
         if len(gradient) < 1:
             return weights, gradient
-        xp = self.ops.xp
+        ops = get_array_ops(weights)
         self.nr_update[key] += 1
         nr_upd = self.nr_update[key]
         if self.L2 != 0 and not self.L2_is_weight_decay:
             gradient += self.L2 * weights
         if self.grad_clip:
-            gradient = self.ops.clip_gradient(gradient, self.grad_clip)
+            gradient = ops.clip_gradient(gradient, self.grad_clip)
         if self.use_radam:
             weights, gradient = self._radam(
-                xp, weights, gradient, lr_scale, key, nr_upd
+                ops, weights, gradient, lr_scale, key, nr_upd
             )
         elif self.b1 > 0.0 and self.b2 > 0.0:
-            weights, gradient = self._adam(xp, weights, gradient, lr_scale, key, nr_upd)
+            weights, gradient = self._adam(
+                ops, weights, gradient, lr_scale, key, nr_upd
+            )
         elif self.b2 > 0.0:  # pragma: no cover
             raise NotImplementedError  # TODO: error message
         else:
@@ -266,15 +245,15 @@ class Optimizer(object):
             weights -= self.L2 * weights
         if self.averages is not None:
             if key not in self.averages:
-                self.averages[key] = self.ops.alloc(weights.shape, dtype="float32")
-            self.ops.update_averages(self.averages[key], weights, nr_upd)
+                self.averages[key] = ops.alloc(weights.shape, dtype="float32")
+            ops.update_averages(self.averages[key], weights, nr_upd)
         return weights, gradient
 
-    def _radam(self, xp, weights, grad, lr_scale, key, nr_upd):
+    def _radam(self, ops, weights, grad, lr_scale, key, nr_upd):
         if key not in self.mom1:
-            self.mom1[key] = self.ops.alloc1f(weights.size)
+            self.mom1[key] = ops.alloc1f(weights.size)
         if key not in self.mom2:
-            self.mom2[key] = self.ops.alloc1f(weights.size)
+            self.mom2[key] = ops.alloc1f(weights.size)
 
         # While we port from the pytorch implementation, keep some of the same
         # naming
@@ -334,7 +313,7 @@ class Optimizer(object):
         if N_sma >= 5:
             if group["weight_decay"] != 0:
                 weights += -group["weight_decay"] * group["lr"] * weights
-            denom = xp.sqrt(exp_avg_sq) + group["eps"]
+            denom = ops.xp.sqrt(exp_avg_sq) + group["eps"]
             weights += -step_size * group["lr"] * (exp_avg / denom)
         elif step_size > 0:
             if group["weight_decay"] != 0:
@@ -342,13 +321,13 @@ class Optimizer(object):
             weights += -step_size * group["lr"] * exp_avg
         return weights, grad
 
-    def _adam(self, xp, weights, gradient, lr_scale, key, nr_upd):
-        weights_1D = self.ops.reshape1f(weights, weights.size)
-        gradient_1D = self.ops.reshape1f(gradient, gradient.size)
+    def _adam(self, ops, weights, gradient, lr_scale, key, nr_upd):
+        weights_1D = ops.reshape1f(weights, weights.size)
+        gradient_1D = ops.reshape1f(gradient, gradient.size)
         if key not in self.mom1:
-            self.mom1[key] = self.ops.alloc1f(weights.size)
+            self.mom1[key] = ops.alloc1f(weights.size)
         if key not in self.mom2:
-            self.mom2[key] = self.ops.alloc1f(weights.size)
+            self.mom2[key] = ops.alloc1f(weights.size)
         mom1 = self.mom1[key]
         mom2 = self.mom2[key]
         b1 = self.b1
@@ -358,14 +337,14 @@ class Optimizer(object):
         lr = self.learn_rate * fix2 ** 0.5 / fix1
         eps = self.eps
         # needs to be 1D going into the adam function
-        weights_1D, gradient_1D, mom1, mom2 = self.ops.adam(
+        weights_1D, gradient_1D, mom1, mom2 = ops.adam(
             weights_1D, gradient_1D, mom1, mom2, b1, b2, eps, lr * lr_scale
         )
         self.mom1[key] = mom1
         self.mom2[key] = mom2
         return (
-            self.ops.reshape_f(weights_1D, weights.shape),
-            self.ops.reshape_f(gradient_1D, gradient.shape),
+            ops.reshape_f(weights_1D, weights.shape),
+            ops.reshape_f(gradient_1D, gradient.shape),
         )
 
 

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -13,7 +13,7 @@ except ImportError:  # pragma: no cover
     pass
 
 from ..util import mxnet2xp, xp2mxnet, convert_recursive, make_tempfile
-from ..backends import get_current_ops
+from ..backends import get_current_ops, get_array_ops
 from ..types import ArgsKwargs
 from .shim import Shim
 
@@ -95,8 +95,9 @@ class MXNetShim(Shim):
             key = f"mxnet_{self.id}_{name}"
             sgd.nr_update[key] += 1
             xp_param = mxnet2xp(param.grad())
+            ops = get_array_ops(xp_param)
             if key in sgd.averages:
-                sgd.ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
+                ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
             else:
                 sgd.averages[key] = xp_param.copy()
                 sgd.nr_update[key] = init_steps

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover
     pass
 
 from ..util import torch2xp, xp2torch, convert_recursive
-from ..backends import get_current_ops
+from ..backends import get_current_ops, get_array_ops
 from ..types import ArgsKwargs
 from .shim import Shim
 
@@ -101,8 +101,9 @@ class PyTorchShim(Shim):
             key = f"pytorch_{self.id}_{name}"
             sgd.nr_update[key] += 1
             xp_param = torch2xp(param)
+            ops = get_array_ops(xp_param)
             if key in sgd.averages:
-                sgd.ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
+                ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
             else:
                 sgd.averages[key] = xp_param.copy()
                 sgd.nr_update[key] = init_steps

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -6,7 +6,7 @@ import itertools
 from io import BytesIO
 import numpy
 
-from ..backends import Ops, get_current_ops
+from ..backends import Ops, get_current_ops, get_array_ops
 from ..types import ArgsKwargs, ArrayXd
 from ..util import tensorflow2xp
 from .shim import Shim
@@ -202,8 +202,9 @@ class TensorFlowShim(Shim):
             key = f"tensorflow_{self.id}_{layer.name}"
             sgd.nr_update[key] += 1
             xp_param = tensorflow2xp(layer)
+            ops = get_array_ops(xp_param)
             if key in sgd.averages:
-                sgd.ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
+                ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
             else:
                 sgd.averages[key] = xp_param.copy()
                 sgd.nr_update[key] = init_steps

--- a/thinc/tests/layers/test_linear.py
+++ b/thinc/tests/layers/test_linear.py
@@ -187,7 +187,7 @@ def test_update():
     model = Linear(2, 2)
     model.set_param("W", W)
     model.set_param("b", bias)
-    sgd = SGD(1.0, L2=0.0, ops=model.ops, grad_clip=0.0)
+    sgd = SGD(1.0, L2=0.0, grad_clip=0.0)
     sgd.averages = None
 
     ff = numpy.asarray([[0.0, 0.0]], dtype="f")

--- a/thinc/tests/layers/test_sparse_linear.py
+++ b/thinc/tests/layers/test_sparse_linear.py
@@ -15,7 +15,7 @@ def instances():
 
 @pytest.fixture
 def sgd():
-    return SGD(0.001, ops=NumpyOps())
+    return SGD(0.001)
 
 
 def test_basic(instances, sgd):

--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -13,7 +13,7 @@ ROWS = 10
 # used to. The key feature is this composite decorator. It injects a function,
 # 'draw'.
 @composite
-def lists_of_integers(draw, columns=2, lo=0, hi=ROWS-1):
+def lists_of_integers(draw, columns=2, lo=0, hi=ROWS - 1):
     # We call draw to get example values, which we can manipulate.
     # Here we get a list of integers, where each member of the list
     # should be between a min and max value.
@@ -43,7 +43,7 @@ def test_uniqued_calls_init():
     assert calls == [True, True]
 
 
-@given(X=lists_of_integers(lo=0, hi=ROWS-1))
+@given(X=lists_of_integers(lo=0, hi=ROWS - 1))
 def test_uniqued_doesnt_change_result(model, X):
     umodel = uniqued(model, column=model.attrs["column"]).initialize()
     Y, bp_Y = model(X, is_train=True)


### PR DESCRIPTION
The `Optimizer` object can't assume that all layers are using the same backend, because we might have mixed CPU/GPU execution. So the optimizer needs to fetch an ops appropriate to the inputs.

We remove the `ops` argument to the optimizer, and add a helper `get_array_ops`.