### PR TITLE
allocator argument 

### DIFF
--- a/examples/02_transformers_tagger_bert.ipynb
+++ b/examples/02_transformers_tagger_bert.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's use Thinc's `prefer_gpu` helper to make sure we're performing operations **on GPU if available**. The function should be called right after importing Thinc, and it returns a boolean indicating whether the GPU has been activated. If we're on GPU, we can also call `use_pytorch_for_gpu_memory` to route `cupy`'s memory allocation via PyTorch, so both can play together nicely."
+    "First, let's use Thinc's `prefer_gpu` helper to make sure we're performing operations **on GPU if available**. The function should be called right after importing Thinc, and it returns a boolean indicating whether the GPU has been activated. If we're on GPU, we route `cupy`'s memory allocation via PyTorch, so both can play together nicely."
    ]
   },
   {
@@ -31,12 +31,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from thinc.api import prefer_gpu, use_pytorch_for_gpu_memory\n",
+    "from thinc.api import prefer_gpu\n",
     "\n",
-    "is_gpu = prefer_gpu()\n",
-    "print(\"GPU:\", is_gpu)\n",
-    "if is_gpu:\n",
-    "    use_pytorch_for_gpu_memory()"
+    "is_gpu = prefer_gpu(allocator=\"pytorch\")\n",
+    "print(\"GPU:\", is_gpu)"
    ]
   },
   {

--- a/examples/04_configure_gpu_memory.ipynb
+++ b/examples/04_configure_gpu_memory.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Thinc's internal models use cupy for GPU operations, and cupy offers a nice solution for this problem. You can provide cupy with a custom memory allocation function, which allows us to route cupy's memory requests via another library. This avoids the memory problem when you use PyTorch and cupy together, or when you use cupy and Tensorflow together. We don't yet have a similar solution for using PyTorch and Tensorflow together, however.\n",
     "\n",
-    "To start with, we call the `require_gpu()` function, which tells Thinc and PyTorch to allocate on GPU."
+    "To start with, we call the `require_gpu()` function, which tells Thinc and PyTorch to allocate on GPU. We specifically provide \"pytorch\" as GPU mem allocator, so that when `cupy` tries to request GPU memory, it will do so by asking PyTorch, rather than asking the GPU directly."
    ]
   },
   {
@@ -30,25 +30,7 @@
    "source": [
     "from thinc.api import require_gpu\n",
     "\n",
-    "require_gpu()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We then call `use_pytorch_for_gpu_memory()` to set up the allocation strategy. Now when `cupy` tries to request GPU memory, it will do so by asking PyTorch, rather than asking the GPU directly."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from thinc.api import use_pytorch_for_gpu_memory\n",
-    "\n",
-    "use_pytorch_for_gpu_memory()"
+    "require_gpu(allocator=\"pytorch\")"
    ]
   },
   {

--- a/examples/transformers_tagger.py
+++ b/examples/transformers_tagger.py
@@ -8,7 +8,7 @@ from transformers import AutoTokenizer, AutoModel
 import thinc
 from thinc.api import PyTorchWrapper, Softmax, chain, with_array, Model, Config
 from thinc.api import torch2xp, xp2torch, SequenceCategoricalCrossentropy
-from thinc.api import prefer_gpu, use_pytorch_for_gpu_memory
+from thinc.api import prefer_gpu
 from thinc.types import Floats2d, ArgsKwargs
 import ml_datasets
 import tqdm
@@ -38,9 +38,8 @@ n_epoch = 10
 
 
 def main(path: Optional[Path] = None, out_dir: Optional[Path] = None):
-    if prefer_gpu():
+    if prefer_gpu(allocator="pytorch"):
         print("Using gpu!")
-        use_pytorch_for_gpu_memory()
     # You can edit the CONFIG string within the file, or copy it out to
     # a separate file and pass in the path.
     if path is None:

--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a33"
+__version__ = "8.0.0a34"
 __release__ = True

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -17,7 +17,6 @@ from .util import to_categorical, get_width, get_array_module, to_numpy
 from .util import torch2xp, xp2torch, tensorflow2xp, xp2tensorflow, mxnet2xp, xp2mxnet
 from .backends import get_ops, set_current_ops, get_current_ops, use_ops
 from .backends import Ops, CupyOps, NumpyOps, JaxOps, has_cupy, has_jax
-from .backends import use_pytorch_for_gpu_memory, use_tensorflow_for_gpu_memory
 
 from .layers import Dropout, Embed, expand_window, HashEmbed, LayerNorm, Linear
 from .layers import Maxout, Mish, MultiSoftmax, Relu, softmax_activation, Softmax, LSTM

--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -18,42 +18,6 @@ context_ops: ContextVar[NumpyOps] = ContextVar("context_ops", default=NumpyOps()
 context_Ops: ContextVar[Type[NumpyOps]] = ContextVar("context_Ops", default=NumpyOps)
 
 
-def use_pytorch_for_gpu_memory() -> None:  # pragma: no cover
-    """Route GPU memory allocation via PyTorch.
-
-    This is recommended for using PyTorch and cupy together, as otherwise
-    OOM errors can occur when there's available memory sitting in the other
-    library's pool.
-
-    We'd like to support routing Tensorflow memory allocation via PyTorch as well
-    (or vice versa), but do not currently have an implementation for it.
-    """
-    import cupy.cuda
-
-    assert_pytorch_installed()
-    cupy.cuda.set_allocator(
-        cupy.cuda.MemoryPool(allocator=cupy_pytorch_allocator).malloc
-    )
-
-
-def use_tensorflow_for_gpu_memory() -> None:  # pragma: no cover
-    """Route GPU memory allocation via TensorFlow.
-
-    This is recommended for using TensorFlow and cupy together, as otherwise
-    OOM errors can occur when there's available memory sitting in the other
-    library's pool.
-
-    We'd like to support routing PyTorch memory allocation via Tensorflow as
-    well (or vice versa), but do not currently have an implementation for it.
-    """
-    import cupy.cuda
-
-    assert_tensorflow_installed()
-    cupy.cuda.set_allocator(
-        cupy.cuda.MemoryPool(allocator=cupy_tensorflow_allocator).malloc
-    )
-
-
 def get_ops(name: OpsNames, **kwargs) -> Ops:
     """Get a backend object."""
     ops = {"numpy": NumpyOps, "cupy": CupyOps, "jax": JaxOps}

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -375,7 +375,7 @@ def test_unique_id_multithreading():
 
 
 def test_model_gpu():
-    prefer_gpu()
+    prefer_gpu(allocator="")
     n_hidden = 32
     dropout = 0.2
     (train_X, train_Y), (dev_X, dev_Y) = ml_datasets.mnist()

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -174,7 +174,7 @@ def set_active_gpu(gpu_id: int) -> "cupy.cuda.Device":  # pragma: no cover
     return device
 
 
-def prefer_gpu(gpu_id: int = 0, allocator: str = "") -> bool:  # pragma: no cover
+def prefer_gpu(gpu_id: int = 0, *, allocator: str = "") -> bool:  # pragma: no cover
     """Use GPU if it's available. Returns True if so, False otherwise.
     Set 'allocator' to 'pytorch' or 'tensorflow' to have cupy
     allocate memory via those respective libraries (only if GPU is available)."""
@@ -187,7 +187,7 @@ def prefer_gpu(gpu_id: int = 0, allocator: str = "") -> bool:  # pragma: no cove
         return True
 
 
-def require_gpu(gpu_id: int = 0, allocator: str = "") -> bool:  # pragma: no cover
+def require_gpu(gpu_id: int = 0, *, allocator: str = "") -> bool:  # pragma: no cover
     """Use GPU. Returns True if available, raise a ValueError otherwise.
 
     If allocator is "pytorch" or "tensorflow", route GPU memory allocation via


### PR DESCRIPTION
Incorporate `allocator` argument in `prefer_gpu` and `require_gpu` that can be "tensorflow" or "pytorch".

Version bump to 8.0.0a34

TODO after merging: Thinc docs