### PR TITLE
Use thinc optimizer in Shim classes

### DIFF
--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -62,6 +62,7 @@ class MXNetShim(Shim):
             param = cast(FloatsXd, mxnet2xp(value.data()))
             param, _ = optimizer((value.name, value.name), param, grad)
             value.set_data(xp2mxnet(param))
+            value.zero_grad()
 
     def copy(self, ctx: "mx.context.Context" = None):
         if ctx is None:

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -57,9 +57,10 @@ class MXNetShim(Shim):
         return output, backprop
 
     def finish_update(self, optimizer: Optimizer):
+        ctx = mx.current_context()
         for value in self._model.collect_params().values():
-            grad = cast(FloatsXd, mxnet2xp(value.grad()))
-            param = cast(FloatsXd, mxnet2xp(value.data()))
+            grad = cast(FloatsXd, mxnet2xp(value.grad(ctx)))
+            param = cast(FloatsXd, mxnet2xp(value.data(ctx)))
             param, _ = optimizer((value.name, value.name), param, grad)
             value.set_data(xp2mxnet(param))
             value.zero_grad()

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -58,10 +58,10 @@ class MXNetShim(Shim):
 
     def finish_update(self, optimizer: Optimizer):
         ctx = mx.current_context()
-        for value in self._model.collect_params().values():
+        for key, value in self._model.collect_params().items():
             grad = cast(FloatsXd, mxnet2xp(value.grad(ctx)))
             param = cast(FloatsXd, mxnet2xp(value.data(ctx)))
-            param, _ = optimizer((value.name, value.name), param, grad)
+            param, _ = optimizer((key, value.name), param, grad)
             value.set_data(xp2mxnet(param))
             value.zero_grad()
 

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -55,12 +55,12 @@ class PyTorchShim(Shim):
         return output, backprop
 
     def finish_update(self, optimizer: Optimizer):
-        for name, value in self._model.named_parameters():
-            cpu_data = cast(FloatsXd, torch2xp(value.data))
-            cpu_grad = cast(FloatsXd, torch2xp(value.grad))
-            param, _ = optimizer(name, cpu_data, cpu_grad)
-            value.data = xp2torch(param, requires_grad=True)
-            value.grad.zero_()
+        for name, torch_data in self._model.named_parameters():
+            xp_data = cast(FloatsXd, torch2xp(torch_data.data))
+            xp_grad = cast(FloatsXd, torch2xp(torch_data.grad))
+            param, _ = optimizer(name, xp_data, xp_grad)
+            torch_data.data = xp2torch(param, requires_grad=True)
+            torch_data.grad.zero_()
 
     @contextlib.contextmanager
     def use_params(self, params):

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -12,6 +12,7 @@ except ImportError:  # pragma: no cover
 
 from ..util import torch2xp, xp2torch, convert_recursive
 from ..backends import get_current_ops, get_array_ops
+from ..optimizers import Optimizer
 from ..types import ArgsKwargs
 from .shim import Shim
 
@@ -53,39 +54,10 @@ class PyTorchShim(Shim):
 
         return output, backprop
 
-    def finish_update(self, optimizer):
-        pytorch_opt = self._get_pytorch_optimizer(optimizer)
-        if getattr(optimizer, "grad_clip", None):
-            torch.nn.utils.clip_grad_norm_(
-                self._model.parameters(), optimizer.grad_clip
-            )
-        pytorch_opt.step()
-        pytorch_opt.zero_grad()
-        self._update_pytorch_averages(optimizer)
-
-    def _get_pytorch_optimizer(self, sgd):
-        args = {
-            "lr": sgd.learn_rate,
-            "weight_decay": sgd.L2
-        }
-
-        if sgd.b1 != 0 and sgd.b2 != 0:
-            args["betas"] = (sgd.b1, sgd.b2)
-            args["eps"] = sgd.eps
-            if sgd.L2_is_weight_decay:
-                cls = torch.optim.AdamW
-            else:
-                cls = torch.optim.Adam
-        else:
-            cls = torch.optim.SGD
-            if sgd.b2 == 0:
-                args["momentum"] = sgd.b1
-        if self._optimizer is None:
-            self._optimizer = cls(self._model.parameters(), **args)
-        else:
-            for param_group in self._optimizer.param_groups:
-                param_group.update(args)
-        return self._optimizer
+    def finish_update(self, optimizer: Optimizer):
+        for value in self._model.parameters():
+            param, _ = optimizer(value.names, value.data.numpy(), value.grad.numpy())
+            value.data = xp2torch(param, requires_grad=True)
 
     @contextlib.contextmanager
     def use_params(self, params):

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -74,21 +74,6 @@ class PyTorchShim(Shim):
         else:
             yield
 
