### PR TITLE
Support ${a.b} and ${a:b} in variables for values and sections

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a27"
+__version__ = "8.0.0a28"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -211,12 +211,7 @@ class Config(dict):
             try:
                 keys_values = list(values.items())
             except InterpolationMissingOptionError as e:
-                err_msg = (
-                    "If you're using variables referring to sub-sections, make "
-                    "sure they're devided by a colon (:) not a dot. For example: "
-                    "${section:subsection}"
-                )
-                raise ConfigValidationError(f"{e}\n\n{err_msg}", []) from None
+                raise ConfigValidationError(f"{e}", []) from None
             for key, value in keys_values:
                 config_v = config.get(section, key)
                 if VARIABLE_RE.search(config_v):


### PR DESCRIPTION
Configs support variables of two different types: references to other values via `${a:b}` (like Python's regular configparser) and references to other sections via `${a.b}` (requires a custom implementation where we add a placeholder and then substitute the block once the config is interpreted).

### Problems 

* It's very easy to make mistakes here and accidentally write `${a.b}` instead of `${a:b}`.
* The value vs. section distinction makes sense on the implementation level, but not actually from the usage perspective: values in a Thinc config can be set explicitly or using a section (`batch_size = 128` vs. `[training.batch_size]`). There's virtually no difference in terms of the result it produces, and a user can easily swap in a section and vice versa. So having to change a variable reference from `:` to `.`, just because it's now a section seems pretty unintuitive and against the config philosophy.

### Solution

* Treat both `${a.b}` and `${a:b}` the same and default to the `.` syntax internally. Don't expect the value to be the string following `:` – instead, expect it to the the last item following the last `.`.
* When trying to fetch a reference, check if it's a regular value first (default configparser interpolation) and use a fallback value if no value is found. If the fallback is returned, try again as a section. (If no section exists either, the user will see an error regardless.)