### PR TITLE
nested names

### DIFF
--- a/thinc/layers/residual.py
+++ b/thinc/layers/residual.py
@@ -13,7 +13,7 @@ InT = TypeVar("InT", List[Floats1d], List[Floats2d], List[Floats3d], List[Floats
 @registry.layers("residual.v1")
 def residual(layer: Model[InT, InT]) -> Model[InT, InT]:
     return Model(
-        "residual",
+        f"residual({layer.name})",
         forward,
         init=init,
         layers=[layer],

--- a/thinc/layers/uniqued.py
+++ b/thinc/layers/uniqued.py
@@ -18,7 +18,7 @@ def uniqued(layer: Model, *, column: int = 0) -> Model[InT, OutT]:
     local to each minibatch.
     """
     return Model(
-        f"uniqued-{layer.name}",
+        f"uniqued({layer.name})",
         forward,
         init=init,
         layers=[layer],

--- a/thinc/layers/with_array.py
+++ b/thinc/layers/with_array.py
@@ -17,7 +17,7 @@ def with_array(layer: Model[ValT, ValT], pad: int = 0) -> Model[SeqT, SeqT]:
     If the input is a 2d array, it is passed through unchanged.
     """
     return Model(
-        f"with_array-{layer.name}",
+        f"with_array({layer.name})",
         forward,
         init=init,
         layers=[layer],

--- a/thinc/layers/with_debug.py
+++ b/thinc/layers/with_debug.py
@@ -35,4 +35,4 @@ def with_debug(
         on_init(model, X, Y)
         return layer.initialize(X, Y)
 
-    return Model(f"debug:{name}", forward, init=init, layers=[layer])
+    return Model(f"debug({name})", forward, init=init, layers=[layer])

--- a/thinc/layers/with_flatten.py
+++ b/thinc/layers/with_flatten.py
@@ -12,7 +12,7 @@ OutT = List2d
 
 @registry.layers("with_flatten.v1")
 def with_flatten(layer: Model) -> Model[InT, OutT]:
-    return Model(f"with_flatten-{layer.name}", forward, layers=[layer], init=init)
+    return Model(f"with_flatten({layer.name})", forward, layers=[layer], init=init)
 
 
 def forward(

--- a/thinc/layers/with_getitem.py
+++ b/thinc/layers/with_getitem.py
@@ -14,7 +14,7 @@ def with_getitem(idx: int, layer: Model) -> Model[InT, OutT]:
     from a tuple.
     """
     return Model(
-        f"with_getitem-{layer.name}",
+        f"with_getitem({layer.name})",
         forward,
         init=init,
         layers=[layer],

--- a/thinc/layers/with_list.py
+++ b/thinc/layers/with_list.py
@@ -10,7 +10,7 @@ SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d])
 
 @registry.layers("with_list.v1")
 def with_list(layer: Model[List2d, List2d]) -> Model[SeqT, SeqT]:
-    return Model(f"with_list-{layer.name}", forward, init=init, layers=[layer])
+    return Model(f"with_list({layer.name})", forward, init=init, layers=[layer])
 
 
 def forward(

--- a/thinc/layers/with_padded.py
+++ b/thinc/layers/with_padded.py
@@ -13,7 +13,7 @@ SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d, Floats3d, PaddedData]
 
 @registry.layers("with_padded.v1")
 def with_padded(layer: Model[Padded, Padded]) -> Model[SeqT, SeqT]:
-    return Model(f"with_padded-{layer.name}", forward, init=init, layers=[layer])
+    return Model(f"with_padded({layer.name})", forward, init=init, layers=[layer])
 
 
 def forward(

--- a/thinc/layers/with_ragged.py
+++ b/thinc/layers/with_ragged.py
@@ -11,7 +11,7 @@ SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d, RaggedData])
 
 @registry.layers("with_ragged.v1")
 def with_ragged(layer: Model[Ragged, Ragged]) -> Model[SeqT, SeqT]:
-    return Model(f"with_ragged-{layer.name}", forward, init=init, layers=[layer])
+    return Model(f"with_ragged({layer.name})", forward, init=init, layers=[layer])
 
 
 def forward(

--- a/thinc/layers/with_reshape.py
+++ b/thinc/layers/with_reshape.py
@@ -12,7 +12,7 @@ InT = Array3d
 def with_reshape(layer: Model[Array2d, Array2d]) -> Model[InT, InT]:
     """Reshape data on the way into and out from a layer."""
     return Model(
-        f"with_reshape-{layer.name}",
+        f"with_reshape({layer.name})",
         forward,
         init=init,
         layers=[layer],

--- a/thinc/tests/layers/test_lstm.py
+++ b/thinc/tests/layers/test_lstm.py
@@ -152,4 +152,4 @@ def test_lstm_init():
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")
 def test_pytorch_lstm_init():
     model = with_padded(PyTorchLSTM(2, 2, depth=0)).initialize()
-    assert model.name.endswith("noop")
+    assert model.name == "with_padded(noop)"


### PR DESCRIPTION
Maybe it's just me, but I kind of like analyzing a layer/model's architecture using its name. The "syntax" using `-` gets unusable with many nested layers though, so proposing `()` here instead.