### PR TITLE
Add Model methods to check deserialization compatibility

### DIFF
--- a/thinc/model.py
+++ b/thinc/model.py
@@ -568,7 +568,7 @@ class Model(Generic[InT, OutT]):
         return self
 
 
-    def can_from_disk(self, path: Union[Path, str], *, strict: bool=False) -> bool:
+    def can_from_disk(self, path: Union[Path, str], *, strict: bool=True) -> bool:
         """Check whether serialized data on disk is compatible with the model.
         If 'strict', the function returns False if the model would resize to
         load the data.
@@ -581,7 +581,7 @@ class Model(Generic[InT, OutT]):
         return self.can_from_bytes(bytes_data, strict=strict)
 
 
-    def can_from_bytes(self, bytes_data: bytes, *, strict: bool=False) -> bool:
+    def can_from_bytes(self, bytes_data: bytes, *, strict: bool=True) -> bool:
         """Check whether the bytes data is compatible with the model. If 'strict',
         the function returns False if the model would resize to load the data.
         """
@@ -591,7 +591,7 @@ class Model(Generic[InT, OutT]):
             return False
         return self.can_from_dict(msg, strict=strict)
 
-    def can_from_dict(self, msg: Dict, *, strict: bool=False) -> bool:
+    def can_from_dict(self, msg: Dict, *, strict: bool=True) -> bool:
         """Check whether a dictionary is compatible with the model.
         If 'strict', the function returns False if the model would resize to
         load the data.

--- a/thinc/tests/test_serialize.py
+++ b/thinc/tests/test_serialize.py
@@ -187,19 +187,14 @@ def test_simple_model_can_from_dict():
     # Test check without initialize
     assert Maxout(5, 10, nP=2).can_from_dict(model_dict)
     # Test not-strict check 
-    assert Maxout(10, 5, nP=2).can_from_dict(model_dict, strict=False)
-    # Test strict check, where sizes must be compatible.
-    assert not Maxout(10, 5, nP=2).can_from_dict(model_dict, strict=True)
-    assert Maxout(5, nP=2).can_from_dict(model_dict, strict=True)
+    assert not Maxout(10, 5, nP=2).can_from_dict(model_dict)
+    assert Maxout(5, nP=2).can_from_dict(model_dict)
 
 
 def test_multi_model_can_from_dict():
     model = chain(Maxout(5, 10, nP=2), Maxout(2, 3)).initialize()
     model_dict = model.to_dict()
     assert model.can_from_dict(model_dict)
-    # Test check without initialize
     assert chain(Maxout(5, 10, nP=2), Maxout(2, 3)).can_from_dict(model_dict)
-    # Test not-strict check 
     resized = chain(Maxout(5, 10, nP=3), Maxout(2, 3))
-    assert resized.can_from_dict(model_dict, strict=False)
-    assert not resized.can_from_dict(model_dict, strict=True)
+    assert not resized.can_from_dict(model_dict)

--- a/thinc/tests/test_serialize.py
+++ b/thinc/tests/test_serialize.py
@@ -178,3 +178,28 @@ def test_serialize_attrs():
     assert model4.attrs["test"].value == "foo"
     result = deserialize_attr(model4.attrs["test"], bytes_attr, "test", model4)
     assert result.value == "foo from bytes"
+
+
+def test_simple_model_can_from_dict():
+    model = Maxout(5, 10, nP=2).initialize()
+    model_dict = model.to_dict()
+    assert model.can_from_dict(model_dict)
+    # Test check without initialize
+    assert Maxout(5, 10, nP=2).can_from_dict(model_dict)
+    # Test not-strict check 
+    assert Maxout(10, 5, nP=2).can_from_dict(model_dict, strict=False)
+    # Test strict check, where sizes must be compatible.
+    assert not Maxout(10, 5, nP=2).can_from_dict(model_dict, strict=True)
+    assert Maxout(5, nP=2).can_from_dict(model_dict, strict=True)
+
+
+def test_multi_model_can_from_dict():
+    model = chain(Maxout(5, 10, nP=2), Maxout(2, 3)).initialize()
+    model_dict = model.to_dict()
+    assert model.can_from_dict(model_dict)
+    # Test check without initialize
+    assert chain(Maxout(5, 10, nP=2), Maxout(2, 3)).can_from_dict(model_dict)
+    # Test not-strict check 
+    resized = chain(Maxout(5, 10, nP=3), Maxout(2, 3))
+    assert resized.can_from_dict(model_dict, strict=False)
+    assert not resized.can_from_dict(model_dict, strict=True)

