### PR TITLE
Optimize parameters in bulk

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -100,7 +100,8 @@ def reduce_mean(X, lengths, out=None, threads_per_block=128, num_blocks=128):
     T = X.shape[0]
     O = X.shape[1]
     reduce_sum_kernel((num_blocks,), (threads_per_block,), (out, X, lengths, B, T, O))
-    out /= lengths.reshape((-1, 1))
+    # Avoid divide by zero
+    out /= lengths.reshape((-1, 1)) + 1e-10
     return out
 
 

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -751,7 +751,8 @@ class Ops:
         Y = self.alloc2f(lengths.shape[0], X.shape[1])
         start = 0
         for i, length in enumerate(lengths):
-            Y[i] = X[start : start + length].mean(axis=0)
+            if length:
+                Y[i] = X[start : start + length].mean(axis=0)
             start += length
         return Y
 
@@ -760,8 +761,9 @@ class Ops:
         which = self.alloc2i(lengths.shape[0], X.shape[1])
         start = 0
         for i, length in enumerate(lengths):
-            which[i] = X[start : start + length].argmax(axis=0)
-            Y[i] = X[start : start + length].max(axis=0)
+            if length:
+                which[i] = X[start : start + length].argmax(axis=0)
+                Y[i] = X[start : start + length].max(axis=0)
             start += length
         return Y, which
 

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -311,8 +311,8 @@ class Model(Generic[InT, OutT]):
                 param = node.get_param(name)
                 grad = node.get_grad(name)
 
-                params.append(param.ravel())
-                grads.append(grad.ravel())
+                params.append(self.ops.asarray(param.ravel()))
+                grads.append(self.ops.asarray(grad.ravel()))
                 shapes.append((param.size, param.shape))
                 if node.ops.xp.isnan(grad.sum()):
                     raise ValueError("nan in gradient")
@@ -329,8 +329,8 @@ class Model(Generic[InT, OutT]):
         for node in self.walk():
             for name in node.param_names:
                 size, shape = shapes.pop(0)
-                param = flat_params[start : start + size]
-                grad = flat_grads[start : start + size]
+                param = node.ops.asarray(flat_params[start : start + size])
+                grad = node.ops.asarray(flat_grads[start : start + size])
                 node.set_param(name, param.reshape(shape))
                 node.set_grad(name, grad.reshape(shape))
                 start += size

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -309,7 +309,10 @@ class Model(Generic[InT, OutT]):
         for node in self.walk():
             for name in node.param_names:
                 param = node.get_param(name)
-                grad = node.get_grad(name)
+                if node.has_grad(name):
+                    grad = node.get_grad(name)
+                else:
+                    grad = node.ops.xp.zeros_like(param)
 
                 params.append(self.ops.asarray(param.ravel()))
                 grads.append(self.ops.asarray(grad.ravel()))

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -330,8 +330,8 @@ class Model(Generic[InT, OutT]):
         for node in self.walk():
             for name in node.param_names:
                 size, shape = shapes.pop(0)
-                param = flat_params[start : start + end]  # type: ignore
-                grad = flat_grads[start : start + end]  # type: ignore
+                param = flat_params[start : start + size]  # type: ignore
+                grad = flat_grads[start : start + size]  # type: ignore
                 param = node.ops.asarray(param.reshape(shape))  # type: ignore
                 grad = node.ops.asarray(grad.reshape(shape))  # type: ignore
                 node.set_param(name, param)

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -322,7 +322,7 @@ class Model(Generic[InT, OutT]):
         flat_params, flat_grads = optimizer(
             (self.id, self.name),
             self.ops.xp.concatenate(params),
-            self.ops.xp.concatenate(grads)
+            self.ops.xp.concatenate(grads),
         )
         params = []
         grads = []
@@ -330,10 +330,10 @@ class Model(Generic[InT, OutT]):
         for node in self.walk():
             for name in node.param_names:
                 size, shape = shapes.pop(0)
-                param = flat_params[start : start+end] # type: ignore
-                grad = flat_grads[start : start+end] # type: ignore
-                param = node.ops.asarray(param.reshape(shape)) # type: ignore
-                grad = node.ops.asarray(grad.reshape(shape)) # type: ignore
+                param = flat_params[start : start + end]  # type: ignore
+                grad = flat_grads[start : start + end]  # type: ignore
+                param = node.ops.asarray(param.reshape(shape))  # type: ignore
+                grad = node.ops.asarray(grad.reshape(shape))  # type: ignore
                 node.set_param(name, param)
                 node.set_grad(name, grad)
                 start += size

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -432,8 +432,7 @@ class Model(Generic[InT, OutT]):
         """Transfer the model to a given GPU device."""
         import cupy.cuda.device
 
-        device = cupy.cuda.device.Device(gpu_id)
-        with device.use():
+        with cupy.cuda.device.Device(gpu_id):
             self._to_ops(CupyOps())
 
     def to_cpu(self) -> None:  # pragma: no cover
@@ -450,7 +449,7 @@ class Model(Generic[InT, OutT]):
                 if node.has_grad(name):
                     node.set_grad(name, ops.asarray_f(node.get_grad(name)))
             for shim in node.shims:
