### PR TITLE
Update textcat example to thinc==8.0.0a9

### DIFF
--- a/examples/03_textcat_basic_neural_bow.ipynb
+++ b/examples/03_textcat_basic_neural_bow.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Basic neural bag-of-words text classifier with Thinc\n",
     "\n",
-    "This notebook shows how to implement a simple neural text classification model in Thinc."
+    "This notebook shows how to implement a simple neural text classification model in Thinc. Last tested with `thinc==8.0.0a9`."
    ]
   },
   {
@@ -114,7 +114,7 @@
     "@thinc.registry.layers(\"EmbedPoolTextcat.v1\")\n",
     "def EmbedPoolTextcat(embed: Model[Array2d, Array2d]) -> Model[List[Array2d], Array2d]:\n",
     "    with Model.define_operators({\">>\": chain}):\n",
-    "        model = list2ragged() >> with_array(embed) >> reduce_mean() >> Softmax()\n",
+    "        model = with_array(embed) >> list2ragged() >> reduce_mean() >> Softmax()\n",
     "    model.set_ref(\"embed\", embed)\n",
     "    return model"
    ]
@@ -192,7 +192,7 @@
     "batch_size = C[\"training\"][\"batch_size\"]\n",
     "optimizer = C[\"optimizer\"]\n",
     "model = C[\"model\"]\n",
-    "model.get_ref(\"embed\").set_dim(\"nV\", len(vocab))\n",
+    "model.get_ref(\"embed\").set_dim(\"nV\", len(vocab) + 1)\n",
     "\n",
     "model.initialize(X=train_X, Y=train_y)"
    ]
@@ -251,9 +251,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.2 64-bit ('.env': venv)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python37"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -265,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updates vocab size and model definition for changes since 8.0.0a1.

Fixes #354.