### PR TITLE
check for conflicting promise before merging

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a32"
+__version__ = "8.0.0a33"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -478,14 +478,23 @@ def deep_merge_configs(
             node = config.setdefault(key, {})
             if not isinstance(node, dict):
                 continue
-            promises = [key for key in value if key.startswith("@")]
-            promise = promises[0] if promises else None
+            value_promises = [k for k in value if k.startswith("@")]
+            value_promise = value_promises[0] if value_promises else None
+            node_promises = [k for k in node if k.startswith("@")] if node else []
+            node_promise = node_promises[0] if node_promises else None
             # We only update the block from defaults if it refers to the same
             # registered function
             if (
-                promise
-                and any(k.startswith("@") for k in node)
-                and (promise in node and node[promise] != value[promise])
+                value_promise
+                and node_promise
+                and (
+                    value_promise in node
+                    and node[value_promise] != value[value_promise]
+                )
+            ):
+                continue
+            if node_promise and (
+                node_promise not in value or node[node_promise] != value[node_promise]
             ):
                 continue
             defaults = deep_merge_configs(node, value, remove_extra=remove_extra)

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1099,6 +1099,21 @@ def test_config_deep_merge():
     assert merged["a"] == "hello"
     assert merged["b"] == {"@test": "y", "foo": 1, "bar": 2}
     assert merged["c"] == 100
+    # Test that switching to a different factory prevents the default from being added
+    config = {"a": "hello", "b": {"@foo": 1}, "c": 100}
+    defaults = {"a": "world", "b": {"@bar": "y"}}
+    merged = Config(defaults).merge(config)
+    assert len(merged) == 3
+    assert merged["a"] == "hello"
+    assert merged["b"] == {"@foo": 1}
+    assert merged["c"] == 100
+    config = {"a": "hello", "b": {"@foo": 1}, "c": 100}
+    defaults = {"a": "world", "b": "y"}
+    merged = Config(defaults).merge(config)
+    assert len(merged) == 3
+    assert merged["a"] == "hello"
+    assert merged["b"] == {"@foo": 1}
+    assert merged["c"] == 100
 
 
 def test_config_deep_merge_variables():


### PR DESCRIPTION
There was an issue when merging a config with a default. If the original config has a promise (`@foo`) but the default has something else that doesn't match, the default values would still get added in the merged version. This was because the `continue` in the code started from the viewpoint of the default config. So I think we need both viewpoints - hence the second condition for another `continue`.

Hopefully the new unit tests make it clear. We need this behaviour to be able to implement different version of `training.corpus` in spaCy.