### PR TITLE
Add maybe_get_{dim, param, grad, ref} methods

### DIFF
--- a/thinc/model.py
+++ b/thinc/model.py
@@ -189,6 +189,13 @@ class Model(Generic[InT, OutT]):
             raise ValueError(err)
         self._dims[name] = value
 
+    def maybe_get_dim(self, name: str) -> Optional[int]:
+        """Retrieve the value of a dimension of the given name, or None."""
+        if name not in self._dims:
+            return None
+        else:
+            return self._dims[name]
+
     def has_param(self, name: str) -> Optional[bool]:
         """Check whether the model has a weights parameter of the given name.
 
@@ -211,6 +218,10 @@ class Model(Generic[InT, OutT]):
             )
         return self._params.get_param(self.id, name)
 
+    def maybe_get_param(self, name: str) -> Optional[FloatsXd]:
+        """Retrieve a weights parameter by name, or None."""
+        return self.get_param(name) if self.has_param(name) else None
+
     def set_param(self, name: str, value: Optional[FloatsXd]) -> None:
         """Set a weights parameter's value."""
         if value is None:
@@ -231,6 +242,10 @@ class Model(Generic[InT, OutT]):
     def set_grad(self, name: str, value: FloatsXd) -> None:
         """Set a gradient value for the model."""
         self._params.set_grad(self.id, name, value)
+
+    def maybe_get_grad(self, name: str) -> Optional[FloatsXd]:
+        """Retrieve a gradient by name, or None."""
+        return self.get_grad(name) if self.has_grad(name) else None
 
     def inc_grad(self, name: str, value: FloatsXd) -> None:
         """Increment the gradient of a parameter by a value."""
@@ -257,6 +272,10 @@ class Model(Generic[InT, OutT]):
             raise ValueError(err)
         else:
             return value
+
+    def maybe_get_ref(self, name: str) -> "Model":
+        """Retrieve the value of a reference if it exists, or None."""
+        return self.get_ref(name) if self.has_ref(name) else None
 
     def set_ref(self, name: str, value: Optional["Model"]) -> None:
         """Set a value for a reference."""

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -191,10 +191,7 @@ class Model(Generic[InT, OutT]):
 
     def maybe_get_dim(self, name: str) -> Optional[int]:
         """Retrieve the value of a dimension of the given name, or None."""
-        if name not in self._dims:
-            return None
-        else:
-            return self._dims[name]
+        return self.get_dim(name) if self.has_dim(name) else None
 
     def has_param(self, name: str) -> Optional[bool]:
         """Check whether the model has a weights parameter of the given name.

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -270,7 +270,7 @@ class Model(Generic[InT, OutT]):
         else:
             return value
 
-    def maybe_get_ref(self, name: str) -> "Model":
+    def maybe_get_ref(self, name: str) -> Optional["Model"]:
         """Retrieve the value of a reference if it exists, or None."""
         return self.get_ref(name) if self.has_ref(name) else None
 

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -146,6 +146,17 @@ def test_model_set_reference():
     assert not parent.has_ref("grandkind")
 
 
+def test_maybe_methods():
+    model = Linear(5)
+    assert model.maybe_get_dim("nI") is None
+    model.set_dim("nI", 4)
+    assert model.maybe_get_dim("nI") == 4
+    assert model.maybe_get_ref("boo") is None
+    assert model.maybe_get_param("W") is None
+    model.initialize()
+    assert model.maybe_get_param("W") is not None
+
+
 def test_model_can_save_to_disk(model_with_no_args):
     with make_tempdir() as path:
         model_with_no_args.to_disk(path / "thinc_model")


### PR DESCRIPTION
Writing the conditional logic for the getters is inconvenient, but we don't want to return `None` from those methods, or the type-guarantees will be greatly weakened. Instead I suggest we have separate methods that are allowed to return `None`.