### PR TITLE
Handle promises with unavailable references if resolve=False

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a40"
+__version__ = "8.0.0a41"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -686,6 +686,14 @@ class registry(object):
         setattr(cls, registry_name, reg)
 
     @classmethod
+    def has(cls, registry_name: str, func_name: str) -> Callable:
+        """Check whether a function is available in a registry."""
+        if not hasattr(cls, registry_name):
+            return False
+        reg = getattr(cls, registry_name)
+        return func_name in reg
+
+    @classmethod
     def get(cls, registry_name: str, func_name: str) -> Callable:
         """Get a registered function from a given registry."""
         if not hasattr(cls, registry_name):
@@ -808,7 +816,7 @@ class registry(object):
                     # validation if it doesn't receive the function return value
                     field = schema.__fields__[key]
                     schema.__fields__[key] = copy_model_field(field, Any)
-                promise_schema = cls.make_promise_schema(value)
+                promise_schema = cls.make_promise_schema(value, resolve=resolve)
                 filled[key], validation[v_key], final[key] = cls._fill(
                     value,
                     promise_schema,
@@ -999,11 +1007,15 @@ class registry(object):
         return args, kwargs
 
     @classmethod
-    def make_promise_schema(cls, obj: Dict[str, Any]) -> Type[BaseModel]:
+    def make_promise_schema(
+        cls, obj: Dict[str, Any], *, resolve: bool = True
+    ) -> Type[BaseModel]:
         """Create a schema for a promise dict (referencing a registry function)
         by inspecting the function signature.
         """
         reg_name, func_name = cls.get_constructor(obj)
+        if not resolve and not cls.has(reg_name, func_name):
+            return EmptySchema
         func = cls.get(reg_name, func_name)
         # Read the argument annotations and defaults from the function signature
         id_keys = [k for k in obj.keys() if k.startswith("@")]

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -686,7 +686,7 @@ class registry(object):
         setattr(cls, registry_name, reg)
 
     @classmethod
-    def has(cls, registry_name: str, func_name: str) -> Callable:
+    def has(cls, registry_name: str, func_name: str) -> bool:
         """Check whether a function is available in a registry."""
         if not hasattr(cls, registry_name):
             return False

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Iterable, Union, Optional, List, Callable, Dict
+from typing import Iterable, Union, Optional, List, Callable, Dict, Any
 from types import GeneratorType
 from pydantic import BaseModel, StrictBool, StrictFloat, PositiveInt, constr
 import catalogue
@@ -1319,3 +1319,12 @@ def test_config_fill_without_resolve():
     assert filled2["catsie"]["cute"] is True
     resolved = my_registry.resolve(filled2)
     assert resolved["catsie"] == "meow"
+    # With unavailable function
+    class BaseSchema2(BaseModel):
+        catsie: Any
+        other: int = 12
+
+    config = {"catsie": {"@cats": "dog", "evil": False}}
+    filled3 = my_registry.fill(config, schema=BaseSchema2)
+    assert filled3["catsie"] == config["catsie"]
+    assert filled3["other"] == 12


### PR DESCRIPTION
If we're just filling a config, promises that refer to registered functions that are not available should be ignored.