### PR TITLE
fix concatenate (list) on GPU

### DIFF
--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -80,12 +80,12 @@ def _list_forward(
         d_output = model.ops.xp.concatenate(d_output, axis=0)
         dY = model.ops.as_contig(d_output[:, : widths[0]])
         # We want to generalize unflatten later.
-        dY = model.ops.asarray(model.ops.unflatten(dY, lengths))  # type: ignore
+        dY = model.ops.unflatten(dY, lengths)  # type: ignore
         dX = callbacks[0](dY)
         start = widths[0]
         for bwd, width in zip(callbacks[1:], widths[1:]):
             dY = model.ops.as_contig(d_output[:, start : start + width])
-            dY = model.ops.asarray(model.ops.unflatten(dY, lengths))  # type: ignore
+            dY = model.ops.unflatten(dY, lengths)  # type: ignore
             dX += bwd(dY)
             start += width
         return dX


### PR DESCRIPTION
The backprop calls take `List`'s as input, I think there's no need for the `asarray` transformations. They don't matter for `numpy` (I assume because of duck typing), but on GPU `cupy` throws an error because of the varying lengths and a resulting `Unsupported dtype object`.

This fix makes `CharEmbed` / the morphologizer work again on GPU / spaCy (together with https://github.com/explosion/spaCy/pull/5757)