### PR TITLE
Support custom sort in serialization methods

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a25"
+__version__ = "8.0.0a26"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -135,7 +135,7 @@ class Config(dict):
         data: Optional[Union[Dict[str, Any], "ConfigParser", "Config"]] = None,
         *,
         is_interpolated: Optional[bool] = None,
-        section_order: List[str] = [],
+        section_order: Optional[List[str]] = None,
     ) -> None:
         """Initialize a new Config object with optional data."""
         dict.__init__(self)
@@ -157,9 +157,14 @@ class Config(dict):
             self.is_interpolated = True
         # Sort sections by index on section order, then alphabetic and account
         # for subsections
-        sort_map = {section: i for i, section in enumerate(section_order)}
+        if section_order is not None:
+            self.section_order = section_order
+        elif isinstance(data, Config):
+            self.section_order = data.section_order
+        else:
+            self.section_order = []
+        sort_map = {section: i for i, section in enumerate(self.section_order)}
         sort_key = lambda x: (sort_map.get(x[0].split(".")[0], len(sort_map)), x[0])
-        self.section_order = section_order
         self.section_sort_key = sort_key
         # Update with data
         self.update(self._sort(data))

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -159,6 +159,7 @@ class Config(dict):
         # for subsections
         sort_map = {section: i for i, section in enumerate(section_order)}
         sort_key = lambda x: (sort_map.get(x[0].split(".")[0], len(sort_map)), x[0])
+        self.section_order = section_order
         self.section_sort_key = sort_key
         # Update with data
         self.update(self._sort(data))
@@ -262,15 +263,22 @@ class Config(dict):
             config = copy.deepcopy(self)
         except Exception as e:
             raise ValueError(f"Couldn't deep-copy config: {e}") from e
-        return Config(config, is_interpolated=self.is_interpolated)
+        return Config(
+            config,
+            is_interpolated=self.is_interpolated,
+            section_order=self.section_order,
+        )
 
     def merge(self, updates: Union[Dict[str, Any], "Config"]) -> "Config":
         """Deep merge the config with updates, using current as defaults."""
         defaults = self.copy()
         updates = Config(updates).copy()
-        is_interpolated = defaults.is_interpolated and updates.is_interpolated
         merged = deep_merge_configs(updates, defaults)
-        return Config(merged, is_interpolated=is_interpolated)
+        return Config(
+            merged,
+            is_interpolated=defaults.is_interpolated and updates.is_interpolated,
+            section_order=defaults.section_order,
+        )
 
     def _sort(
         self, data: Union["Config", "ConfigParser", Dict[str, Any]]

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -344,7 +344,7 @@ class Config(dict):
         sort_key: Optional[Callable[[Tuple[str, Any]], Any]] = None,
     ) -> bytes:
         """Serialize the config to a byte string."""
