### PR TITLE
Listener flag

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a30"
+__version__ = "8.0.0a31"
 __release__ = True

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -86,6 +86,9 @@ def init(
             layer.initialize(X=curr_input, Y=Y)
         else:
             layer.initialize(X=curr_input)
+        # a listener layer can't be run directly with layer.predict
+        if layer.attrs.get("is_listener", None):
+            curr_input = None
         if curr_input is not None:
             curr_input = layer.predict(curr_input)
 

--- a/thinc/layers/siamese.py
+++ b/thinc/layers/siamese.py
@@ -48,7 +48,10 @@ def init(
     if X is not None:
         model.layers[0].set_dim("nI", get_width(X[1]))
         model.layers[0].initialize(X=X[0])
-        X = (model.layers[0].predict(X[0]), model.layers[0].predict(X[1]))
+        if not model.layers[0].attrs.get("is_listener", None):
+            X = (model.layers[0].predict(X[0]), model.layers[0].predict(X[1]))
+        else:
+            X = None
     model.layers[1].initialize(X=X, Y=Y)
     model.set_dim("nI", model.layers[0].get_dim("nI"))
     model.set_dim("nO", model.layers[1].get_dim("nO"))

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -88,6 +88,8 @@ class Model(Generic[InT, OutT]):
         self._params = ParamServer()
         self._dims = dict(dims)
         self._attrs = dict(attrs)
+        if "is_listener" not in self._attrs:
+            self._attrs["is_listener"] = False
         self._refs = dict(refs)
         self._layers = list(layers)
         self._shims = list(shims)


### PR DESCRIPTION
Add `is_listener` flag in `model.attrs`, default `False`. If this flag is `True`, prevent calling `model.predict` directly for initialization/shape inference, as that won't work (the model is not independent)