### PR TITLE
Support remove extra fields from config when filling

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a29"
+__version__ = "8.0.0a30"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -744,7 +744,7 @@ class registry(object):
             result = schema.construct(**validation)
             # If our schema doesn't allow extra values, we need to filter them
             # manually because .construct doesn't parse anything
-            if schema.Config.extra == Extra.forbid:
+            if schema.Config.extra in (Extra.forbid, Extra.ignore):
                 fields = schema.__fields__.keys()
                 exclude = [k for k in result.__fields_set__ if k not in fields]
         exclude_validation = set([ARGS_FIELD_ALIAS, *RESERVED_FIELDS.keys()])

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -443,6 +443,9 @@ def try_dump_json(value: Any, data: Union[Dict[str, dict], Config, str] = "") ->
     # to preserve ${x:y} vs. "${x:y}"
     if isinstance(value, str) and VARIABLE_RE.search(value):
         return value
+    if isinstance(value, str) and value.replace(".", "", 1).isdigit():
+        # Work around values that are strings but numbers
+        value = f'"{value}"'
     try:
         return srsly.json_dumps(value)
     except Exception as e:

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1226,6 +1226,12 @@ def test_config_fill_extra_fields():
         my_registry.fill_config(config, schema=TestSchema)
     filled = my_registry.fill_config(config, schema=TestSchema, validate=False)["cfg"]
     assert filled == {"a": "1", "b": 2}
+    config2 = config.interpolate()
+    filled = my_registry.fill_config(config2, schema=TestSchema, validate=False)["cfg"]
+    assert filled == {"a": "1", "b": 2}
+    config3 = Config({"cfg": {"a": "1", "b": 2, "c": True}}, is_interpolated=False)
+    filled = my_registry.fill_config(config3, schema=TestSchema, validate=False)["cfg"]
+    assert filled == {"a": "1", "b": 2}
 
     class TestSchemaContent2(BaseModel):
         a: str

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -294,25 +294,6 @@ def test_make_from_config_schema_coerced():
     assert filled["cfg"] == config
 
 
-def test_fill_config_extra_values():
-    class TestBaseSchema(BaseModel):
-        test1: str
-        test2: bool
-        test3: float = 1.0
-
-        class Config:
-            extra = "forbid"
-
-    class TestSchema(BaseModel):
-        cfg: TestBaseSchema
-
-    config = {"test1": "a", "test2": True, "test4": 20}
-    filled = my_registry.fill_config({"cfg": config}, schema=TestSchema, validate=False)
-    # Filled config doesn't currently remove any extra values
-    assert filled["cfg"]["test4"] == 20
-    assert filled["cfg"]["test3"] == 1.0
-
-
 def test_read_config():
     byte_string = EXAMPLE_CONFIG.encode("utf8")
     cfg = Config().from_bytes(byte_string)
@@ -1225,3 +1206,36 @@ def test_config_pickle():
     config_new = pickle.loads(data)
     assert config_new == {"foo": "bar"}
     assert config_new.section_order == ["foo", "bar", "baz"]
+
+
+def test_config_fill_extra_fields():
+    """Test that filling a config from a schema removes extra fields."""
+
+    class TestSchemaContent(BaseModel):
+        a: str
+        b: int
+
+        class Config:
+            extra = "forbid"
+
+    class TestSchema(BaseModel):
+        cfg: TestSchemaContent
+
+    config = Config({"cfg": {"a": "1", "b": 2, "c": True}})
+    with pytest.raises(ConfigValidationError):
+        my_registry.fill_config(config, schema=TestSchema)
+    filled = my_registry.fill_config(config, schema=TestSchema, validate=False)["cfg"]
+    assert filled == {"a": "1", "b": 2}
+
+    class TestSchemaContent2(BaseModel):
+        a: str
+        b: int
+
+        class Config:
+            extra = "allow"
+
+    class TestSchema2(BaseModel):
+        cfg: TestSchemaContent2
+
+    filled = my_registry.fill_config(config, schema=TestSchema2, validate=False)["cfg"]
+    assert filled == {"a": "1", "b": 2, "c": True}


### PR DESCRIPTION
When filling and resolving a config, there are currently two options:

* with validation: will raise an error if values are wrong or missing
* without validation: will fill in all gaps and try to fix problems but not raise errors

However, we didn't handle extra values if validation was disabled. In that case, we're only constructing the config from the schema (in the most efficient way possible, using `pydantic`). So we need to filter all fields that are not in the original schema manually, if the schema says it doesn't allow extra fields.

To make this work consistently with both interpolated and non-interpolated configs, we need a little hack: to restore the variabels, we're merging the original non-interpolated config into the final filled config. This works fine, unless the original config includes extra values that have been removed during filling. So for that particular merge operation, we need to remove all extra values (which should only happen in this context – a filled config that removed extra settings).