-        return self.to_str(interpolate=interpolate).encode("utf8")
+        return self.to_str(interpolate=interpolate, sort_key=sort_key).encode("utf8")
 
     def from_bytes(
         self,
@@ -368,7 +368,7 @@ class Config(dict):
         """Serialize the config to a file."""
         path = Path(path)
         with path.open("w", encoding="utf8") as file_:
-            file_.write(self.to_str(interpolate=interpolate))
+            file_.write(self.to_str(interpolate=interpolate, sort_key=sort_key))
 
     def from_disk(
         self,

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -535,13 +535,14 @@ class registry(object):
         # If a Config was loaded with interpolate=False, we assume it needs to
         # be interpolated first, otherwise we take it at face value
         is_interpolated = not isinstance(config, Config) or config.is_interpolated
+        section_order = config.section_order if isinstance(config, Config) else None
         orig_config = config
         if not is_interpolated:
             config = Config(orig_config).interpolate()
         filled, _, resolved = cls._fill(
             config, schema, validate=validate, overrides=overrides
         )
-        filled = Config(filled)
+        filled = Config(filled, section_order=section_order)
         # Check that overrides didn't include invalid properties not in config
         if validate:
             cls._validate_overrides(filled, overrides)

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1146,3 +1146,16 @@ def test_config_serialize_custom_sort(section_order, expected_str, expected_keys
     assert keys == expected_keys
     keys = list(Config(cfg, section_order=section_order).keys())
     assert keys == expected_keys
+
+
+def test_config_serialize_custom_sort_merge():
+    """Test that sort order is preserved when merging and copying configs."""
+    cfg = {"x": {}, "y": {}, "z": {}}
+    section_order = ["y", "z", "x"]
+    expected = "[y]\n\n[z]\n\n[x]"
+    config = Config(cfg, section_order=section_order)
+    assert config.to_str() == expected
+    config = config.copy()
+    assert config.to_str() == expected
+    config = config.merge({"a": {}})
+    assert config.to_str() == f"{expected}\n\n[a]"

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1148,8 +1148,9 @@ def test_config_serialize_custom_sort(section_order, expected_str, expected_keys
     assert keys == expected_keys
 
 
-def test_config_serialize_custom_sort_merge():
-    """Test that sort order is preserved when merging and copying configs."""
+def test_config_custom_sort_preserve():
+    """Test that sort order is preserved when merging and copying configs,
+    or when configs are filled and resolved."""
     cfg = {"x": {}, "y": {}, "z": {}}
     section_order = ["y", "z", "x"]
     expected = "[y]\n\n[z]\n\n[x]"
@@ -1161,3 +1162,9 @@ def test_config_serialize_custom_sort_merge():
     assert config3.to_str() == f"{expected}\n\n[a]"
     config4 = Config(config)
     assert config4.to_str() == expected
+    config_str = """[a]\nb = 1\n[c]\n@cats = "catsie.v1"\nevil = true\n\n[t]\n x = 2"""
+    section_order = ["c", "a", "t"]
+    config5 = Config(section_order=section_order).from_str(config_str)
+    assert list(config5.keys()) == section_order
+    filled = my_registry.fill_config(config5)
+    assert filled.section_order == section_order

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1155,7 +1155,9 @@ def test_config_serialize_custom_sort_merge():
     expected = "[y]\n\n[z]\n\n[x]"
     config = Config(cfg, section_order=section_order)
     assert config.to_str() == expected
-    config = config.copy()
-    assert config.to_str() == expected
-    config = config.merge({"a": {}})
-    assert config.to_str() == f"{expected}\n\n[a]"
+    config2 = config.copy()
+    assert config2.to_str() == expected
+    config3 = config.merge({"a": {}})
+    assert config3.to_str() == f"{expected}\n\n[a]"
+    config4 = Config(config)
+    assert config4.to_str() == expected

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1122,3 +1122,16 @@ def test_config_is_interpolated():
     assert config.is_interpolated
     config = config.merge(Config().from_str(config_str, interpolate=False))
     assert not config.is_interpolated
+
+
+def test_config_serialize_custom_sort():
+    cfg = {"a": {"b": 1, "c": 2}, "d": {"e": 3}, "f": {"g": 4}, "h": {"i": 5}}
+    config = Config(cfg)
+    config_str = config.to_str()
+    assert config_str == "[a]\nb = 1\nc = 2\n\n[d]\ne = 3\n\n[f]\ng = 4\n\n[h]\ni = 5"
+    sort_key = lambda x: ["f", "d", "h", "a"].index(x[0])
+    config_str = config.to_str(sort_key=sort_key)
+    assert config_str == "[f]\ng = 4\n\n[d]\ne = 3\n\n[h]\ni = 5\n\n[a]\nb = 1\nc = 2"
+    sort_key = lambda x: {"d": 0, "h": 1}.get(x[0], 2)
+    config_str = config.to_str(sort_key=sort_key)
+    assert config_str == "[d]\ne = 3\n\n[h]\ni = 5\n\n[a]\nb = 1\nc = 2\n\n[f]\ng = 4"


### PR DESCRIPTION
Allows passing in a `sort_key`, a function that takes `(key, value)` tuples. Only applied to the top-level sections. The default alphabetic order isn't always the best.

## TODO

- [x] fix sorting for subsections
- [x] implement sort order setting
- [x] Does it make more sense to allow passing in a complete or incomplete list of section names instead? This is likely the most common use case: you want to specify an exact order of sections, rather than sorting them in reverse or by value or whatever.
- [x] Does it make more sense to set the sort key on `Config` initialization? This would make it easier to integrate it under the hood because it means you only have to define the sort key once and not every single time you call `to_str` in various places.