### PR TITLE
Raise error if expanding undefined config block

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a14"
+__version__ = "8.0.0a15"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -55,11 +55,9 @@ class Config(dict):
                 if part == "*":
                     node = node.setdefault(part, {})
                 elif part not in node:
-                    raise ConfigStructureError(
-                        "Error parsing config section '{section}'. "
-                        "The block '{part}' is not defined. Perhaps a section "
-                        "name is wrong?"
-                    )
+                    err_title = f"Error parsing config section. Perhaps a section name is wrong?"
+                    err = [{"loc": parts, "msg": f"Section '{part}' is not defined"}]
+                    raise ConfigValidationError(self, err, message=err_title)
                 else:
                     node = node[part]
             node = node.setdefault(parts[-1], {})
@@ -140,11 +138,6 @@ class ConfigValidationError(ValueError):
             data.append((err_loc, error.get("msg")))
         result = [message, table(data), f"{config}"]
         ValueError.__init__(self, "\n\n" + "\n".join(result))
-
-
-class ConfigStructureError(ConfigValidationError):
-    def __init__(self, message: str):
-        ValueError.__init__(self, message)
 
 
 ARGS_FIELD = "*"

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -655,7 +655,6 @@ def test_handle_error_duplicate_keys(cfg):
         Config().from_str(cfg)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "cfg,is_valid",
     [

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -657,10 +657,7 @@ def test_handle_error_duplicate_keys(cfg):
 
 @pytest.mark.parametrize(
     "cfg,is_valid",
-    [
-        ("[a]\nb = 1\n\n[a.c]\nd = 3", True),
-        ("[a]\nb = 1\n\n[A.c]\nd = 2", False)
-    ],
+    [("[a]\nb = 1\n\n[a.c]\nd = 3", True), ("[a]\nb = 1\n\n[A.c]\nd = 2", False)],
 )
 def test_cant_expand_undefined_block(cfg, is_valid):
     """Test that you can't expand a block that hasn't been created yet. This
@@ -668,10 +665,10 @@ def test_cant_expand_undefined_block(cfg, is_valid):
     it's very hard to create good errors for those typos.
     """
     if is_valid:
-        _ = Config().from_str(cfg)
+        Config().from_str(cfg)
     else:
         with pytest.raises(ConfigValidationError):
-            _ = Config().from_str(cfg)
+            Config().from_str(cfg)
 
 
 def test_fill_config_overrides():

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -655,6 +655,26 @@ def test_handle_error_duplicate_keys(cfg):
         Config().from_str(cfg)
 
 
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "cfg,is_valid",
+    [
+        ("[a]\nb = 1\nc = 2\n\n[a.c]\nd = 3", True),
+        ("[a]\nb = 1\n\n[A.c]\nd = 2", False)
+    ],
+)
+def test_cant_expand_undefined_block(cfg, is_valid):
+    """Test that you can't expand a block that hasn't been created yet. This
+    comes up when you typo a name, and if we allow expansion of undefined blocks,
+    it's very hard to create good errors for those typos.
+    """
+    if is_valid:
+        _ = Config().from_str(cfg)
+    else:
+        with pytest.raises(ConfigValidationError):
+            _ = Config().from_str(cfg)
+
+
 def test_fill_config_overrides():
     config = {
         "one": 1,

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -658,7 +658,7 @@ def test_handle_error_duplicate_keys(cfg):
 @pytest.mark.parametrize(
     "cfg,is_valid",
     [
-        ("[a]\nb = 1\nc = 2\n\n[a.c]\nd = 3", True),
+        ("[a]\nb = 1\n\n[a.c]\nd = 3", True),
         ("[a]\nb = 1\n\n[A.c]\nd = 2", False)
     ],
 )


### PR DESCRIPTION
This catches a common typo case where you have something like:

```
[nlp.pipeline]
blah = true

[nlp.pipline.ner]
@architecture = "tok2vec.v1"

[nlp.pipeline.ner.model]
...
```

These errors are otherwise difficult to catch, as we'll end up complaining about the validation of the `"tok2vec.v1" function as it's missing its arguments...Which look like they're provided, unless the user sees the typo.

So you have to open a block, you can't create nested structures all in one section command. The only exception is the `*` block used for lists, which it wouldn't make sense to create explicitly.

I've made a separate error, `ConfigStructureError` for this as I didn't want the same error args as the `ConfigValidationError`. I did inherit from `ConfigValidationError` though, so people only have to catch the parent class to catch both.