### PR TITLE
Support extended config interpolation

### DIFF
--- a/thinc/config.py
+++ b/thinc/config.py
@@ -32,7 +32,13 @@ class CustomInterpolation(ExtendedInterpolation):
             pass
         return super().before_read(parser, section, option, value)
 
-    def _interpolate_some(self, parser, option, accum, rest, section, map, depth):
+    def before_get(self, parser, section, option, value, defaults):
+        # Mostly copy-pasted from the built-in configparser implementation.
+        L = []
+        self.interpolate(parser, option, L, value, section, defaults, 1)
+        return "".join(L)
+
+    def interpolate(self, parser, option, accum, rest, section, map, depth):
         # Mostly copy-pasted from the built-in configparser implementation.
         # We need to overwrite this method so we can add special handling for
         # block references :( All values produced here should be strings –
@@ -86,9 +92,7 @@ class CustomInterpolation(ExtendedInterpolation):
                     ) from None
                 if "$" in v:
                     new_map = dict(parser.items(sect, raw=True))
-                    self._interpolate_some(
-                        parser, opt, accum, v, sect, new_map, depth + 1,
-                    )
+                    self.interpolate(parser, opt, accum, v, sect, new_map, depth + 1)
                 else:
                     accum.append(v)
             else:

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -848,6 +848,14 @@ def test_config_interpolation_sections():
     config_str = """[a]\nfoo = "hello"\n\n[a.x]\ny = ${a.b}\n\n[a.b]\nc = 1\nd = [10]"""
     config = Config().from_str(config_str)
     assert config["a"]["x"]["y"] == config["a"]["b"]
+    # Multiple references in the same string
+    config_str = """[a]\nx = "string"\ny = 10\n\n[b]\nz = "${a:x}/${a:y}\""""
+    config = Config().from_str(config_str)
+    assert config["b"]["z"] == "string/10"
+    # Non-string references in string (converted to string)
+    config_str = """[a]\nx = ["hello", "world"]\n\n[b]\ny = "result: ${a:x}\""""
+    config = Config().from_str(config_str)
+    assert config["b"]["y"] == 'result: ["hello", "world"]'
     # References to sections referencing sections
     config_str = """[a]\nfoo = "x"\n\n[b]\nbar = ${a}\n\n[c]\nbaz = ${b}"""
     config = Config().from_str(config_str)


### PR DESCRIPTION
Resolves #352.

This PR improves how variable interpolation is handled in configs and adds support for referencing blocks. Even the basic interpolation ended up being tricky to support, because we need to make sure that values are loaded with `json.loads` _before_ they're substituted, so you don't end up with `"hello ${value}"` -> `"hello "value""`.

Some examples of what's possible now (also see the tests for more):

```ini
[paths]
root = "/some/path"
some_int = 10

[section]
my_path = "${paths:root}/some/subpath"
my_other_path = "${paths:root}/some/subpath/${paths:some_int}"
```

```ini
[section]
some_value = "value"

[other_section]
some_value = ${section}
```

```ini
[section]
some_value = "value"

[section.subsection]
other_value = 20

[other_section]
some_value = ${section.subsection}
```

### Implementation notes

* In order to make this work, I had to implement our own versions of some of the `configparser.ExtendedInterpolation` methods. `_interpolate_some` is especially annoying because we really just needed to add a small section, but this was the only way to make it work properly.