### PR TITLE
fix(to_categorical): make consistent with tf/torch one_hot helpers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,10 @@ jobs:
   - script: |
       pip install tensorflow
       pip install "mxnet; sys_platform != 'win32'"
-      pip install torch -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "mxnet; sys_platform != 'win32'"
+      # NOTE: need this to close for 1.5 on windows: https://github.com/pytorch/pytorch/issues/37209
+      pip install "torch==1.4; sys_platform == 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch; sys_platform != 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
       pip install jax jaxlib 
       pip install ipykernel pydot graphviz 
       python -m ipykernel install --name thinc-notebook-tests --user

--- a/thinc/tests/layers/test_mxnet_wrapper.py
+++ b/thinc/tests/layers/test_mxnet_wrapper.py
@@ -40,7 +40,10 @@ def X(input_size: int) -> Array2d:
 @pytest.fixture
 def Y(answer: int, n_classes: int) -> Array2d:
     ops: Ops = get_current_ops()
-    return to_categorical(cast(IntsXd, ops.asarray([answer])), n_classes=n_classes)
+    return cast(
+        Array2d,
+        to_categorical(cast(IntsXd, ops.asarray([answer])), n_classes=n_classes),
+    )
 
 
 @pytest.fixture

--- a/thinc/tests/test_util.py
+++ b/thinc/tests/test_util.py
@@ -43,7 +43,6 @@ def test_array_module_cpu_gpu_helpers():
     assert not is_numpy_array((1, 2))
 
 
-@pytest.mark.xfail(reason="¯/_(ツ)_/¯")
 def test_to_categorical():
     # Test without n_classes
     one_hot = to_categorical(numpy.asarray([1, 2], dtype="i"))
@@ -52,7 +51,7 @@ def test_to_categorical():
     # https://github.com/keras-team/keras/blob/master/tests/keras/utils/np_utils_test.py
     nc = 5
     shapes = [(1,), (3,), (4, 3), (5, 4, 3), (3, 1), (3, 2, 1)]
-    expected_shapes = [(1, nc), (3, nc), (4, 3, nc), (5, 4, 3, nc), (3, nc), (3, 2, nc)]
+    expected_shapes = [(1, nc), (3, nc), (4, 3, nc), (5, 4, 3, nc), (3, 1, nc), (3, 2, 1, nc)]
     labels = [numpy.random.randint(0, nc, shape) for shape in shapes]
     one_hots = [to_categorical(label, nc) for label in labels]
     for label, one_hot, expected_shape in zip(labels, one_hots, expected_shapes):

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -51,7 +51,7 @@ try:  # pragma: no cover
 except ImportError:  # pragma: no cover
     has_mxnet = False
 
-from .types import ArrayXd, ArgsKwargs, Ragged, Padded, Floats2d, IntsXd
+from .types import ArrayXd, ArgsKwargs, Ragged, Padded, FloatsXd, IntsXd
 
 
 def get_array_module(arr):  # pragma: no cover
@@ -193,18 +193,20 @@ def copy_array(dst: ArrayXd, src: ArrayXd) -> None:  # pragma: no cover
         numpy.copyto(dst, src)
 
 
-def to_categorical(Y: IntsXd, n_classes: Optional[int] = None) -> Floats2d:
+def to_categorical(Y: IntsXd, n_classes: Optional[int] = None) -> FloatsXd:
     # From keras
     xp = get_array_module(Y)
     if xp is cupy:  # pragma: no cover
         Y = Y.get()
+    keep_shapes: List[int] = list(Y.shape)
     Y = numpy.array(Y, dtype="int").ravel()
-    if not n_classes:
-        n_classes = numpy.max(Y) + 1
+    if n_classes is None:
+        n_classes = int(numpy.max(Y) + 1)
+    keep_shapes.append(n_classes)
     n = Y.shape[0]
     categorical = numpy.zeros((n, n_classes), dtype="float32")
     categorical[numpy.arange(n), Y] = 1
-    return xp.asarray(categorical)
+    return xp.asarray(categorical).reshape(keep_shapes)
 
 
 def get_width(


### PR DESCRIPTION
The to_categorical helper outputs different shapes than PyTorch and TensorFlow equivalent helpers. 

This "fixes" it so that Thinc/TF/Torch all agree on the output.

 - resume testing to_categorical helper _(lol at xfail reason)_
 - to_categorical restores the input shape before returning
 - closes #339