-                shim.to_device(ops.device_type)
+                shim.to_device(ops.device_type, ops.device_id)
 
     def to_bytes(self) -> bytes:
         """Serialize the model to a bytes representation. Models are usually

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -72,9 +72,7 @@ class MXNetShim(Shim):
             return
         xp = get_array_module(params[0])
         flat_params, flat_grads = optimizer(
-            (self.id, "mxnet-shim"),
-            xp.concatenate(params),
-            xp.concatenate(grads)
+            (self.id, "mxnet-shim"), xp.concatenate(params), xp.concatenate(grads)
         )
         start = 0
         for key, value in self._model.collect_params().items():

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -57,13 +57,31 @@ class MXNetShim(Shim):
         return output, backprop
 
     def finish_update(self, optimizer: Optimizer):
+        params = []
+        grads = []
+        shapes = []
         ctx = mx.current_context()
         for key, value in self._model.collect_params().items():
             grad = cast(FloatsXd, mxnet2xp(value.grad(ctx)))
             param = cast(FloatsXd, mxnet2xp(value.data(ctx)))
-            param, _ = optimizer((key, value.name), param, grad)
+            params.append(param.ravel())
+            grads.append(grad.ravel())
+            shapes.append((param.size, shape))
+        if not params:
+            return
+        xp = get_array_module(params[0])
+        flat_params, flat_grads = optimizer(
+            self.id,
+            xp.concatenate(params),
+            xp.concatenate(grads)
+        )
+        start = 0
+        for key, value in self._model.collect_params().items():
+            size, shape = shapes.pop(0)
+            param = flat_params[start : start + size].reshape(shape)
             value.set_data(xp2mxnet(param))
             value.zero_grad()
+            start += size
 
     def copy(self, ctx: "mx.context.Context" = None):
         if ctx is None:

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -10,6 +10,7 @@ except ImportError:  # pragma: no cover
     pass
 
 from ..util import mxnet2xp, convert_recursive, make_tempfile, xp2mxnet
+from ..util import get_array_module
 from ..optimizers import Optimizer
 from ..types import ArgsKwargs, FloatsXd
 from .shim import Shim
@@ -66,12 +67,12 @@ class MXNetShim(Shim):
             param = cast(FloatsXd, mxnet2xp(value.data(ctx)))
             params.append(param.ravel())
             grads.append(grad.ravel())
-            shapes.append((param.size, shape))
+            shapes.append((param.size, param.shape))
         if not params:
             return
         xp = get_array_module(params[0])
         flat_params, flat_grads = optimizer(
-            self.id,
+            (self.id, "mxnet-shim"),
             xp.concatenate(params),
             xp.concatenate(grads)
         )

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -91,11 +91,14 @@ class MXNetShim(Shim):
         copied.from_bytes(model_bytes)
         return copied
 
-    def to_device(self, device):
-        if device == "cpu":
+    def to_device(self, device_type: str, device_id: int):
+        if device_type == "cpu":
             self._model = self.copy(mx.cpu())
-        else:
+        elif device_type == "gpu":
             self._model = self.copy(mx.gpu())
+        else:
+            msg = f"Unexpected device_type: {device_type}. Try 'cpu' or 'gpu'."
+            raise ValueError(msg)
 
     def to_bytes(self):
         # MXNet doesn't implement save/load without a filename

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -98,10 +98,10 @@ class PyTorchShim(Shim):
             yield
 
     def to_device(self, device_type: str, device_id: int):  # pragma: no cover
-        if device == "cpu":
+        if device_type == "cpu":
             self._model.cpu()
-        elif device == "gpu":
-            self._model.cuda(device)
+        elif device_type == "gpu":
+            self._model.cuda(device_id)
         else:
             msg = f"Invalid device_type: {device_type}. Try 'cpu' or 'gpu'"
             raise ValueError(msg)

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -71,9 +71,7 @@ class PyTorchShim(Shim):
             return
         xp = get_array_module(params[0])
         flat_params, flat_grads = optimizer(
-            (self.id, "pytorch-shim"),
-            xp.concatenate(params),
-            xp.concatenate(grads)
+            (self.id, "pytorch-shim"), xp.concatenate(params), xp.concatenate(grads)
         )
         start = 0
         for name, torch_data in self._model.named_parameters():

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -97,11 +97,14 @@ class PyTorchShim(Shim):
         else:
             yield
 
-    def to_device(self, device):  # pragma: no cover
+    def to_device(self, device_type: str, device_id: int):  # pragma: no cover
         if device == "cpu":
             self._model.cpu()
-        else:
+        elif device == "gpu":
             self._model.cuda(device)
+        else:
+            msg = f"Invalid device_type: {device_type}. Try 'cpu' or 'gpu'"
+            raise ValueError(msg)
 
     def to_bytes(self):
         filelike = BytesIO()

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -71,7 +71,7 @@ class PyTorchShim(Shim):
             return
         xp = get_array_module(params[0])
         flat_params, flat_grads = optimizer(
-            self.id,
+            (self.id, "pytorch-shim"),
             xp.concatenate(params),
             xp.concatenate(grads)
         )

--- a/thinc/shims/shim.py
+++ b/thinc/shims/shim.py
@@ -51,7 +51,7 @@ class Shim:  # pragma: no cover
     def copy(self):
         return copy.deepcopy(self)
 
-    def to_device(self, device: str):
+    def to_device(self, device_type: str, device_id: int):
         raise NotImplementedError
 
     def to_disk(self, path: Union[str, Path]):

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -159,8 +159,8 @@ class TensorFlowShim(Shim):
             param = variable.numpy()
             grad = grad.numpy()
             shapes.append((param.size, param.shape))
-            params.append(param)
-            grads.append(grad)
+            params.append(param.ravel())
+            grads.append(grad.ravel())
         xp = get_array_module(params[0])
         flat_params, flat_grads = optimizer(
             (self.id, "tensorflow-shim"), xp.concatenate(params), xp.concatenate(grads)
@@ -234,12 +234,12 @@ class TensorFlowShim(Shim):
         copied._load_weights_from_state_dict()
         return copied
 
-    def to_device(self, device):  # pragma: no cover
-        if device == "cpu":
+    def to_device(self, device_type: str, device_id: int):  # pragma: no cover
+        if device_type == "cpu":
             with tf.device("/CPU"):  # pragma: no cover
                 self._clone_model()
-        else:
-            with tf.device("/GPU:{}".format(device)):
+        elif device_type == "gpu":
+            with tf.device("/GPU:{}".format(device_id)):
                 self._clone_model()
 
     def to_bytes(self):

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -154,7 +154,7 @@ class TensorFlowShim(Shim):
         params = []
         grads = []
         shapes = []
- 
+
         for grad, variable in zip(self.gradients, self._model.trainable_variables):
             param = variable.numpy()
             grad = grad.numpy()
@@ -163,9 +163,7 @@ class TensorFlowShim(Shim):
             grads.append(grad)
         xp = get_array_module(params[0])
         flat_params, flat_grads = optimizer(
-            (self.id, "tensorflow-shim"),
-            xp.concatenate(params),
-            xp.concatenate(grads)
+            (self.id, "tensorflow-shim"), xp.concatenate(params), xp.concatenate(grads)
         )
         start = 0
         for grad, variable in zip(self.gradients, self._model.trainable_variables):

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -9,7 +9,7 @@ import numpy
 from ..backends import Ops, get_current_ops, get_array_ops
 from ..optimizers import Optimizer
 from ..types import ArgsKwargs, ArrayXd
-from ..util import tensorflow2xp
+from ..util import tensorflow2xp, get_array_module
 from .shim import Shim
 
 try:
@@ -163,7 +163,7 @@ class TensorFlowShim(Shim):
             grads.append(grad)
         xp = get_array_module(params[0])
         flat_params, flat_grads = optimizer(
-            self.id,
+            (self.id, "tensorflow-shim"),
             xp.concatenate(params),
             xp.concatenate(grads)
         )

--- a/thinc/tests/layers/test_linear.py
+++ b/thinc/tests/layers/test_linear.py
@@ -60,7 +60,7 @@ def test_finish_update_calls_optimizer_with_weights(W_b_input):
     grad_BO = numpy.ones((nr_batch, nr_out), dtype="f")
     grad_BI = finish_update(grad_BO)  # noqa: F841
     model.finish_update(sgd)
-    assert seen_keys == {(model.id, "W"), (model.id, "b")}
+    assert seen_keys == {(model.id, model.name)}
 
 
 @settings(max_examples=100)

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -2,7 +2,7 @@ import numpy
 import pytest
 from thinc.api import Adam, ArgsKwargs, Linear, Model, TensorFlowWrapper
 from thinc.api import get_current_ops, keras_subclass, tensorflow2xp, xp2tensorflow
-from thinc.util import has_tensorflow, to_categorical
+from thinc.util import has_cupy, has_tensorflow, to_categorical
 
 from ..util import check_input_converters, make_tempdir
 
@@ -342,10 +342,9 @@ def test_tensorflow_wrapper_to_cpu(tf_model):
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not has_cupy, reason="needs cupy")
 def test_tensorflow_wrapper_to_gpu(model, X):
-    # Raises while failing to import cupy
-    with pytest.raises(ImportError):
-        model.to_gpu(0)
+    model.to_gpu(0)
 
 
 @pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")


### PR DESCRIPTION
Most other libraries' optimizers work on a group of parameters at once. This changes the definition of gradient normalization, which causes an annoying mismatch between our hyper-parameter values and e.g. PyTorch. It probably doesn't matter, but it's another thing for people to worry about. Optimizing lots of small arrays also makes our optimizer quite slow.

Instead, we can merge the parameters and gradients together and just call the optimizer once. The question is whether we should do this within the `Optimizer` class. Maybe? For now the merging and flattening is duplicated in the shims...

We do create an extra copy of the parameters when we do this, which is a bit unideal, but I don't really see a way to help it.