### PR TITLE
Use "raise ... from" in custom errors for better tracebacks

### DIFF
--- a/thinc/util.py
+++ b/thinc/util.py
@@ -432,7 +432,7 @@ def validate_fwd_input_output(
     try:
         ArgModel.parse_obj(args)
     except ValidationError as e:
-        raise DataValidationError(name, X, Y, e.errors())
+        raise DataValidationError(name, X, Y, e.errors()) from None
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Some background on `raise` with `from`: https://stackoverflow.com/a/24752607/6400719

It's probably a good code practice we should adopt in spaCy as well? This will:

* remove the extensive traceback caused by raising and reraising exceptions during config validation (`from None`)
* in custom exceptions based on other relevant exceptions (like, if copying the config fails because of an error in `deepcopy`): raising it from the original error means the traceback will read: "The above exception was the direct cause of the following exception:"