### PR TITLE
Make config.to_str() create intermediate blocks

### DIFF
--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -311,7 +311,6 @@ def test_config_to_str():
     assert cfg.to_str().strip() == OPTIMIZER_CFG.strip()
 
 
-@pytest.mark.xfail
 def test_config_to_str_creates_intermediate_blocks():
     cfg = Config({"optimizer": {"foo": {"bar": 1}}})
     assert cfg.to_str().strip() == """

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -313,12 +313,15 @@ def test_config_to_str():
 
 def test_config_to_str_creates_intermediate_blocks():
     cfg = Config({"optimizer": {"foo": {"bar": 1}}})
-    assert cfg.to_str().strip() == """
+    assert (
+        cfg.to_str().strip()
+        == """
 [optimizer]
 
 [optimizer.foo]
 bar = 1
     """.strip()
+    )
 
 
 def test_config_roundtrip_bytes():

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -311,6 +311,17 @@ def test_config_to_str():
     assert cfg.to_str().strip() == OPTIMIZER_CFG.strip()
 
 
+@pytest.mark.xfail
+def test_config_to_str_creates_intermediate_blocks():
+    cfg = Config({"optimizer": {"foo": {"bar": 1}}})
+    assert cfg.to_str().strip() == """
+[optimizer]
+
+[optimizer.foo]
+bar = 1
+    """.strip()
+
+
 def test_config_roundtrip_bytes():
     cfg = Config().from_str(OPTIMIZER_CFG)
     cfg_bytes = cfg.to_bytes()


### PR DESCRIPTION
Previously if you had `{"optimizer": {"foo": {"bar": 1}}`, the printed string would not create the `[optimizer]` block as it didn't have any leaf values. That now fails parsing due to the change in #362.