### PR TITLE
Enable blis by default

### DIFF
--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -47,7 +47,7 @@ class NumpyOps(Ops):
         device_type: DeviceTypes = "cpu",
         device_id: int = -1,
         *,
-        use_blis: bool = False
+        use_blis: bool = True
     ) -> None:
         self.device_type = device_type
         self.device_id = device_id


### PR DESCRIPTION
Leaving it off by default is a big hassle, and caused some bad performance in spaCy that was hard to track down.