### PR TITLE
Update learn rate etc in pytorch shim, if schedule

### DIFF
--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -79,7 +79,7 @@ class PyTorchShim(Shim):
         else:
             cls = thinc.optim.SGD
             if sgd.b2 == 0:
-            args["momentum"] = sgd.b1
+                args["momentum"] = sgd.b1
         if self._optimizer is None:
             self._optimizer = cls(self._model.parameters(), **args)
         else:

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -77,7 +77,7 @@ class PyTorchShim(Shim):
             else:
                 cls = torch.optim.Adam
         else:
-            cls = thinc.optim.SGD
+            cls = torch.optim.SGD
             if sgd.b2 == 0:
                 args["momentum"] = sgd.b1
         if self._optimizer is None:


### PR DESCRIPTION
Fixes pretty bad bug: if there were schedules set for learning rate etc, the PyTorch shim wasn't receiving the updated values.

We should update the shims to call into Thinc's optimizer. The current way is pretty brittle :(