### PR TITLE
Fix reporting of whether config is interpolated

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a24"
+__version__ = "8.0.0a25"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -133,6 +133,7 @@ class Config(dict):
     def __init__(
         self,
         data: Optional[Union[Dict[str, Any], "ConfigParser", "Config"]] = None,
+        *,
         is_interpolated: Optional[bool] = None,
     ) -> None:
         """Initialize a new Config object with optional data."""

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -492,7 +492,7 @@ class registry(object):
         schema: Type[BaseModel] = EmptySchema,
         overrides: Dict[str, Any] = {},
         validate: bool = True,
-    ) -> Tuple[Config, Config]:
+    ) -> Tuple[Dict[str, Any], Config]:
         """Unpack a config dictionary and create two versions of the config:
         a resolved version with objects from the registry created recursively,
         and a filled version with all references to registry functions left
@@ -532,7 +532,7 @@ class registry(object):
         schema: Type[BaseModel] = EmptySchema,
         overrides: Dict[str, Any] = {},
         validate: bool = True,
-    ) -> Config:
+    ) -> Dict[str, Any]:
         """Unpack a config dictionary, creating objects from the registry
         recursively. If validate=True, the config will be validated against the
         type annotations of the registered functions referenced in the config
@@ -575,7 +575,7 @@ class registry(object):
         validate: bool = True,
         parent: str = "",
         overrides: Dict[str, Dict[str, Any]] = {},
-    ) -> Tuple[Config, Config, Config]:
+    ) -> Tuple[Config, Config, Dict[str, Any]]:
         """Build three representations of the config:
         1. All promises are preserved (just like config user would provide).
         2. Promises are replaced by their return values. This is the validation
@@ -668,7 +668,7 @@ class registry(object):
         exclude_validation = set([ARGS_FIELD_ALIAS, *RESERVED_FIELDS.keys()])
         validation.update(result.dict(exclude=exclude_validation))
         filled, final = cls._update_from_parsed(validation, filled, final)
-        return Config(filled), Config(validation), Config(final)
+        return Config(filled), Config(validation), dict(final)
 
     @classmethod
     def _update_from_parsed(

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -982,6 +982,10 @@ def test_config_no_interpolation():
     assert config3["c"]["d"] == 1
     assert config3["c"]["e"] == "hello1"
     assert config3["c"]["f"] == {"b": 1}
+    # Bad non-serializable value
+    cfg = {"x": {"y": numpy.asarray([[1, 2, 3], [4, 5, 3]], dtype="f"), "z": "${x:y}"}}
+    with pytest.raises(ConfigValidationError):
+        Config(cfg).interpolate()
 
 
 def test_config_no_interpolation_registry():

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1066,18 +1066,6 @@ def test_config_deep_merge_variables():
     defaults = Config().from_str("""[a]\nb = 100\nc = ${a:b}""", interpolate=False)
     merged = defaults.merge(config)
     assert merged["a"]["c"] == 2
-    # With variable in defaults: preferred
-    config = Config().from_str("""[a]\nb= 1\nc = 2""")
-    defaults = Config().from_str("""[a]\nb = 100\nc = ${a:b}""", interpolate=False)
-    merged = defaults.merge(config, prefer_vars=True)
-    assert merged["a"]["c"] == "${a:b}"
-    assert merged.interpolate()["a"]["c"] == 1
-    # With variable in both configs: preferred
-    config = Config().from_str("""[a]\nc = ${d:e}\n\n[d]\ne = 20""", interpolate=False)
-    defaults = Config().from_str("""[a]\nb = 100\nc = ${a:b}""", interpolate=False)
-    merged = defaults.merge(config, prefer_vars=True)
-    assert merged["a"]["c"] == "${d:e}"
-    assert merged.interpolate()["a"]["c"] == 20
 
 
 def test_config_to_str_roundtrip():

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -970,7 +970,7 @@ def test_config_no_interpolation():
     config = Config().from_str(config_str, interpolate=False)
     assert not config.is_interpolated
     assert config["c"]["d"] == "${a:b}"
-    assert config["c"]["e"] == "hello${a:b}"
+    assert config["c"]["e"] == '"hello${a:b}"'
     assert config["c"]["f"] == "${a}"
     config2 = Config().from_str(config.to_str(), interpolate=True)
     assert config2.is_interpolated
@@ -1084,6 +1084,10 @@ def test_config_to_str_roundtrip():
     config = Config(cfg)
     with pytest.raises(ConfigValidationError):
         config.to_str()
+    # Roundtrip with variables: preserve variables correctly (quoted/unquoted)
+    config_str = """[a]\nb = 1\n\n[c]\nd = ${a:b}\ne = \"hello${a:b}"\nf = "${a:b}\""""
+    config = Config().from_str(config_str, interpolate=False)
+    assert config.to_str() == config_str
 
 
 def test_config_is_interpolated():

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -287,10 +287,10 @@ def test_make_from_config_schema_coerced():
         cfg: TestBaseSchema
 
     config = {"test1": 123, "test2": 1, "test3": 5}
