### PR TITLE
Config enhancements

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a18"
+__version__ = "8.0.0a19"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -104,7 +104,12 @@ class Config(dict):
                 flattened.add_section(section_name)
             for key, value in node.items():
                 if hasattr(value, "items"):
-                    queue.append((path + (key,), value))
+                    # Reference to a function with no arguments, serialize
+                    # inline as a dict and don't create new section
+                    if registry.is_promise(value) and len(value) == 1:
+                        flattened.set(section_name, key, srsly.json_dumps(value))
+                    else:
+                        queue.append((path + (key,), value))
                 else:
                     flattened.set(section_name, key, srsly.json_dumps(value))
         string_io = io.StringIO()

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -10,6 +10,7 @@ import catalogue
 import inspect
 import io
 import numpy
+import copy
 
 from .types import Decorator
 
@@ -72,6 +73,14 @@ class Config(dict):
                     raise ValueError(
                         f"Error reading key '{key}' in section '{section}': {e}"
                     )
+
+    def copy(self) -> "Config":
+        """Deepcopy the config."""
+        try:
+            config = copy.deepcopy(self)
+        except Exception as e:
+            raise ValueError(f"Couldn't deep-copy config: {e}")
+        return Config(config)
 
     def from_str(self, text: str) -> "Config":
         "Load the config from a string."

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -112,6 +112,10 @@ class Config(dict):
                         queue.append((path + (key,), value))
                 else:
                     flattened.set(section_name, key, srsly.json_dumps(value))
+        # Order so subsection follow parent (not all sections, then all subs etc.)
+        flattened._sections = dict(
+            sorted(flattened._sections.items(), key=lambda x: x[0])
+        )
         string_io = io.StringIO()
         flattened.write(string_io)
         return string_io.getvalue().strip()

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -811,3 +811,13 @@ def test_config_to_str_simple_promises():
     config = Config().from_str(config_str)
     assert config["section"]["subsection"]["@registry"] == "value"
     assert config.to_str() == config_str
+
+
+def test_config_to_str_order():
+    """Test that Config.to_str orders the sections."""
+    config = {"a": {"b": {"c": 1, "d": 2}, "e": 3}, "f": {"g": {"h": {"i": 4, "j": 5}}}}
+    expected = (
+        "[a]\ne = 3\n\n[a.b]\nc = 1\nd = 2\n\n[f]\n\n[f.g]\n\n[f.g.h]\ni = 4\nj = 5"
+    )
+    config = Config(config)
+    assert config.to_str() == expected

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -428,7 +428,7 @@ def test_make_config_positional_args_complex():
 def test_positional_args_to_from_string():
     cfg = """[a]\nb = 1\n* = ["foo","bar"]"""
     assert Config().from_str(cfg).to_str() == cfg
-    cfg = """[a]\nb = 1\n\n[a.*.foo]\ntest = 1\n\n[a.*.bar]\ntest = 2"""
+    cfg = """[a]\nb = 1\n\n[a.*.bar]\ntest = 2\n\n[a.*.foo]\ntest = 1"""
     assert Config().from_str(cfg).to_str() == cfg
 
     @my_registry.cats("catsie.v666")

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -790,3 +790,15 @@ def test_fill_config_dict_return_type():
     result = my_registry.fill_config(config, validate=True)["test"]
     assert result["evil"] is False
     assert "not_evil" not in result
+
+
+def test_deepcopy_config():
+    config = Config({"a": 1, "b": {"c": 2, "d": 3}})
+    copied = config.copy()
+    # Same values but not same object
+    assert config == copied
+    assert config is not copied
+    # Check for error if value can't be pickled/deepcopied
+    config = Config({"a": 1, "b": numpy})
+    with pytest.raises(ValueError):
+        config.copy()

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -802,3 +802,12 @@ def test_deepcopy_config():
     config = Config({"a": 1, "b": numpy})
     with pytest.raises(ValueError):
         config.copy()
+
+
+def test_config_to_str_simple_promises():
+    """Test that references to function registries without arguments are
+    serialized inline as dict."""
+    config_str = """[section]\nsubsection = {"@registry":"value"}"""
+    config = Config().from_str(config_str)
+    assert config["section"]["subsection"]["@registry"] == "value"
+    assert config.to_str() == config_str

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -821,3 +821,16 @@ def test_config_to_str_order():
     )
     config = Config(config)
     assert config.to_str() == expected
+
+
+@pytest.mark.xfail(reason="interpolation doesn't work because json.loads")
+def test_config_interpolation():
+    config_str = """[a]\nfoo = "hello"\n\n[b]\nbar = ${a.foo}"""
+    with pytest.raises(ConfigValidationError):
+        Config().from_str(config_str)
+    config_str = """[a]\nfoo = "hello"\n\n[b]\nbar = ${a:foo}"""
+    config = Config().from_str(config_str)
+    assert config["b"]["bar"] == "hello"
+    config_str = """[a]\nfoo = "hello"\n\n[b]\nbar = ${a:foo}!"""
+    config = Config().from_str(config_str)
+    assert config["b"]["bar"] == "hello!"


### PR DESCRIPTION
- [x] Add `Config.copy` for deepcopying configs.
- [x] Serialize refrences to registered functions with no args as dict

```diff
[section]
+ subsection = {"@some_registry": "SomeFunction.v1"}

- [section.subsection]
- @some_registry = "SomeFunction.v1"
```
- [x] preserve reasonable order in `Config.to_str` (previously, config was sorted with top-level sections first, followed by all subsections and so on – now sections are ordered by key, so `[nlp]`, followed by `[nlp.pipeline]`, followed by `[nlp.pipeline.tagger]` and so on)
- [x] improve error messages around config deserialization and interpolation issues