### PR TITLE
add "PyTorchCrossEntropy.v1" loss

### DIFF
--- a/thinc/loss.py
+++ b/thinc/loss.py
@@ -6,7 +6,7 @@ from .util import get_array_module, to_categorical, xp2torch
 from .config import registry
 
 
-# Needed to allow
+# Needed to keep "torch.Tensor" types from causing mypy errors
 try:  # pragma: no cover
     import torch
 except ImportError:  # pragma: no cover

--- a/thinc/tests/test_loss.py
+++ b/thinc/tests/test_loss.py
@@ -1,3 +1,4 @@
+from thinc.util import has_torch
 import pytest
 import numpy
 from thinc.api import CategoricalCrossentropy, SequenceCategoricalCrossentropy
@@ -167,21 +168,25 @@ def test_cosine_unmatched():
 
 
 @pytest.mark.parametrize(
-    "name,kwargs,args",
+    "name,kwargs,args,condition",
     [
-        ("CategoricalCrossentropy.v1", {}, (scores0, labels0)),
-        ("SequenceCategoricalCrossentropy.v1", {}, ([scores0], [labels0])),
-        ("L2Distance.v1", {}, (scores0, scores0)),
+        ("CategoricalCrossentropy.v1", {}, (scores0, labels0), True),
+        ("SequenceCategoricalCrossentropy.v1", {}, ([scores0], [labels0]), True),
+        ("L2Distance.v1", {}, (scores0, scores0), True),
         (
             "CosineDistance.v1",
             {"normalize": True, "ignore_zeros": True},
             (scores0, scores0),
+            True,
         ),
+        ("PyTorchCrossEntropy.v1", {}, (scores0, labels0), has_torch),
     ],
 )
-def test_loss_from_config(name, kwargs, args):
+def test_loss_from_config(name, kwargs, args, condition):
     """Test that losses are loaded and configured correctly from registry
-    (as partials)."""
+    (as partials). """
+    if not condition:
+        pytest.skip("test conditions not met for loss function")
     cfg = {"test": {"@losses": name, **kwargs}}
     func = registry.make_from_config(cfg)["test"]
     loss = func.get_grad(*args)


### PR DESCRIPTION
The PyTorch cross_entropy loss uses log softmax + negative-log-likelihood and it performs better on certain tasks than the thinc CCE loss:
![Screen Shot 2020-05-11 at 12 39 21 PM](https://user-images.githubusercontent.com/101493/81611502-02d04a00-9390-11ea-9c42-315d5bcc85d4.png)


I'm not sure if this loss is desirable as part of thinc, but I figured it couldn't hurt to have a PR to look at and talk about.

If this is something thinc would like to keep I can add better tests and document the loss class options.