### PR TITLE
fix(xp2torch): don't explode if input is already a tensor

### DIFF
--- a/thinc/tests/layers/test_pytorch_wrapper.py
+++ b/thinc/tests/layers/test_pytorch_wrapper.py
@@ -23,6 +23,19 @@ def check_learns_zero_output(model, sgd, X, Y):
 
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+def test_pytorch_tensor_conversions():
+    import torch
+
+    a = numpy.zeros((10, 2, 1))
+    assert not isinstance(a, torch.Tensor)
+    b = xp2torch(a)
+    assert isinstance(b, torch.Tensor)
+
+    c = xp2torch(b)
+    assert isinstance(c, torch.Tensor)
+
+
+@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
 def test_unwrapped(nN, nI, nO):
     model = Linear(nO, nI).initialize()

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -285,9 +285,11 @@ def convert_recursive(
 
 
 def xp2torch(
-    xp_tensor: ArrayXd, requires_grad: bool = False
+    xp_tensor: Union[ArrayXd, "torch.Tensor"], requires_grad: bool = False,
 ) -> "torch.Tensor":  # pragma: no cover
     """Convert a numpy or cupy tensor to a PyTorch tensor."""
+    if isinstance(xp_tensor, torch.Tensor):
+        return xp_tensor
     if hasattr(xp_tensor, "toDlpack"):
         dlpack_tensor = xp_tensor.toDlpack()  # type: ignore
         torch_tensor = torch.utils.dlpack.from_dlpack(dlpack_tensor)


### PR DESCRIPTION
 With the current behavior, you have to be careful to check the input types before calling xp2torch. With this change, xp2torch returns the tensor directly if given one.

Does this fix look alright? If returning a tensor do I need to do any device checking to ensure the tensor is on the current device?