-    def _update_pytorch_averages(self, sgd, *, init_steps=1):
-        if getattr(sgd, "averages", None) is None:
-            return
-        # Collect parameters if we don't have them
-        for name, param in self._model.state_dict().items():
-            key = f"pytorch_{self.id}_{name}"
-            sgd.nr_update[key] += 1
-            xp_param = torch2xp(param)
-            ops = get_array_ops(xp_param)
-            if key in sgd.averages:
-                ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
-            else:
-                sgd.averages[key] = xp_param.copy()
-                sgd.nr_update[key] = init_steps
-
     def to_device(self, device):  # pragma: no cover
         if device == "cpu":
             self._model.cpu()

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -55,8 +55,10 @@ class PyTorchShim(Shim):
         return output, backprop
 
     def finish_update(self, optimizer: Optimizer):
-        for value in self._model.parameters():
-            param, _ = optimizer(value.names, value.data.numpy(), value.grad.numpy())
+        for name, value in self._model.named_parameters():
+            cpu_data = value.data.cpu().numpy()
+            cpu_grad = value.grad.cpu().numpy()
+            param, _ = optimizer(name, cpu_data, cpu_grad)
             value.data = xp2torch(param, requires_grad=True)
             value.grad.zero_()
 

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 import contextlib
 from io import BytesIO
 import srsly
@@ -13,7 +13,7 @@ except ImportError:  # pragma: no cover
 from ..util import torch2xp, xp2torch, convert_recursive
 from ..backends import get_current_ops, get_array_ops
 from ..optimizers import Optimizer
-from ..types import ArgsKwargs
+from ..types import ArgsKwargs, FloatsXd
 from .shim import Shim
 
 
@@ -56,8 +56,8 @@ class PyTorchShim(Shim):
 
     def finish_update(self, optimizer: Optimizer):
         for name, value in self._model.named_parameters():
-            cpu_data = value.data.cpu().numpy()
-            cpu_grad = value.grad.cpu().numpy()
+            cpu_data = cast(FloatsXd, torch2xp(value.data))
+            cpu_grad = cast(FloatsXd, torch2xp(value.grad))
             param, _ = optimizer(name, cpu_data, cpu_grad)
             value.data = xp2torch(param, requires_grad=True)
             value.grad.zero_()

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -58,6 +58,7 @@ class PyTorchShim(Shim):
         for value in self._model.parameters():
             param, _ = optimizer(value.names, value.data.numpy(), value.grad.numpy())
             value.data = xp2torch(param, requires_grad=True)
+            value.grad.zero_()
 
     @contextlib.contextmanager
     def use_params(self, params):

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -83,7 +83,7 @@ class TensorFlowShim(Shim):
     gradients: Optional[List["tf.Tensor"]]
 
     def __init__(self, model: Any, config=None, optimizer: Any = None):
-        super().__init__(model, optimizer)
+        super().__init__(model, config, optimizer)
         self.gradients = None
 
     def __str__(self):

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -200,23 +200,6 @@ class TensorFlowShim(Shim):
         else:
             yield
 
