### PR TITLE
Add overrides option to fill_config and train_from_config

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a13"
+__version__ = "8.0.0a14"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -183,6 +183,7 @@ class registry(object):
         config: Union[Config, Dict[str, Dict[str, Any]]],
         *,
         schema: Type[BaseModel] = EmptySchema,
+        overrides: Dict[str, Any] = {},
         validate: bool = True,
     ) -> Config:
         """Unpack a config dictionary, creating objects from the registry
@@ -195,7 +196,9 @@ class registry(object):
         if cls.is_promise(config):
             err_msg = "The top-level config object can't be a reference to a registered function."
             raise ConfigValidationError(config, [{"msg": err_msg}])
-        _, _, resolved = cls._fill(config, schema, validate)
+        _, _, resolved = cls._fill(
+            config, schema, overrides=overrides, validate=validate
+        )
         return resolved
 
     @classmethod
@@ -204,6 +207,7 @@ class registry(object):
         config: Union[Config, Dict[str, Dict[str, Any]]],
         *,
         schema: Type[BaseModel] = EmptySchema,
+        overrides: Dict[str, Any] = {},
         validate: bool = True,
     ) -> Config:
         """Unpack a config dictionary, leave all references to registry
@@ -218,7 +222,7 @@ class registry(object):
         if cls.is_promise(config):
             err_msg = "The top-level config object can't be a reference to a registered function."
             raise ConfigValidationError(config, [{"msg": err_msg}])
-        filled, _, _ = cls._fill(config, schema, validate)
+        filled, _, _ = cls._fill(config, schema, validate=validate, overrides=overrides)
         return filled
 
     @classmethod
@@ -226,8 +230,10 @@ class registry(object):
         cls,
         config: Union[Config, Dict[str, Dict[str, Any]]],
         schema: Type[BaseModel] = EmptySchema,
+        *,
         validate: bool = True,
         parent: str = "",
+        overrides: Dict[str, Dict[str, Any]] = {},
     ) -> Tuple[Config, Config, Config]:
         """Build three representations of the config:
         1. All promises are preserved (just like config user would provide).
@@ -242,10 +248,16 @@ class registry(object):
         final: Dict[str, Any] = {}
         for key, value in config.items():
             key_parent = f"{parent}.{key}".strip(".")
+            if key_parent in overrides:
+                value = overrides[key_parent]
             if cls.is_promise(value):
                 promise_schema = cls.make_promise_schema(value)
                 filled[key], validation[key], final[key] = cls._fill(
-                    value, promise_schema, validate, parent=key_parent
+                    value,
+                    promise_schema,
+                    validate=validate,
+                    parent=key_parent,
+                    overrides=overrides,
                 )
                 # Call the function and populate the field value. We can't just
                 # create an instance of the type here, since this wouldn't work
@@ -275,7 +287,11 @@ class registry(object):
                         # If we don't have a pydantic schema and just a type
                         field_type = EmptySchema
                 filled[key], validation[key], final[key] = cls._fill(
-                    value, field_type, validate, parent=key_parent
+                    value,
+                    field_type,
+                    validate=validate,
+                    parent=key_parent,
+                    overrides=overrides,
                 )
                 if key == ARGS_FIELD and isinstance(validation[key], dict):
                     # If the value of variable positional args is a dict (e.g.

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -683,6 +683,13 @@ def test_fill_config_overrides():
     with pytest.raises(ConfigValidationError):
         overrides = {"one": {"@cats": "catsie.v1"}, "two": None}
         my_registry.fill_config(config, overrides=overrides)
+    # Overrides that don't match config should raise error
+    with pytest.raises(ConfigValidationError):
+        overrides = {"two.three.evil": False, "two.four": True}
+        my_registry.fill_config(config, overrides=overrides, validate=True)
+    with pytest.raises(ConfigValidationError):
+        overrides = {"five": False}
+        my_registry.fill_config(config, overrides=overrides, validate=True)
 
 
 def test_make_from_config_overrides():
@@ -710,3 +717,19 @@ def test_make_from_config_overrides():
     with pytest.raises(ConfigValidationError):
         overrides = {"one": {"@cats": "catsie.v1"}, "two": None}
         my_registry.make_from_config(config, overrides=overrides)
+    # Overrides that don't match config should raise error
+    with pytest.raises(ConfigValidationError):
+        overrides = {"two.three.evil": False, "two.four": True}
+        my_registry.make_from_config(config, overrides=overrides, validate=True)
+    with pytest.raises(ConfigValidationError):
+        overrides = {"five": False}
+        my_registry.make_from_config(config, overrides=overrides, validate=True)
+
+
+@pytest.mark.parametrize(
+    "prop,expected",
+    [("a.b.c", True), ("a.b", True), ("a", True), ("a.e", True), ("a.b.c.d", False)],
+)
+def test_is_in_config(prop, expected):
+    config = {"a": {"b": {"c": 5, "d": 6}, "e": [1, 2]}}
+    assert my_registry._is_in_config(prop, config) is expected


### PR DESCRIPTION
This PR adds support for a dictionary `overrides` that can be provided to `registry.make_from_config` and `registry.fill_config`. This feature allows implementing workflows that need a mechanism to overwrite config settings without editing the config file, e.g. via a CLI (the intended use in spaCy). 

Overrides are applied as the config is resolved and should be passed in as a dictionary, keyed by config properties using the dot notation:

```python
{"section.subsection.value": 123, "other_section.foo": "bar"}
```

Values are substituted before a section is validated, so overwriting a typed argument with a value of the wrong type will raise a regular config validation error. It's also possible to overwrite "promises" (references to registered functions), e.g. to overwrite a schedule with a single float/int. Overrides can also contain function references for consistency, although this is likely a less common use case.
