### PR TITLE
Refactor filling and resolving config

### DIFF
--- a/examples/00_intro_to_thinc.ipynb
+++ b/examples/00_intro_to_thinc.ipynb
@@ -247,7 +247,7 @@
    "source": [
     "When you open the config with `Config.from_str`, Thinc will parse it as a dict and fill in the references to values defined in other sections. For example, `${hyper_params:learn_rate}` is substituted with `0.001`. \n",
     "\n",
-    "Keys starting with `@` are references to **registered functions**. For example, `@optimizers = \"Adam.v1\"` refers to the function registered under the name `\"Adam.v1\"`, a function creating an Adam optimizer. The function takes one argument, the `learn_rate`. Calling `registry.make_from_config` will resolve the config and create the functions it defines."
+    "Keys starting with `@` are references to **registered functions**. For example, `@optimizers = \"Adam.v1\"` refers to the function registered under the name `\"Adam.v1\"`, a function creating an Adam optimizer. The function takes one argument, the `learn_rate`. Calling `registry.resolve` will resolve the config and create the functions it defines."
    ]
   },
   {
@@ -256,7 +256,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_config1 = registry.make_from_config(config1)\n",
+    "loaded_config1, _ = registry.resolve(config1)\n",
     "loaded_config1"
    ]
   },
@@ -292,7 +292,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Calling `registry.make_from_config` will now construct the objects bottom-up: first, it will create the schedule with the given arguments. Next, it will create the optimizer and pass in the schedule as the `learn_rate` argument."
+    "Calling `registry.resolve` will now construct the objects bottom-up: first, it will create the schedule with the given arguments. Next, it will create the optimizer and pass in the schedule as the `learn_rate` argument."
    ]
   },
   {
@@ -301,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_config2 = registry.make_from_config(config2)\n",
+    "loaded_config2, _ = registry.resolve(config2)\n",
     "loaded_config2"
    ]
   },
@@ -368,7 +368,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_config = registry.make_from_config(config)\n",
+    "loaded_config, filled_config = registry.resolve(config)\n",
     "loaded_config"
    ]
   },
@@ -376,7 +376,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you call `registry.make_from_config`, Thinc will first create the three layers using the specified arguments populated by the hyperparameters. It will then pass the return values (the layer objects) to `chain`. It will also create an optimizer. All other values, like the training config, will be passed through as a regular dict. Your training code can now look like this:"
+    "When you call `registry.resolve`, Thinc will first create the three layers using the specified arguments populated by the hyperparameters. It will then pass the return values (the layer objects) to `chain`. It will also create an optimizer. All other values, like the training config, will be passed through as a regular dict. Your training code can now look like this:"
    ]
   },
   {
@@ -469,7 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_config = registry.make_from_config(config)\n",
+    "loaded_config, _ = registry.resolve(config)\n",
     "loaded_config"
    ]
   },
@@ -516,7 +516,7 @@
     "\"\"\"\n",
     "\n",
     "config = Config().from_str(CONFIG3)\n",
-    "loaded_config = registry.make_from_config(config)\n",
+    "loaded_config, _ = registry.resolve(config)\n",
     "loaded_config"
    ]
   },

--- a/examples/00_intro_to_thinc.ipynb
+++ b/examples/00_intro_to_thinc.ipynb
@@ -256,7 +256,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_config1, _ = registry.resolve(config1)\n",
+    "loaded_config1 = registry.resolve(config1)\n",
     "loaded_config1"
    ]
   },
@@ -301,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_config2, _ = registry.resolve(config2)\n",
+    "loaded_config2 = registry.resolve(config2)\n",
     "loaded_config2"
    ]
   },
@@ -368,7 +368,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_config, filled_config = registry.resolve(config)\n",
+    "loaded_config = registry.resolve(config)\n",
     "loaded_config"
    ]
   },
@@ -469,7 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_config, _ = registry.resolve(config)\n",
+    "loaded_config = registry.resolve(config)\n",
     "loaded_config"
    ]
   },
@@ -516,7 +516,7 @@
     "\"\"\"\n",
     "\n",
     "config = Config().from_str(CONFIG3)\n",
-    "loaded_config, _ = registry.resolve(config)\n",
+    "loaded_config = registry.resolve(config)\n",
     "loaded_config"
    ]
   },

--- a/examples/02_transformers_tagger_bert.ipynb
+++ b/examples/02_transformers_tagger_bert.ipynb
@@ -294,7 +294,7 @@
    "source": [
     "from thinc.api import Config, registry\n",
     "\n",
-    "C, _ = registry.resolve(Config().from_str(CONFIG))\n",
+    "C = registry.resolve(Config().from_str(CONFIG))\n",
     "C"
    ]
   },

--- a/examples/02_transformers_tagger_bert.ipynb
+++ b/examples/02_transformers_tagger_bert.ipynb
@@ -294,7 +294,7 @@
    "source": [
     "from thinc.api import Config, registry\n",
     "\n",
-    "C = registry.make_from_config(Config().from_str(CONFIG))\n",
+    "C, _ = registry.resolve(Config().from_str(CONFIG))\n",
     "C"
    ]
   },

--- a/examples/03_pos_tagger_basic_cnn.ipynb
+++ b/examples/03_pos_tagger_basic_cnn.ipynb
@@ -251,7 +251,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "C, _ = registry.resolve(config)\n",
+    "C = registry.resolve(config)\n",
     "C"
    ]
   },
@@ -351,7 +351,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "C, _ = registry.resolve(Config().from_str(CONFIG))\n",
+    "C = registry.resolve(Config().from_str(CONFIG))\n",
     "C"
    ]
   },

--- a/examples/03_pos_tagger_basic_cnn.ipynb
+++ b/examples/03_pos_tagger_basic_cnn.ipynb
@@ -242,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`registry.make_from_config` then creates the objects and calls the functions **bottom-up**."
+    "`registry.resolve` then creates the objects and calls the functions **bottom-up**."
    ]
   },
   {
@@ -251,7 +251,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "C = registry.make_from_config(config)\n",
+    "C, _ = registry.resolve(config)\n",
     "C"
    ]
   },
@@ -351,7 +351,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "C = registry.make_from_config(Config().from_str(CONFIG))\n",
+    "C, _ = registry.resolve(Config().from_str(CONFIG))\n",
     "C"
    ]
   },

--- a/examples/03_textcat_basic_neural_bow.ipynb
+++ b/examples/03_textcat_basic_neural_bow.ipynb
@@ -159,7 +159,7 @@
    "source": [
     "## Training setup\n",
     "\n",
-    "When the config is loaded, it's first parsed as a dictionary and all references to values from other sections, e.g. `${hyper_params:width}` are replaced. The result is a nested dictionary describing the objects defined in the config. `registry.make_from_config` then creates the objects and calls the functions **bottom-up**."
+    "When the config is loaded, it's first parsed as a dictionary and all references to values from other sections, e.g. `${hyper_params:width}` are replaced. The result is a nested dictionary describing the objects defined in the config. `registry.resolve` then creates the objects and calls the functions **bottom-up**."
    ]
   },
   {
@@ -170,7 +170,7 @@
    "source": [
     "from thinc.api import registry, Config\n",
     "\n",
-    "C = registry.make_from_config(Config().from_str(CONFIG))\n",
+    "C, _ = registry.resolve(Config().from_str(CONFIG))\n",
     "C"
    ]
   },

--- a/examples/03_textcat_basic_neural_bow.ipynb
+++ b/examples/03_textcat_basic_neural_bow.ipynb
@@ -170,7 +170,7 @@
    "source": [
     "from thinc.api import registry, Config\n",
     "\n",
-    "C, _ = registry.resolve(Config().from_str(CONFIG))\n",
+    "C = registry.resolve(Config().from_str(CONFIG))\n",
     "C"
    ]
   },

