### PR TITLE
remove graphviz from azure and skip visualizer tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,17 +61,8 @@ jobs:
       pip install dist/$SDIST
     displayName: 'Install from sdist'
 
-  - script: 'sudo apt-get -yq install graphviz'
-    displayName: 'Install graphviz (Linux)'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-
-  - script: 'brew install graphviz'
-    displayName: 'Install graphviz (MacOS)'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-    
   - script: |
       pip install tensorflow
-      pip install "mxnet; sys_platform != 'win32'"
       pip install "mxnet; sys_platform != 'win32'"
       # NOTE: need this to close for 1.5 on windows: https://github.com/pytorch/pytorch/issues/37209
       pip install "torch==1.4; sys_platform == 'win32'" -f https://download.pytorch.org/whl/torch_stable.html

--- a/thinc/tests/test_examples.py
+++ b/thinc/tests/test_examples.py
@@ -23,21 +23,18 @@ def test_files(nb_file):
                 raise Exception(f"{output.ename}: {output.evalue}")
 
 
-@pytest.mark.skip(reason="graphviz missing on CI")
 @pytest.mark.parametrize(
     "nb_file",
     (
         "examples/01_intro_model_definition_methods.ipynb",
         "examples/05_benchmarking_layers.ipynb",
-        "examples/05_visualizing_models.ipynb",
     ),
 )
 def test_ipython_notebooks(test_files: None):
     ...
 
 
-@pytest.mark.skip(reason="graphviz missing on CI")
-@pytest.mark.slow
+@pytest.mark.skip(reason="these notebooks need special software or hardware")
 @pytest.mark.parametrize(
     "nb_file",
     (
@@ -47,6 +44,7 @@ def test_ipython_notebooks(test_files: None):
         "examples/03_textcat_basic_neural_bow.ipynb",
         "examples/04_configure_gpu_memory.ipynb",
         "examples/04_parallel_training_ray.ipynb",
+        "examples/05_visualizing_models.ipynb",
         "examples/06_predicting_like_terms.ipynb",
     ),
 )


### PR DESCRIPTION
This should allow us to test the stable notebook tests while skipping the ones that need graphviz