### PR TITLE
fix with_cpu shape inference

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a30"
+__version__ = "8.0.0a31"
 __release__ = True

--- a/thinc/layers/with_cpu.py
+++ b/thinc/layers/with_cpu.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Any
+from typing import Tuple, Callable, Any, Dict, Optional
 
 import numpy
 from thinc.backends import Ops
@@ -10,7 +10,16 @@ from ..config import registry
 @registry.layers("with_cpu.v1")
 def with_cpu(layer: Model, ops: Ops) -> Model:
     layer.to_cpu()
-    return Model(f"with_cpu", forward, layers=[layer], ops=ops, init=init)
+    dims: Dict[str, Optional[int]] = {"nO": None}
+    # set input dimension only if included layer has one - should be "False" otherwise
+    if layer.has_dim("nI") is True:
+        dims["nI"] = layer.get_dim("nI")
+    if layer.has_dim("nI") is None:
+        dims["nI"] = None
+    # set output dimension according to included layer
+    if layer.has_dim("nO") is True:
+        dims["nO"] = layer.get_dim("nO")
+    return Model(f"with_cpu({layer.name})", forward, layers=[layer], ops=ops, init=init, dims=dims)
 
 
 def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -42,7 +42,9 @@ class PyTorchShim(Shim):
     def begin_update(self, inputs: ArgsKwargs):
         """Pass the inputs through to the underlying PyTorch model, keeping
         track of which items in the input are tensors requiring gradients.
-        If the model returns a single value, it is converted into a one-element tuple. Return the outputs and a callback to backpropagate.  """
+        If the model returns a single value, it is converted into a one-element tuple.
+        Return the outputs and a callback to backpropagate.
+        """
         self._model.train()
         output = self._model(*inputs.args, **inputs.kwargs)
 


### PR DESCRIPTION
I couldn't get the `textcat` shape inference to work properly in spaCy. Ultimately tracked it down to `with_cpu` that was not properly hooked up with the right dimensions. This should fix it.

Also changed the name to include the encapsulated layer, as that simplifies debugging.

Bump to 8.0.0a31