--- a/website/docs/api-model.md
+++ b/website/docs/api-model.md
@@ -623,7 +623,7 @@ Check whether bytes data is compatible with the model for deserialization.
 | Argument          | Type                      | Description                  |
 | ----------------- | ------------------------- | ---------------------------- |
 |  `bytes_data`     | <tt>bytes</tt> | The bytestring to check.                |
-|  `strict`         | <tt>bool</tt>  | Whether to require dimensions to match. |
+|  `strict`         | <tt>bool</tt>  | Whether to require attributes to match. |
 | **RETURNS**       | <tt>bool</tt>  | Whether the data is compatible.         |
 
 ### Model.can_from_bytes {#can_from_bytes tag="method"}
@@ -633,7 +633,7 @@ Check whether a path is compatible with the model for deserialization.
 | Argument          | Type                      | Description         |
 | ----------------- | ------------------------- | ------------------- |
 |  `path`           | <tt>Union[Path, str]</tt> | The path to check.  |
-|  `strict`         | <tt>bool</tt>             | Whether to require dimensions to match. |
+|  `strict`         | <tt>bool</tt>             | Whether to require attributes to match. |
 | **RETURNS**       | <tt>Model</tt>            | Whether the path is compatible. |
 
 ### Model.can_from_dict {#from_dict tag="method"}
@@ -643,7 +643,7 @@ Check whether a dictionary is compatible with the model for deserialization.
 | Argument    | Type           | Description       |
 | ----------- | -------------- | ----------------- |
 | `msg`       | <tt>dict</tt>  | The data to check. |
-| `strict`    | <tt>bool</tt>  | Whether to require dimensions to match. |
+| `strict`    | <tt>bool</tt>  | Whether to require attributes to match. |
 | **RETURNS** | <tt>Model</tt> | Whether the data is compatible. |
 
 ---

--- a/website/docs/api-model.md
+++ b/website/docs/api-model.md
@@ -597,9 +597,9 @@ should just be the bytes contents of [`Model.to_bytes`](#to_bytes).
 model.to_disk("/path/to/model")
 ```
 
-| Argument | Type                      | Description                     |
-| -------- | ------------------------- | ------------------------------- |
-|  `path`  | <tt>Union[Path, str]</tt> | Directory to save the model to. |
+| Argument | Type                      | Description                             |
+| -------- | ------------------------- | --------------------------------------- |
+|  `path`  | <tt>Union[Path, str]</tt> | File or directory to save the model to. |
 
 ### Model.from_disk {#from_disk tag="method"}
 
@@ -615,6 +615,36 @@ model = Model().from_disk("/path/to/model")
 | ----------- | ------------------------- | --------------------------------- |
 |  `path`     | <tt>Union[Path, str]</tt> | Directory to load the model from. |
 | **RETURNS** | <tt>Model</tt>            | The loaded model.                 |
+
+### Model.can_from_bytes {#can_from_bytes tag="method"}
+
+Check whether bytes data is compatible with the model for deserialization.
+
+| Argument          | Type                      | Description                  |
+| ----------------- | ------------------------- | ---------------------------- |
+|  `bytes_data`     | <tt>bytes</tt> | The bytestring to check.                |
+|  `strict`         | <tt>bool</tt>  | Whether to require dimensions to match. |
+| **RETURNS**       | <tt>bool</tt>  | Whether the data is compatible.         |
+
+### Model.can_from_bytes {#can_from_bytes tag="method"}
+
+Check whether a path is compatible with the model for deserialization.
+
+| Argument          | Type                      | Description         |
+| ----------------- | ------------------------- | ------------------- |
+|  `path`           | <tt>Union[Path, str]</tt> | The path to check.  |
+|  `strict`         | <tt>bool</tt>             | Whether to require dimensions to match. |
+| **RETURNS**       | <tt>Model</tt>            | Whether the path is compatible. |
+
+### Model.can_from_dict {#from_dict tag="method"}
+
+Check whether a dictionary is compatible with the model for deserialization.
+
+| Argument    | Type           | Description       |
+| ----------- | -------------- | ----------------- |
+| `msg`       | <tt>dict</tt>  | The data to check. |
+| `strict`    | <tt>bool</tt>  | Whether to require dimensions to match. |
+| **RETURNS** | <tt>Model</tt> | Whether the data is compatible. |
 
 ---
 


### PR DESCRIPTION
This should allow us to look before we leap to avoid confusing errors. I've called the methods `model.can_from_disk(path)`, `model.can_from_bytes(bytes_data)` and `model.can_from_dict(msg)`. By default, if the model is initialized and the data would cause us to change an attribute value that's already been set, we return `False`, even though that would be legal. This can be changed by setting `strict=False`.