### PR TITLE
Refactor ConfigValidationError and make it more extensible

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a35"
+__version__ = "8.0.0a36"
 __release__ = True

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1291,4 +1291,5 @@ def test_config_validation_error_custom():
     assert e2.error_types == e1.error_types
     assert e2.title == title
     assert e2.desc == desc
+    assert e2.show_config is False
     assert e1.text != e2.text


### PR DESCRIPTION
This makes it easier to test for specific config validation errors (because we can easily inspect the errors in a structured way) and re-raise modified versions of the error (e.g. in spaCy).