-    result = my_registry.make_from_config({"cfg": config}, schema=TestSchema)["cfg"]
-    assert result["test1"] == "123"
-    assert result["test2"] is True
-    assert result["test3"] == 5.0
+    result, filled = my_registry.resolve({"cfg": config}, schema=TestSchema)
+    assert result["cfg"] == {"test1": "123", "test2": True, "test3": 5.0}
+    # This only affects the resolved config, not the filled config
+    assert filled["cfg"] == config
 
 
 def test_read_config():

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -293,6 +293,25 @@ def test_make_from_config_schema_coerced():
     assert filled["cfg"] == config
 
 
+def test_fill_config_extra_values():
+    class TestBaseSchema(BaseModel):
+        test1: str
+        test2: bool
+        test3: float = 1.0
+
+        class Config:
+            extra = "forbid"
+
+    class TestSchema(BaseModel):
+        cfg: TestBaseSchema
+
+    config = {"test1": "a", "test2": True, "test4": 20}
+    filled = my_registry.fill_config({"cfg": config}, schema=TestSchema, validate=False)
+    # Filled config doesn't currently remove any extra values
+    assert filled["cfg"]["test4"] == 20
+    assert filled["cfg"]["test3"] == 1.0
+
+
 def test_read_config():
     byte_string = EXAMPLE_CONFIG.encode("utf8")
     cfg = Config().from_bytes(byte_string)


### PR DESCRIPTION
This is relevant, because it impacts how a config is resolved and whether it's interpolated before.

### Summary of interpolation / resolving non-interpolated configs

```python
config_str = """
[variables]
width = 123

[model]
@architectures = "my_model"
width = ${variables:width}
"""

@registry.architectures("my_model")
def my_model(width: int, depth: int = 456):
    ...
```

Auto-fill partial config (e.g. as part of `init config` command)

```python
config = Config().from_str(config_str)
filled = registry.fill_config(config)
```

Result:

```ini
[variables]
width = 123

[model]
@architectures = "my_model"
width = 123
depth = 456
```

Problem: reference to `${variables:width}` is gone. A user's CLI script that overwrites `--variables.width` will now produce different and very misleading results. All the convenience of referencing blocks and values is gone, just because the user wanted to fill in a few defaults.

Solution: we now also support loading configs without interpolating and  resolving the variables on load. Config can be interpolated later by calling `config.interpolate()`.

```python
raw_config = Config().from_str(config_str, interpolate=False)
# filled = registry.fill_config(raw_config)
```

Next problem: resolving (create functions, check signatures) and filling (add missing defaults) is always done jointly in `registry.resolve`. In order to do this, we need to know all values so we can create the functions, so we need to interpolate the config.

```python
# internally:
interpolated = raw_config.interpolate()
filled, resolved = registry.resolve(interpolated)
```

Next problem: The filled config now looks like the config above and doesn't include variables anymore. But we still have our original non-interpolated config, so we can create a final config by putting the two configs together:

* the filled config provides the "truth", including additional properties
* the original non-interpolated config provides the overrides for the fields that were originally variables

```python
# internally:
filled = filled.merge(raw_config)
```

Result:

```ini
[variables]
width = 123

[model]
@architectures = "my_model"
width = ${variables:width}
depth = 456
```
