### PR TITLE
Fix handling of dict return values, add registry.resolve

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a17"
+__version__ = "8.0.0a18"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -293,6 +293,10 @@ class registry(object):
                     )
                 validation[key] = getter_result
                 final[key] = getter_result
+                if isinstance(validation[key], dict):
+                    # The registered function returned a dict, prevent it from
+                    # being validated as a config section
+                    validation[key] = {}
                 if isinstance(validation[key], GeneratorType):
                     # If value is a generator we can't validate type without
                     # consuming it (which doesn't work if it's infinite – see


### PR DESCRIPTION
* Fix handling and validation of registered functions returning dicts when config is filled and validated.
* Add `registry.resolve` shorthand that fills and resolves a config (so we don't have to call into `registry._fill` from spaCy etc.)