### PR TITLE
Allow config overrides on creation (and used with interpolation)

### DIFF
--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -891,13 +891,12 @@ def test_config_from_str_overrides():
     assert config["a"]["b"] == 10
     assert config["a"]["c"]["d"] == 20
     assert config["a"]["c"]["e"] == 3
-    # Adding new keys via overrides
-    overrides = {"a.b": 10, "a.c.f": 200}
-    config = Config().from_str(config_str, overrides=overrides)
-    assert config["a"]["c"] == {"d": 2, "e": 3, "f": 200}
     # Invalid keys and sections
     with pytest.raises(ConfigValidationError):
         Config().from_str(config_str, overrides={"f": 10})
+    # Adding new keys that are not in initial config via overrides
+    with pytest.raises(ConfigValidationError):
+        Config().from_str(config_str, overrides={"a.b": 10, "a.c.f": 200})
     # This currently isn't expected to work, because the dict in f.g is not
     # interpreted as a section while the config is still just the configparser
     with pytest.raises(ConfigValidationError):


### PR DESCRIPTION
The `Config.from_str`, `Config.from_bytes` and `Config.from_disk` methods can now take optional `overrides` that are added to the config parser _before_ the config is interpreted. This allows overwriting values that are referenced as variables in other sections, without breaking the config.

### Example

```ini
[section]
a = 2
b = 3

[section.subsection]
c = "hello"

[other_section]
d = ${section:a}
e = ${section.subsection}
```

```python
overrides = {"section.a": 20, "section.subsection.c": "world"}
config = Config.from_str(config_str, overrides=overrides)
```

```python
# Result
{
  "section": {
    "a": 20,
    "b": 3,
    "subsection": {
      "c": "world"
    },
  "other_section": {
    "d": 20,
    "e": {
       "c": "world"
    }
  }
}
```