--- a/examples/04_parallel_training_ray.ipynb
+++ b/examples/04_parallel_training_ray.ipynb
@@ -253,7 +253,7 @@
    "source": [
     "### Setting up the model\n",
     "\n",
-    "Using the `CONFIG` defined above, we can load the settings and set up the model and optimizer. Thinc's `registry.resolve` will parse the config, resolve all references to registered functions and return a dict of the resolved objects and a filled config with all defaults."
+    "Using the `CONFIG` defined above, we can load the settings and set up the model and optimizer. Thinc's `registry.resolve` will parse the config, resolve all references to registered functions and return a dict of the resolved objects."
    ]
   },
   {
@@ -263,7 +263,7 @@
    "outputs": [],
    "source": [
     "from thinc.api import registry, Config\n",
-    "C, _ = registry.resolve(Config().from_str(CONFIG))\n",
+    "C = registry.resolve(Config().from_str(CONFIG))\n",
     "C"
    ]
   },

--- a/examples/04_parallel_training_ray.ipynb
+++ b/examples/04_parallel_training_ray.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "# Parallel training with Thinc and Ray\n",
     "\n",
@@ -33,9 +31,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "Let's start with a simple model and [config file](https://thinc.ai/docs/usage-config). You can edit the `CONFIG` string within the file, or copy it out to a separate file and use `Config.from_disk` to load it from a path. The `[ray]` section contains the settings to use for Ray. (We're using a config for convenience, but you don't have to – you can also just hard-code the values.)"
    ]
@@ -83,9 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "Just like in the original Ray tutorial, we're using the MNIST data (via our [`ml-datasets`](https://github.com/explosion/ml-datasets) package) and are setting up two helper functions: \n",
     "\n",
@@ -122,9 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "---\n",
     "\n",
@@ -171,9 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "### Defining the Parameter Server\n",
     "\n",
@@ -220,9 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "### Defining the Worker\n",
     "\n",
@@ -261,13 +249,11 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "### Setting up the model\n",
     "\n",
-    "Using the `CONFIG` defined above, we can load the settings and set up the model and optimizer. Thinc's `registry.make_from_config` will parse the config, resolve all references to registered functions and return a dict."
+    "Using the `CONFIG` defined above, we can load the settings and set up the model and optimizer. Thinc's `registry.resolve` will parse the config, resolve all references to registered functions and return a dict of the resolved objects and a filled config with all defaults."
    ]
   },
   {
@@ -277,15 +263,13 @@
    "outputs": [],
    "source": [
     "from thinc.api import registry, Config\n",
-    "C = registry.make_from_config(Config().from_str(CONFIG))\n",
+    "C, _ = registry.resolve(Config().from_str(CONFIG))\n",
     "C"
    ]
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "We didn't specify all the dimensions in the model, so we need to pass in a batch of data to finish initialization. This lets Thinc infer the missing shapes."
    ]
@@ -305,9 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "---\n",
     "\n",
@@ -346,9 +328,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "On each iteration, we now compute the gradients for each worker. After all gradients are available, `ParameterServer.apply_gradients` is called to calculate the update. The `frequency` setting in the `evaluation` config specifies how often to evaluate – for instance, a frequency of `10` means we're only evaluating every 10th epoch. "
    ]
@@ -373,9 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "### Asynchronous Parameter Server Training\n",
     "\n",
@@ -429,9 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "---\n",
     "\n",

--- a/examples/benchmarks/lstm_tagger.py
+++ b/examples/benchmarks/lstm_tagger.py
@@ -113,7 +113,7 @@ def main(pytorch: bool = False, gpu_id: int = -1):
             print(f"Skipping {name}")
             continue
         set_backend(name, gpu_id)
-        C = registry.make_from_config(Config().from_str(CONFIG))
+        C, _ = registry.resolve(Config().from_str(CONFIG))
         model = C["model"]
         X, Y = get_dummy_data(**C["data"])
         print("Copy to device")

--- a/examples/benchmarks/lstm_tagger.py
+++ b/examples/benchmarks/lstm_tagger.py
@@ -113,7 +113,7 @@ def main(pytorch: bool = False, gpu_id: int = -1):
             print(f"Skipping {name}")
             continue
         set_backend(name, gpu_id)
-        C, _ = registry.resolve(Config().from_str(CONFIG))
+        C = registry.resolve(Config().from_str(CONFIG))
         model = C["model"]
         X, Y = get_dummy_data(**C["data"])
         print("Copy to device")

--- a/examples/transformers_tagger.py
+++ b/examples/transformers_tagger.py
@@ -51,7 +51,7 @@ def main(path: Optional[Path] = None, out_dir: Optional[Path] = None):
     # In the optimizer block we write @optimizers = "Adam.v1". This tells Thinc
     # to use registry.optimizers to fetch the "Adam.v1" function. You can
     # register your own functions as well and build up trees of objects.
-    C, _ = thinc.registry.resolve(config)
+    C = thinc.registry.resolve(config)
     words_per_subbatch = C["training"]["words_per_subbatch"]
     n_epoch = C["training"]["n_epoch"]
     batch_size = C["training"]["batch_size"]

--- a/examples/transformers_tagger.py
+++ b/examples/transformers_tagger.py
@@ -47,12 +47,11 @@ def main(path: Optional[Path] = None, out_dir: Optional[Path] = None):
         config = Config().from_str(CONFIG)
     else:
         config = Config().from_disk(path)
-    # make_from_config constructs objects whenever you have blocks with an @ key.
+    # resolve constructs objects whenever you have blocks with an @ key.
     # In the optimizer block we write @optimizers = "Adam.v1". This tells Thinc
     # to use registry.optimizers to fetch the "Adam.v1" function. You can
     # register your own functions as well and build up trees of objects.
-    C = thinc.registry.make_from_config(config)
-
+    C, _ = thinc.registry.resolve(config)
     words_per_subbatch = C["training"]["words_per_subbatch"]
     n_epoch = C["training"]["n_epoch"]
     batch_size = C["training"]["batch_size"]

--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a36"
+__version__ = "8.0.0a37"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -704,10 +704,11 @@ class registry(object):
         schema: Type[BaseModel] = EmptySchema,
         overrides: Dict[str, Any] = {},
         validate: bool = True,
-    ) -> Tuple[Dict[str, Any], Config]:
-        return cls._make(
+    ) -> Dict[str, Any]:
+        resolved, _ = cls._make(
             config, schema=schema, overrides=overrides, validate=validate, resolve=True
         )