-    def _update_tensorflow_averages(self, sgd, *, init_steps=1):
-        if getattr(sgd, "averages", None) is None:
-            return
-        # Collect parameters if we don't have them
-        layers = [l.weights for l in self._model.layers]
-        layers = itertools.chain(*layers)
-        for layer in layers:
-            key = f"tensorflow_{self.id}_{layer.name}"
-            sgd.nr_update[key] += 1
-            xp_param = tensorflow2xp(layer)
-            ops = get_array_ops(xp_param)
-            if key in sgd.averages:
-                ops.update_averages(sgd.averages[key], xp_param, sgd.nr_update[key])
-            else:
-                sgd.averages[key] = xp_param.copy()
-                sgd.nr_update[key] = init_steps
-
     def _clone_model(self):
         """similar to tf.keras.models.clone_model()
         But the tf.keras.models.clone_model changes the names of tf.Variables.

--- a/thinc/tests/layers/test_pytorch_wrapper.py
+++ b/thinc/tests/layers/test_pytorch_wrapper.py
@@ -24,7 +24,7 @@ def check_learns_zero_output(model, sgd, X, Y):
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
-def test_unwrapped(nN, nI, nO):
+def test_pytorch_unwrapped(nN, nI, nO):
     model = Linear(nO, nI).initialize()
     X = numpy.zeros((nN, nI), dtype="f")
     X += numpy.random.uniform(size=X.size).reshape(X.shape)
@@ -35,7 +35,7 @@ def test_unwrapped(nN, nI, nO):
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
-def test_wrapper(nN, nI, nO):
+def test_pytorch_wrapper(nN, nI, nO):
     import torch.nn
 
     model = PyTorchWrapper(torch.nn.Linear(nI, nO)).initialize()
@@ -55,7 +55,7 @@ def test_wrapper(nN, nI, nO):
 
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")
-def test_roundtrip_conversion():
+def test_pytorch_roundtrip_conversion():
     import torch
 
     xp_tensor = numpy.zeros((2, 3), dtype="f")
@@ -66,7 +66,7 @@ def test_roundtrip_conversion():
 
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")
-def test_wrapper_roundtrip():
+def test_pytorch_wrapper_roundtrip():
     import torch.nn
 
     model = PyTorchWrapper(torch.nn.Linear(2, 3))
@@ -92,7 +92,7 @@ def test_wrapper_roundtrip():
         # fmt: on
     ],
 )
-def test_convert_inputs(data, n_args, kwargs_keys):
+def test_pytorch_convert_inputs(data, n_args, kwargs_keys):
     import torch.nn
 
     model = PyTorchWrapper(torch.nn.Linear(3, 4))

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -217,27 +217,6 @@ def test_tensorflow_wrapper_keras_subclass_decorator_compile_args():
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
-def test_tensorflow_wrapper_keras_subclass_compile_optimizer():
-    import tensorflow as tf
-
-    @keras_subclass(
-        "TestModel", X=numpy.array([0.0, 0.0]), Y=numpy.array([0.5]), input_shape=(2,)
-    )
-    class TestModel(tf.keras.Model):
-        def call(self, inputs):
-            return inputs
-
-    optimizer = tf.keras.optimizers.Adam(lr=3e-18)
-    model = TensorFlowWrapper(TestModel(), optimizer=optimizer)
-    weights_model = model.shims[0]._optimizer.get_weights()
-    for w1, w2 in zip(optimizer.get_weights(), weights_model):
-        assert numpy.array_equal(w1, w2)
-    lr_key = "learning_rate"
-    assert optimizer._get_hyper(lr_key) == 3e-18
-    assert optimizer._get_hyper(lr_key) == model.shims[0]._optimizer._get_hyper(lr_key)
-
-
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_keras_subclass_decorator():
     import tensorflow as tf
 

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -109,23 +109,34 @@ def test_tensorflow_wrapper_train_overfits(model, X, Y, answer):
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
-def test_tensorflow_wrapper_accepts_optimizer(model, tf_model, X, Y, answer):
-    # Update the optimizer weights
+def test_tensorflow_wrapper_accumulate_gradients(model, X, Y, answer):
+    import tensorflow as tf
+
     optimizer = Adam()
-    for i in range(10):
+    gradients = []
+    for i in range(3):
         guesses, backprop = model(X, is_train=True)
         d_guesses = (guesses - Y) / guesses.shape[0]
         backprop(d_guesses)
-        model.finish_update(optimizer)
+        shim_grads = [tf.identity(var) for var in model.shims[0].gradients]
+        gradients.append(shim_grads)
 
-    # Pass the existing optimizer to a new wrapper shim
-    wrapped = TensorFlowWrapper(tf_model, optimizer=model.shims[0]._optimizer)
-    assert model.shims[0]._optimizer is not None
-    assert wrapped.shims[0]._optimizer is not None
-    weights_model = model.shims[0]._optimizer.get_weights()
-    weights_wrapped = wrapped.shims[0]._optimizer.get_weights()
-    for w1, w2 in zip(weights_model, weights_wrapped):
-        assert numpy.array_equal(w1, w2)
+    # Apply the gradients
+    model.finish_update(optimizer)
+    assert model.shims[0].gradients is None
+
+    # Compare prev/next pairs and ensure their gradients have changed
+    for i in range(len(gradients)):
+        # Skip the first one
+        if i == 0:
+            continue
+        found_diff = False
+        curr_grads = gradients[i]
+        prev_grads = gradients[i - 1]
+        for curr, prev in zip(curr_grads, prev_grads):
+            if (prev != curr).numpy().any():
+                found_diff = True
+        assert found_diff is True
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")


### PR DESCRIPTION
Update the shim classes to use the thinc optimizers instead of creating framework-specific ones. 


- [x] Update tensorflow shim
- [x] Update mxnet shim
- [x] Update torch shim
- [x] Verify torch with cuda
- [x] Verify unique parameter ID use in torch/mxnet