+        return resolved
 
     @classmethod
     def fill(

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -630,7 +630,7 @@ def alias_generator(name: str) -> str:
     return name
 
 
-def copy_model_field(field: ModelField, type_: Type[Any]) -> ModelField:
+def copy_model_field(field: ModelField, type_: Any) -> ModelField:
     """Copy a model field and assign a new type, e.g. to accept an Any type
     even though the original value is typed differently.
     """

--- a/thinc/tests/layers/test_layers_api.py
+++ b/thinc/tests/layers/test_layers_api.py
@@ -121,8 +121,8 @@ TEST_CASES = [
 @pytest.mark.parametrize("name,kwargs,in_data,out_data", TEST_CASES)
 def test_layers_from_config(name, kwargs, in_data, out_data):
     cfg = {"@layers": name, **kwargs}
-    filled = registry.fill_config({"config": cfg})
-    model = registry.make_from_config(filled)["config"]
+    resolved, _ = registry.resolve({"config": cfg})
+    model = resolved["config"]
     if "LSTM" in name:
         model = with_padded(model)
     valid = True
@@ -139,8 +139,8 @@ def test_layers_from_config(name, kwargs, in_data, out_data):
 @pytest.mark.parametrize("name,kwargs,in_data,out_data", TEST_CASES_SUMMABLE)
 def test_layers_with_residual(name, kwargs, in_data, out_data):
     cfg = {"@layers": "residual.v1", "layer": {"@layers": name, **kwargs}}
-    filled = registry.fill_config({"config": cfg})
-    model = registry.make_from_config(filled)["config"]
+    resolved, _ = registry.resolve({"config": cfg})
+    model = resolved["config"]
     if "LSTM" in name:
         model = with_padded(model)
     model.initialize(in_data, out_data)

--- a/thinc/tests/layers/test_layers_api.py
+++ b/thinc/tests/layers/test_layers_api.py
@@ -121,8 +121,7 @@ TEST_CASES = [
 @pytest.mark.parametrize("name,kwargs,in_data,out_data", TEST_CASES)
 def test_layers_from_config(name, kwargs, in_data, out_data):
     cfg = {"@layers": name, **kwargs}
-    resolved, _ = registry.resolve({"config": cfg})
-    model = resolved["config"]
+    model = registry.resolve({"config": cfg})["config"]
     if "LSTM" in name:
         model = with_padded(model)
     valid = True
@@ -139,8 +138,7 @@ def test_layers_from_config(name, kwargs, in_data, out_data):
 @pytest.mark.parametrize("name,kwargs,in_data,out_data", TEST_CASES_SUMMABLE)
 def test_layers_with_residual(name, kwargs, in_data, out_data):
     cfg = {"@layers": "residual.v1", "layer": {"@layers": name, **kwargs}}
-    resolved, _ = registry.resolve({"config": cfg})
-    model = resolved["config"]
+    model = registry.resolve({"config": cfg})["config"]
     if "LSTM" in name:
         model = with_padded(model)
     model.initialize(in_data, out_data)

--- a/thinc/tests/layers/test_transforms.py
+++ b/thinc/tests/layers/test_transforms.py
@@ -40,8 +40,7 @@ def array_data(ragged_data):
 
 
 def check_transform(transform, in_data, out_data):
-    resolved, _ = registry.resolve({"config": {"@layers": transform}})
-    model = resolved["config"]
+    model = registry.resolve({"config": {"@layers": transform}})["config"]
     input_checker = get_data_checker(in_data)
     output_checker = get_data_checker(out_data)
     model.initialize(in_data, out_data)

--- a/thinc/tests/layers/test_transforms.py
+++ b/thinc/tests/layers/test_transforms.py
@@ -40,7 +40,8 @@ def array_data(ragged_data):
 
 
 def check_transform(transform, in_data, out_data):
-    model = registry.make_from_config({"config": {"@layers": transform}})["config"]
+    resolved, _ = registry.resolve({"config": {"@layers": transform}})
+    model = resolved["config"]
     input_checker = get_data_checker(in_data)
     output_checker = get_data_checker(out_data)
     model.initialize(in_data, out_data)

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -187,8 +187,7 @@ def test_is_promise():
 
 
 def test_get_constructor():
-    func = my_registry.get_constructor(good_catsie)
-    assert func is catsie_v1
+    my_registry.get_constructor(good_catsie) == ("cats", "catsie.v1")
 
 
 def test_parse_args():
@@ -245,17 +244,18 @@ def test_registry_methods():
         my_registry.get("cats", "catsie.v123")
 
 
-def test_make_from_config_no_schema():
+def test_resolve_no_schema():
     config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
-    result = my_registry.make_from_config({"cfg": config})["cfg"]
+    resolved, _ = my_registry.resolve({"cfg": config})
+    result = resolved["cfg"]
     assert result["one"] == 1
     assert result["two"] == {"three": "scratch!"}
     with pytest.raises(ConfigValidationError):
         config = {"two": {"three": {"@cats": "catsie.v1", "evil": "true"}}}
-        my_registry.make_from_config(config)
+        my_registry.resolve(config)
 
 
-def test_make_from_config_schema():
+def test_resolve_schema():
     class TestBaseSubSchema(BaseModel):
         three: str
 
@@ -270,18 +270,18 @@ def test_make_from_config_schema():
         cfg: TestBaseSchema
 
     config = {"one": 1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
-    my_registry.make_from_config({"cfg": config}, schema=TestSchema)["cfg"]
+    my_registry.resolve({"cfg": config}, schema=TestSchema)
     config = {"one": -1, "two": {"three": {"@cats": "catsie.v1", "evil": True}}}
     with pytest.raises(ConfigValidationError):
         # "one" is not a positive int
-        my_registry.make_from_config({"cfg": config}, schema=TestSchema)
+        my_registry.resolve({"cfg": config}, schema=TestSchema)
     config = {"one": 1, "two": {"four": {"@cats": "catsie.v1", "evil": True}}}
     with pytest.raises(ConfigValidationError):
         # "three" is required in subschema
-        my_registry.make_from_config({"cfg": config}, schema=TestSchema)
+        my_registry.resolve({"cfg": config}, schema=TestSchema)
 
 
-def test_make_from_config_schema_coerced():
+def test_resolve_schema_coerced():
     class TestBaseSchema(BaseModel):
         test1: str
         test2: bool
@@ -309,7 +309,7 @@ def test_read_config():
 
 def test_optimizer_config():
     cfg = Config().from_str(OPTIMIZER_CFG)
-    result = my_registry.make_from_config(cfg, validate=True)
+    result, _ = my_registry.resolve(cfg, validate=True)
     optimizer = result["optimizer"]
     assert optimizer.b1 == 0.9
 
@@ -374,26 +374,26 @@ def test_validation_custom_types():
     my_registry.create("complex")
     my_registry.complex("complex.v1")(complex_args)
     cfg = {"@complex": "complex.v1", "rate": 1.0, "steps": 20, "log_level": "INFO"}
-    my_registry.make_from_config({"config": cfg})
+    my_registry.resolve({"config": cfg})
     cfg = {"@complex": "complex.v1", "rate": 1.0, "steps": -1, "log_level": "INFO"}
     with pytest.raises(ConfigValidationError):
         # steps is not a positive int
-        my_registry.make_from_config({"config": cfg})
+        my_registry.resolve({"config": cfg})
     cfg = {"@complex": "complex.v1", "rate": 1.0, "steps": 20, "log_level": "none"}
     with pytest.raises(ConfigValidationError):
         # log_level is not a string matching the regex
-        my_registry.make_from_config({"config": cfg})
+        my_registry.resolve({"config": cfg})
     cfg = {"@complex": "complex.v1", "rate": 1.0, "steps": 20, "log_level": "INFO"}
     with pytest.raises(ConfigValidationError):
         # top-level object is promise
-        my_registry.make_from_config(cfg)
+        my_registry.resolve(cfg)
     with pytest.raises(ConfigValidationError):
         # top-level object is promise
-        my_registry.fill_config(cfg)
+        my_registry.fill(cfg)
     cfg = {"@complex": "complex.v1", "rate": 1.0, "@cats": "catsie.v1"}
     with pytest.raises(ConfigValidationError):
         # two constructors
-        my_registry.make_from_config({"config": cfg})
+        my_registry.resolve({"config": cfg})
 
 
 def test_validation_no_validate():
@@ -407,14 +407,14 @@ def test_validation_no_validate():
 
 def test_validation_fill_defaults():
     config = {"cfg": {"one": 1, "two": {"@cats": "catsie.v1", "evil": "hello"}}}
-    result = my_registry.fill_config(config, validate=False)
+    result = my_registry.fill(config, validate=False)
     assert len(result["cfg"]["two"]) == 3
     with pytest.raises(ConfigValidationError):
         # Required arg "evil" is not defined
-        my_registry.fill_config(config)
+        my_registry.fill(config)
     config = {"cfg": {"one": 1, "two": {"@cats": "catsie.v2", "evil": False}}}
     # Fill in with new defaults
-    result = my_registry.fill_config(config)
+    result = my_registry.fill(config)
     assert len(result["cfg"]["two"]) == 4
     assert result["cfg"]["two"]["evil"] is False
     assert result["cfg"]["two"]["cute"] is True
@@ -431,8 +431,8 @@ def test_make_config_positional_args():
 
     args = ["^_^", "^(*.*)^"]
     cfg = {"config": {"@cats": "catsie.v567", "foo": "baz", "*": args}}
-    filled_cfg = my_registry.make_from_config(cfg)
-    assert filled_cfg["config"] == "^_^"
+    resolved, _ = my_registry.resolve(cfg)
+    assert resolved["config"] == "^_^"
 
 
 def test_make_config_positional_args_complex():
@@ -442,12 +442,12 @@ def test_make_config_positional_args_complex():
         return args[0]
 
     cfg = {"config": {"@cats": "catsie.v890", "*": [123, True, 1, False]}}
-    filled_cfg = my_registry.make_from_config(cfg)
-    assert filled_cfg["config"] == 123
+    resolved, _ = my_registry.resolve(cfg)
+    assert resolved["config"] == 123
     cfg = {"config": {"@cats": "catsie.v890", "*": [123, "True"]}}
     with pytest.raises(ConfigValidationError):
         # "True" is not a valid boolean or positive int
-        my_registry.make_from_config(cfg)
+        my_registry.resolve(cfg)
 
 
 def test_positional_args_to_from_string():
@@ -461,24 +461,26 @@ def test_positional_args_to_from_string():
         return args
 
     cfg = """[a]\n@cats = "catsie.v666"\n* = ["foo","bar"]"""
-    filled = my_registry.fill_config(Config().from_str(cfg)).to_str()
+    filled = my_registry.fill(Config().from_str(cfg)).to_str()
     assert filled == """[a]\n@cats = "catsie.v666"\n* = ["foo","bar"]\nmeow = false"""
-    assert my_registry.make_from_config(Config().from_str(cfg)) == {"a": ("foo", "bar")}
+    resolved, _ = my_registry.resolve(Config().from_str(cfg))
+    assert resolved == {"a": ("foo", "bar")}
     cfg = """[a]\n@cats = "catsie.v666"\n\n[a.*.foo]\nx = 1"""
-    filled = my_registry.fill_config(Config().from_str(cfg)).to_str()
+    filled = my_registry.fill(Config().from_str(cfg)).to_str()
     assert filled == """[a]\n@cats = "catsie.v666"\nmeow = false\n\n[a.*.foo]\nx = 1"""
-    assert my_registry.make_from_config(Config().from_str(cfg)) == {"a": ({"x": 1},)}
+    resolved, _ = my_registry.resolve(Config().from_str(cfg))
+    assert resolved == {"a": ({"x": 1},)}
 
     @my_registry.cats("catsie.v777")
     def catsie_777(y: int = 1):
         return "meow" * y
 
     cfg = """[a]\n@cats = "catsie.v666"\n\n[a.*.foo]\n@cats = "catsie.v777\""""
-    filled = my_registry.fill_config(Config().from_str(cfg)).to_str()
+    filled = my_registry.fill(Config().from_str(cfg)).to_str()
     expected = """[a]\n@cats = "catsie.v666"\nmeow = false\n\n[a.*.foo]\n@cats = "catsie.v777"\ny = 1"""
     assert filled == expected
     cfg = """[a]\n@cats = "catsie.v666"\n\n[a.*.foo]\n@cats = "catsie.v777"\ny = 3"""
-    result = my_registry.make_from_config(Config().from_str(cfg))
+    result, _ = my_registry.resolve(Config().from_str(cfg))
     assert result == {"a": ("meowmeowmeow",)}
 
 
@@ -495,12 +497,12 @@ def test_make_config_positional_args_dicts():
         },
         "optimizer": {"@optimizers": "Adam.v1", "learn_rate": 0.001},
     }
-    loaded = my_registry.make_from_config(cfg)
-    model = loaded["model"]
+    resolved, _ = my_registry.resolve(cfg)
+    model = resolved["model"]
     X = numpy.ones((784, 1), dtype="f")
     model.initialize(X=X, Y=numpy.zeros((784, 1), dtype="f"))
     model.begin_update(X)
-    model.finish_update(loaded["optimizer"])
+    model.finish_update(resolved["optimizer"])
 
 
 def test_validation_generators_iterable():
@@ -514,7 +516,7 @@ def test_validation_generators_iterable():
             yield some_value
 
     config = {"optimizer": {"@optimizers": "test_optimizer.v1", "rate": 0.1}}
-    my_registry.make_from_config(config)
+    my_registry.resolve(config)
 
 
 def test_validation_unset_type_hints():
@@ -525,7 +527,7 @@ def test_validation_unset_type_hints():
         return None
 
     config = {"test": {"@optimizers": "test_optimizer.v2", "rate": 0.1, "steps": 20}}
-    my_registry.make_from_config(config)
+    my_registry.resolve(config)
 
 
 def test_validation_bad_function():
@@ -541,11 +543,11 @@ def test_validation_bad_function():
     # Bad function
     config = {"test": {"@optimizers": "bad.v1"}}
     with pytest.raises(ConfigValidationError):
-        my_registry.make_from_config(config)
+        my_registry.resolve(config)
     # Bad function call
     config = {"test": {"@optimizers": "good.v1", "invalid_arg": 1}}
     with pytest.raises(ConfigValidationError):
-        my_registry.make_from_config(config)
+        my_registry.resolve(config)
 
 
 def test_objects_from_config():
@@ -569,8 +571,8 @@ def test_objects_from_config():
     def decaying(base_rate: float, repeat: int) -> List[float]:
         return repeat * [base_rate]
 
-    loaded = my_registry.make_from_config(config)
-    optimizer = loaded["optimizer"]
+    resolved, _ = my_registry.resolve(config)
+    optimizer = resolved["optimizer"]
     assert optimizer.b1 == 0.2
     assert "learn_rate" in optimizer.schedules
     assert optimizer.learn_rate == 0.001
@@ -581,7 +583,8 @@ def test_partials_from_config():
     correctly (e.g. initializers)."""
     name = "uniform_init.v1"
     cfg = {"test": {"@initializers": name, "lo": -0.2}}
-    func = my_registry.make_from_config(cfg)["test"]
+    resolved, _ = my_registry.resolve(cfg)
+    func = resolved["test"]
     assert hasattr(func, "__call__")
     # The partial will still have lo as an arg, just with default
     assert len(inspect.signature(func).parameters) == 4
@@ -592,10 +595,10 @@ def test_partials_from_config():
     # Make sure validation still works
     bad_cfg = {"test": {"@initializers": name, "lo": [0.5]}}
     with pytest.raises(ConfigValidationError):
-        my_registry.make_from_config(bad_cfg)
+        my_registry.resolve(bad_cfg)
     bad_cfg = {"test": {"@initializers": name, "lo": -0.2, "other": 10}}
     with pytest.raises(ConfigValidationError):
-        my_registry.make_from_config(bad_cfg)
+        my_registry.resolve(bad_cfg)
 
 
 def test_partials_from_config_nested():
@@ -618,7 +621,8 @@ def test_partials_from_config_nested():
         "c": 5,
         "init": {"@initializers": "test_initializer.v1", "b": 10},
     }
-    func = my_registry.make_from_config({"test": cfg})["test"]
+    resolved, _ = my_registry.resolve({"test": cfg})
+    func = resolved["test"]
     assert func(1) == 51
     assert func(100) == 150
 
@@ -633,8 +637,8 @@ def test_validate_generator():
             yield 10
 
     cfg = {"@schedules": "test_schedule.v2"}
-    result = my_registry.make_from_config({"test": cfg})["test"]
-    assert isinstance(result, GeneratorType)
+    resolved, _ = my_registry.resolve({"test": cfg})
+    assert isinstance(resolved["test"], GeneratorType)
 
     @my_registry.optimizers("test_optimizer.v2")
     def test_optimizer2(rate: Generator) -> Generator:
@@ -644,8 +648,8 @@ def test_validate_generator():
         "@optimizers": "test_optimizer.v2",
         "rate": {"@schedules": "test_schedule.v2"},
     }
-    result = my_registry.make_from_config({"test": cfg})["test"]
-    assert isinstance(result, GeneratorType)
+    resolved, _ = my_registry.resolve({"test": cfg})
+    assert isinstance(resolved["test"], GeneratorType)
 
     @my_registry.optimizers("test_optimizer.v3")
     def test_optimizer3(schedules: Dict[str, Generator]) -> Generator:
@@ -655,8 +659,8 @@ def test_validate_generator():
         "@optimizers": "test_optimizer.v3",
         "schedules": {"rate": {"@schedules": "test_schedule.v2"}},
     }
-    result = my_registry.make_from_config({"test": cfg})["test"]
-    assert isinstance(result, GeneratorType)
+    resolved, _ = my_registry.resolve({"test": cfg})
+    assert isinstance(resolved["test"], GeneratorType)
 
     @my_registry.optimizers("test_optimizer.v4")
     def test_optimizer4(*schedules: Generator) -> Generator:
@@ -673,7 +677,8 @@ def test_handle_generic_model_type():
         return model
 
     cfg = {"@layers": "my_transform.v1", "model": {"@layers": "Linear.v1"}}
-    model = my_registry.make_from_config({"test": cfg})["test"]
+    resolved, _ = my_registry.resolve({"test": cfg})
+    model = resolved["test"]
     assert isinstance(model, Model)
     assert model.name == "transformed_model"
 
@@ -717,16 +722,16 @@ def test_fill_config_overrides():
         }
     }
     overrides = {"cfg.two.three.evil": False}
-    result = my_registry.fill_config(config, overrides=overrides, validate=True)
+    result = my_registry.fill(config, overrides=overrides, validate=True)
     assert result["cfg"]["two"]["three"]["evil"] is False
     # Test that promises can be overwritten as well
     overrides = {"cfg.two.three": 3}
-    result = my_registry.fill_config(config, overrides=overrides, validate=True)
+    result = my_registry.fill(config, overrides=overrides, validate=True)
     assert result["cfg"]["two"]["three"] == 3
     # Test that value can be overwritten with promises and that the result is
     # interpreted and filled correctly
     overrides = {"cfg": {"one": {"@cats": "catsie.v1", "evil": False}, "two": None}}
-    result = my_registry.fill_config(config, overrides=overrides)
+    result = my_registry.fill(config, overrides=overrides)
     assert result["cfg"]["two"] is None
     assert result["cfg"]["one"]["@cats"] == "catsie.v1"
     assert result["cfg"]["one"]["evil"] is False
@@ -734,21 +739,21 @@ def test_fill_config_overrides():
     # Overwriting with wrong types should cause validation error
     with pytest.raises(ConfigValidationError):
         overrides = {"cfg.two.three.evil": 20}
-        my_registry.fill_config(config, overrides=overrides, validate=True)
+        my_registry.fill(config, overrides=overrides, validate=True)
     # Overwriting with incomplete promises should cause validation error
     with pytest.raises(ConfigValidationError):
         overrides = {"cfg": {"one": {"@cats": "catsie.v1"}, "two": None}}
-        my_registry.fill_config(config, overrides=overrides)
+        my_registry.fill(config, overrides=overrides)
     # Overrides that don't match config should raise error
     with pytest.raises(ConfigValidationError):
         overrides = {"cfg.two.three.evil": False, "two.four": True}
-        my_registry.fill_config(config, overrides=overrides, validate=True)
+        my_registry.fill(config, overrides=overrides, validate=True)
     with pytest.raises(ConfigValidationError):
         overrides = {"cfg.five": False}
-        my_registry.fill_config(config, overrides=overrides, validate=True)
+        my_registry.fill(config, overrides=overrides, validate=True)
 
 
-def test_make_from_config_overrides():
+def test_resolve_overrides():
     config = {
         "cfg": {
             "one": 1,
@@ -756,32 +761,32 @@ def test_make_from_config_overrides():
         }
     }
     overrides = {"cfg.two.three.evil": False}
-    result = my_registry.make_from_config(config, overrides=overrides, validate=True)
+    result, _ = my_registry.resolve(config, overrides=overrides, validate=True)
     assert result["cfg"]["two"]["three"] == "meow"
     # Test that promises can be overwritten as well
     overrides = {"cfg.two.three": 3}
-    result = my_registry.make_from_config(config, overrides=overrides, validate=True)
+    result, _ = my_registry.resolve(config, overrides=overrides, validate=True)
     assert result["cfg"]["two"]["three"] == 3
     # Test that value can be overwritten with promises
     overrides = {"cfg": {"one": {"@cats": "catsie.v1", "evil": False}, "two": None}}
-    result = my_registry.make_from_config(config, overrides=overrides)
+    result, _ = my_registry.resolve(config, overrides=overrides)
     assert result["cfg"]["one"] == "meow"
     assert result["cfg"]["two"] is None
     # Overwriting with wrong types should cause validation error
     with pytest.raises(ConfigValidationError):
         overrides = {"cfg.two.three.evil": 20}
-        my_registry.make_from_config(config, overrides=overrides, validate=True)
+        my_registry.resolve(config, overrides=overrides, validate=True)
     # Overwriting with incomplete promises should cause validation error
     with pytest.raises(ConfigValidationError):
         overrides = {"cfg": {"one": {"@cats": "catsie.v1"}, "two": None}}
-        my_registry.make_from_config(config, overrides=overrides)
+        my_registry.resolve(config, overrides=overrides)
     # Overrides that don't match config should raise error
     with pytest.raises(ConfigValidationError):
         overrides = {"cfg.two.three.evil": False, "cfg.two.four": True}
-        my_registry.make_from_config(config, overrides=overrides, validate=True)
+        my_registry.resolve(config, overrides=overrides, validate=True)
     with pytest.raises(ConfigValidationError):
         overrides = {"cfg.five": False}
-        my_registry.make_from_config(config, overrides=overrides, validate=True)
+        my_registry.resolve(config, overrides=overrides, validate=True)
 
 
 @pytest.mark.parametrize(
@@ -793,7 +798,7 @@ def test_is_in_config(prop, expected):
     assert my_registry._is_in_config(prop, config) is expected
 
 
-def test_make_from_config_prefilled_values():
+def test_resolve_prefilled_values():
     class Language(object):
         def __init__(self):
             ...
@@ -805,7 +810,8 @@ def test_make_from_config_prefilled_values():
     # Passing an instance of Language here via the config is bad, since it
     # won't serialize to a string, but we still test for it
     config = {"test": {"@optimizers": "prefilled.v1", "nlp": Language(), "value": 50}}
-    result = my_registry.make_from_config(config, validate=True)["test"]
+    resolved, _ = my_registry.resolve(config, validate=True)
+    result = resolved["test"]
     assert isinstance(result[0], Language)
     assert result[1] == 50
 
@@ -818,7 +824,7 @@ def test_fill_config_dict_return_type():
         return {"not_evil": not evil}
 
     config = {"test": {"@cats": "catsie_with_dict.v1", "evil": False}, "foo": 10}
-    result = my_registry.fill_config({"cfg": config}, validate=True)["cfg"]["test"]
+    result = my_registry.fill({"cfg": config}, validate=True)["cfg"]["test"]
     assert result["evil"] is False
     assert "not_evil" not in result
 
@@ -1066,10 +1072,10 @@ def test_config_no_interpolation_registry():
     # Resolving a non-interpolated filled config
     config = Config().from_str(config_str, interpolate=False)
     assert not config.is_interpolated
-    filled = my_registry.fill_config(config)
+    filled = my_registry.fill(config)
     assert not filled.is_interpolated
     assert filled["c"]["d"] == "${b}"
-    resolved = my_registry.make_from_config(filled)
+    resolved, _ = my_registry.resolve(filled)
     assert resolved["c"]["d"] == "scratch!"
 
 
@@ -1214,7 +1220,7 @@ def test_config_custom_sort_preserve():
     section_order = ["c", "a", "t"]
     config5 = Config(section_order=section_order).from_str(config_str)
     assert list(config5.keys()) == section_order
-    filled = my_registry.fill_config(config5)
+    filled = my_registry.fill(config5)
     assert filled.section_order == section_order
 
 
@@ -1241,14 +1247,14 @@ def test_config_fill_extra_fields():
 
     config = Config({"cfg": {"a": "1", "b": 2, "c": True}})
     with pytest.raises(ConfigValidationError):
-        my_registry.fill_config(config, schema=TestSchema)
-    filled = my_registry.fill_config(config, schema=TestSchema, validate=False)["cfg"]
+        my_registry.fill(config, schema=TestSchema)
+    filled = my_registry.fill(config, schema=TestSchema, validate=False)["cfg"]
     assert filled == {"a": "1", "b": 2}
     config2 = config.interpolate()
-    filled = my_registry.fill_config(config2, schema=TestSchema, validate=False)["cfg"]
+    filled = my_registry.fill(config2, schema=TestSchema, validate=False)["cfg"]
     assert filled == {"a": "1", "b": 2}
     config3 = Config({"cfg": {"a": "1", "b": 2, "c": True}}, is_interpolated=False)
-    filled = my_registry.fill_config(config3, schema=TestSchema, validate=False)["cfg"]
+    filled = my_registry.fill(config3, schema=TestSchema, validate=False)["cfg"]
     assert filled == {"a": "1", "b": 2}
 
     class TestSchemaContent2(BaseModel):
@@ -1261,7 +1267,7 @@ def test_config_fill_extra_fields():
     class TestSchema2(BaseModel):
         cfg: TestSchemaContent2
 
-    filled = my_registry.fill_config(config, schema=TestSchema2, validate=False)["cfg"]
+    filled = my_registry.fill(config, schema=TestSchema2, validate=False)["cfg"]
     assert filled == {"a": "1", "b": 2, "c": True}
 
 
@@ -1299,3 +1305,19 @@ def test_config_parsing_error():
     config_str = "[a]\nb c"
     with pytest.raises(ConfigValidationError):
         Config().from_str(config_str)
+
+
+def test_config_fill_without_resolve():
+    class BaseSchema(BaseModel):
+        catsie: int
+
+    config = {"catsie": {"@cats": "catsie.v1", "evil": False}}
+    resolved, filled = my_registry.resolve(config)
+    assert resolved["catsie"] == "meow"
+    assert filled["catsie"]["cute"] is True
+    with pytest.raises(ConfigValidationError):
+        my_registry.resolve(config, schema=BaseSchema)
+    filled2 = my_registry.fill(config, schema=BaseSchema)
+    assert filled2["catsie"]["cute"] is True
+    resolved, _ = my_registry.resolve(filled2)
+    assert resolved["catsie"] == "meow"

--- a/thinc/tests/test_initializers.py
+++ b/thinc/tests/test_initializers.py
@@ -28,6 +28,5 @@ def test_initializer_from_config(name, kwargs):
     """Test that initializers are loaded and configured correctly from registry
     (as partials)."""
     cfg = {"test": {"@initializers": name, **kwargs}}
-    resolved, _ = registry.resolve(cfg)
-    func = resolved["test"]
+    func = registry.resolve(cfg)["test"]
     func(NumpyOps(), (1, 2, 3, 4))

--- a/thinc/tests/test_initializers.py
+++ b/thinc/tests/test_initializers.py
@@ -28,5 +28,6 @@ def test_initializer_from_config(name, kwargs):
     """Test that initializers are loaded and configured correctly from registry
     (as partials)."""
     cfg = {"test": {"@initializers": name, **kwargs}}
-    func = registry.make_from_config(cfg)["test"]
+    resolved, _ = registry.resolve(cfg)
+    func = resolved["test"]
     func(NumpyOps(), (1, 2, 3, 4))

--- a/thinc/tests/test_loss.py
+++ b/thinc/tests/test_loss.py
@@ -190,7 +190,8 @@ def test_loss_from_config(name, kwargs, args):
     """Test that losses are loaded and configured correctly from registry
     (as partials)."""
     cfg = {"test": {"@losses": name, **kwargs}}
-    func = registry.make_from_config(cfg)["test"]
+    resolved, _ = registry.resolve(cfg)
+    func = resolved["test"]
     loss = func.get_grad(*args)
     if isinstance(loss, (list, tuple)):
         loss = loss[0]

--- a/thinc/tests/test_loss.py
+++ b/thinc/tests/test_loss.py
@@ -190,8 +190,7 @@ def test_loss_from_config(name, kwargs, args):
     """Test that losses are loaded and configured correctly from registry
     (as partials)."""
     cfg = {"test": {"@losses": name, **kwargs}}
-    resolved, _ = registry.resolve(cfg)
-    func = resolved["test"]
+    func = registry.resolve(cfg)["test"]
     loss = func.get_grad(*args)
     if isinstance(loss, (list, tuple)):
         loss = loss[0]

--- a/thinc/tests/test_optimizers.py
+++ b/thinc/tests/test_optimizers.py
@@ -48,16 +48,14 @@ def schedule_invalid(request):
 def test_optimizers_from_config(name):
     learn_rate = 0.123
     cfg = {"@optimizers": name, "learn_rate": learn_rate}
-    resolved, _ = registry.resolve({"config": cfg})
-    optimizer = resolved["config"]
+    optimizer = registry.resolve({"config": cfg})["config"]
     assert optimizer.learn_rate == learn_rate
 
 
 def test_optimizer_schedules_from_config(schedule_valid):
     lr, lr_next1, lr_next2, lr_next3 = schedule_valid
     cfg = {"@optimizers": "Adam.v1", "learn_rate": lr}
-    resolved, _ = registry.resolve({"cfg": cfg})
-    optimizer = resolved["cfg"]
+    optimizer = registry.resolve({"cfg": cfg})["cfg"]
     assert optimizer.learn_rate == lr_next1
     optimizer.step_schedules()
     assert optimizer.learn_rate == lr_next2

--- a/thinc/tests/test_optimizers.py
+++ b/thinc/tests/test_optimizers.py
@@ -48,14 +48,16 @@ def schedule_invalid(request):
 def test_optimizers_from_config(name):
     learn_rate = 0.123
     cfg = {"@optimizers": name, "learn_rate": learn_rate}
-    optimizer = registry.make_from_config({"config": cfg})["config"]
+    resolved, _ = registry.resolve({"config": cfg})
+    optimizer = resolved["config"]
     assert optimizer.learn_rate == learn_rate
 
 
 def test_optimizer_schedules_from_config(schedule_valid):
     lr, lr_next1, lr_next2, lr_next3 = schedule_valid
     cfg = {"@optimizers": "Adam.v1", "learn_rate": lr}
-    optimizer = registry.make_from_config({"cfg": cfg})["cfg"]
+    resolved, _ = registry.resolve({"cfg": cfg})
+    optimizer = resolved["cfg"]
     assert optimizer.learn_rate == lr_next1
     optimizer.step_schedules()
     assert optimizer.learn_rate == lr_next2

--- a/website/docs/api-config.md
+++ b/website/docs/api-config.md
@@ -394,7 +394,7 @@ examples, see the [docs on Thinc's config system](/docs/usage-config).
 from thinc.api import Config, registry
 
 cfg = Config().from_disk("./my_config.cfg")
-resolved, filled = registry.resolve(cfg)
+resolved = registry.resolve(cfg)
 ```
 
 | Argument       | Type                                   | Description                                                                                                                                                                                                                                                                             |
@@ -404,4 +404,4 @@ resolved, filled = registry.resolve(cfg)
 | `validate`     | <tt>bool</tt>                          | Whether to validate the config against a base schema and/or type annotations defined on the registered functions. Defaults to `True`.                                                                                                                                                   |
 | `schema`       | <tt>pydantic.BaseModel</tt>            | Optional [`pydantic` model](https://pydantic-docs.helpmanual.io/usage/models/) to validate the config against. See the docs on [base schemas](/docs/api-config#advanced-types-base-schema) for details. Defaults to an `EmptySchema` with extra properties and arbitrary types allowed. |
 | `overrides`    | <tt>Dict[str, Any]</tt>                | Optional overrides for config values. Should be a dictionary keyed by config properties with dot notation, e.g. `{"training.batch_size": 128}`.                                                                                                                                         |
-| **RETURNS**    | <tt>Tuple[Dict[str, Any], Config]</tt> | The resolved and the filled config.                                                                                                                                                                                                                                                     |
+| **RETURNS**    | <tt>Dict[str, Any]</tt>                | The resolved config.                                                                                                                                                                                                                                                                    |

--- a/website/docs/api-config.md
+++ b/website/docs/api-config.md
@@ -347,33 +347,7 @@ and underscores.
 
 </infobox>
 
-### registry.make_from_config {#registry-make_from_config tag="classmethod"}
-
-Unpack a config dictionary, creating objects from the registry recursively. If a
-section contains a key beginning with `@`, the rest of that key will be
-interpreted as the name of the registry. For instance,
-`"@optimizers": "my_cool_optimizer.v1"` will load the function from the
-optimizers registry and pass in the specified arguments. For more details and
-examples, see the [docs on Thinc's config system](/docs/usage-config).
-
-```python
-### Example
-from thinc.api import Config, registry
-
-cfg = Config().from_disk("./my_config.cfg")
-C = registry.make_from_config(cfg)
-```
-
-| Argument       | Type                                   | Description                                                                                                                                                                                                                                                                             |
-| -------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `config`       | <tt>Union[Config, Dict[str, Any]]</tt> | The config dict to load.                                                                                                                                                                                                                                                                |
-| _keyword-only_ |                                        |                                                                                                                                                                                                                                                                                         |
-| `validate`     | <tt>bool</tt>                          | Whether to validate the config against a base schema and/or type annotations defined on the registered functions. Defaults to `True`.                                                                                                                                                   |
-| `schema`       | <tt>pydantic.BaseModel</tt>            | Optional [`pydantic` model](https://pydantic-docs.helpmanual.io/usage/models/) to validate the config against. See the docs on [base schemas](/docs/api-config#advanced-types-base-schema) for details. Defaults to an `EmptySchema` with extra properties and arbitrary types allowed. |
-| `overrides`    | <tt>Dict[str, Any]</tt>                | Optional overrides for config values. Should be a dictionary keyed by config properties with dot notation, e.g. `{"training.batch_size": 128}`.                                                                                                                                         |
-| **RETURNS**    | <tt>Dict[str, Any]</tt>                | The resolved config.                                                                                                                                                                                                                                                                    |
-
-### registry.fill_config {#fill_config tag="classmethod"}
+### registry.fill {#fill tag="classmethod"}
 
 Unpack a config dictionary, but leave all references to registry functions
 intact and don't resolve them. Only use the type annotations and optional base
@@ -394,7 +368,7 @@ This means you can auto-fill partial config, without destroying the variables.
 from thinc.api import Config, registry
 
 cfg = Config().from_disk("./my_config.cfg")
-filled_cfg = registry.fill_config(cfg)
+filled_cfg = registry.fill(cfg)
 ```
 
 | Argument       | Type                                   | Description                                                                                                                                                                                                                                                                             |
@@ -408,9 +382,20 @@ filled_cfg = registry.fill_config(cfg)
 
 ### registry.resolve {#registry-resolve tag="classmethod"}
 
-Perform both [`registry.make_from_config`](#registry-make_from_config) and
-[`registry.fill_config`](#registry-fill_config) at the same time. If you need a
-filled and resolved config, this method is the most efficient.
+Unpack a config dictionary, creating objects from the registry recursively. If a
+section contains a key beginning with `@`, the rest of that key will be
+interpreted as the name of the registry. For instance,
+`"@optimizers": "my_cool_optimizer.v1"` will load the function from the
+optimizers registry and pass in the specified arguments. For more details and
+examples, see the [docs on Thinc's config system](/docs/usage-config).
+
+```python
+### Example
+from thinc.api import Config, registry
+
+cfg = Config().from_disk("./my_config.cfg")
+resolved, filled = registry.resolve(cfg)
+```
 
 | Argument       | Type                                   | Description                                                                                                                                                                                                                                                                             |
 | -------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/docs/api-initializers.md
+++ b/website/docs/api-initializers.md
@@ -95,8 +95,8 @@ fan_in = -1
 from thinc.api import registry, Config
 
 config = Config().from_disk("./config.cfg")
-C = registry.make_from_config(config)
-model = C["model"]
+resolved, filled = registry.resolve(config)
+model = resolved["model"]
 ```
 
 </grid>
@@ -119,8 +119,8 @@ hi = 0.1
 from thinc.api import registry, Config, NumpyOps
 
 config = Config().from_disk("./config.cfg")
-C = registry.make_from_config(config)
-initializer = C["initializer"]
+resolved, filled = registry.resolve(config)
+initializer = resolved["initializer"]
 weights = initializer(NumpyOps(), (3, 2))
 ```
 

--- a/website/docs/api-initializers.md
+++ b/website/docs/api-initializers.md
@@ -95,7 +95,7 @@ fan_in = -1
 from thinc.api import registry, Config
 
 config = Config().from_disk("./config.cfg")
-resolved, filled = registry.resolve(config)
+resolved = registry.resolve(config)
 model = resolved["model"]
 ```
 
@@ -119,7 +119,7 @@ hi = 0.1
 from thinc.api import registry, Config, NumpyOps
 
 config = Config().from_disk("./config.cfg")
-resolved, filled = registry.resolve(config)
+resolved = registry.resolve(config)
 initializer = resolved["initializer"]
 weights = initializer(NumpyOps(), (3, 2))
 ```

--- a/website/docs/api-loss.md
+++ b/website/docs/api-loss.md
@@ -209,8 +209,8 @@ normalize = true
 from thinc.api import registry, Config
 
 config = Config().from_disk("./config.cfg")
-C = registry.make_from_config(config)
-loss_calc = C["loss"]
+resolved, filled = registry.resolve(config)
+loss_calc = resolved["loss"]
 loss = loss_calc.get_grad(guesses, truths)
 ```
 

--- a/website/docs/api-loss.md
+++ b/website/docs/api-loss.md
@@ -209,7 +209,7 @@ normalize = true
 from thinc.api import registry, Config
 
 config = Config().from_disk("./config.cfg")
-resolved, filled = registry.resolve(config)
+resolved = registry.resolve(config)
 loss_calc = resolved["loss"]
 loss = loss_calc.get_grad(guesses, truths)
 ```

--- a/website/docs/usage-config.md
+++ b/website/docs/usage-config.md
@@ -153,7 +153,7 @@ gamma = 1e-8
 from thinc.api import Config, registry
 
 config = Config().from_disk("./config.cfg")
-resolved, filled = registry.resolve(config)
+resolved = registry.resolve(config)
 optimizer = resolved["optimizer"]
 ```
 
@@ -260,7 +260,7 @@ defined in the config.
 from thinc.api import Config, registry
 
 config = Config().from_disk("./config.cfg")
-resolved, filled = registry.resolve(config)
+resolved = registry.resolve(config)
 ```
 
 ```python
@@ -641,7 +641,7 @@ pipeline = ["tagger", "parser"]
 from thinc.api import registry, Config
 
 config = Config().from_disk("./config.cfg")
-resolved, filled = registry.resolve(
+resolved = registry.resolve(
     config,
     schema=ConfigBaseSchema
 )

--- a/website/docs/usage-config.md
+++ b/website/docs/usage-config.md
@@ -131,12 +131,12 @@ for configuration files: you can **provide the name of your function** and the
 the object.
 
 Since this is a common workflow, the registry system provides a shortcut for it,
-the [`registry.make_from_config`](/docs/api-config#registry-make_from_config)
-function. If a section contains a key beginning with `@`, it will be interpreted
-as the name of a function registry – e.g. `@optimizers` refers to a function
-registered in the `optimizers` registry. The value will be interpreted as the
-name to look up and the rest of the block will be passed into the function as
-arguments. Here's a simple example:
+the [`registry.resolve`](/docs/api-config#registry-resolve) function. If a
+section contains a key beginning with `@`, it will be interpreted as the name of
+a function registry – e.g. `@optimizers` refers to a function registered in the
+`optimizers` registry. The value will be interpreted as the name to look up and
+the rest of the block will be passed into the function as arguments. Here's a
+simple example:
 
 <grid>
 
@@ -153,7 +153,8 @@ gamma = 1e-8
 from thinc.api import Config, registry
 
 config = Config().from_disk("./config.cfg")
-C = registry.make_from_config(config)
+resolved, filled = registry.resolve(config)
+optimizer = resolved["optimizer"]
 ```
 
 </grid>
@@ -246,10 +247,11 @@ optimizer_func = thinc.registry.get("optimizers", "my_cool_optimizer.v1")
 optimizer = optimizer_func(learn_rate=learn_rate, gamma=1e-8)
 ```
 
-After resolving the config and filling in the values,
-`registry.make_from_config` will return a dict with one key, `"optimizer"`,
-mapped to an instance of the custom optimizer function initialized with the
-arguments defined in the config.
+After resolving the config and filling in the values, `registry.resolve` will
+return a tuple of the resolved config and the filled config with default values
+added. The resolved config will be a dict with one key, `"optimizer"`, mapped to
+an instance of the custom optimizer function initialized with the arguments
+defined in the config.
 
 <grid>
 
@@ -258,7 +260,7 @@ arguments defined in the config.
 from thinc.api import Config, registry
 
 config = Config().from_disk("./config.cfg")
-C = registry.make_from_config(config)
+resolved, filled = registry.resolve(config)
 ```
 
 ```python
@@ -585,7 +587,7 @@ class LoggingConfig(BaseModel):
 If a config file specifies registered functions, their argument values will be
 validated against the type annotations of the function. For all other values,
 you can pass a `schema` to
-[`registry.make_from_config`](/docs/api-config#registry-make_from_config), a
+[`registry.resolve`](/docs/api-config#registry-resolve), a
 [`pydantic` model](https://pydantic-docs.helpmanual.io/usage/models/) used to
 parse and validate the data. Models can also be nested to describe nested
 objects.
@@ -639,7 +641,7 @@ pipeline = ["tagger", "parser"]
 from thinc.api import registry, Config
 
 config = Config().from_disk("./config.cfg")
-C = registry.make_from_config(
+resolved, filled = registry.resolve(
     config,
     schema=ConfigBaseSchema
 )
@@ -652,7 +654,7 @@ C = registry.make_from_config(
 The main motivation for Thinc's configuration system was to eliminate hidden
 defaults and ensure that config settings are passed around consistently. This
 also means that config files should always define **all available settings**.
-The [`registry.fill_config`](/docs/api-config#registry-fill_config) method also
+The [`registry.fill`](/docs/api-config#registry-fill) method also
 resolves the config, but it leaves references to registered functions intact and
 doesn't replace them with their return values. If type annotations and/or a base
 schema are available, they will be used to parse the config and fill in any
@@ -675,9 +677,9 @@ class TrainingSchema(BaseModel):
     max_epochs: StrictInt = 100
 ```
 
-Calling [`registry.fill_config`](/docs/api-config#registry-fill_config) with
-your existing config will produce an updated version of it including the new
-settings and their defaults:
+Calling [`registry.fill`](/docs/api-config#registry-fill) with your
+existing config will produce an updated version of it including the new settings
+and their defaults:
 
 <grid>
 
@@ -702,9 +704,9 @@ max_epochs = 100
 </grid>
 
 The same also works for config blocks that reference registry functions. If your
-**function arguments change**, you can run `registry.fill_config` to get your
-config up to date with the new defaults. For instance, let's say the optimizer
-now allows a new setting, `gamma`, that defaults to `1e-8`:
+**function arguments change**, you can run `registry.fill` to get your config up
+to date with the new defaults. For instance, let's say the optimizer now allows
+a new setting, `gamma`, that defaults to `1e-8`:
 
 ```python
 ### Example {highlight="8"}
@@ -723,8 +725,8 @@ def my_cool_optimizer_v2(
 
 The config file should now also reflect this new setting and the default value
 that's being passed in – otherwise, you'll lose that piece of information.
-Running `registry.fill_config` solves this and returns a new `Config` with the
-complete set of available settings:
+Running `registry.fill` solves this and returns a new `Config` with the complete
+set of available settings:
 
 <grid>
 
@@ -751,11 +753,11 @@ log_level = "INFO"
 
 <infobox variant="warning">
 
-Note that if the config you're filling is incomplete and contains missing
-required arguments, or if your registry functions raise errors,
-[`registry.fill_config`](/docs/api-config#registry-fill_config) will be unable
-to parse the config. This means Thinc will raise a validation error, even if you
-set `validate` to `False`.
+Note that if you're only filling and not resolving a config, Thinc will **not**
+load or call any registered functions, and it won't be able to validate the
+return values of registered functions against any types defined in the base
+schema. If you neeed to check that all functions exist and their return values
+match, use [`registry.resolve`](/docs/api-config#registry-resolve) instead.
 
 </infobox>
 

--- a/website/docs/usage-training.md
+++ b/website/docs/usage-training.md
@@ -150,7 +150,7 @@ compound = 1.001
 from thinc.api import Config, registry
 
 config = Config().from_str("./config.cfg")
-resolved, filled = registry.resolve(config)
+resolved = registry.resolve(config)
 batch_size = resolved["batch_size"]
 ```
 

--- a/website/docs/usage-training.md
+++ b/website/docs/usage-training.md
@@ -150,8 +150,8 @@ compound = 1.001
 from thinc.api import Config, registry
 
 config = Config().from_str("./config.cfg")
-C = registry.make_from_config(config)
-batch_size = C["batch_size"]
+resolved, filled = registry.resolve(config)
+batch_size = resolved["batch_size"]
 ```
 
 </grid>


### PR DESCRIPTION
- Allow configs to be filled without resolving. In this case, registered functions (promises) aren't called or even loaded and their return values aren't validated against any schema.
- Only use two descriptive methods: `registry.fill` returns a filled, unresolved config and `registry.resolve` returns the resolved config