### PR TITLE
upgrade pydantic pin to use field.default_factory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wasabi>=0.4.0,<1.1.0
 catalogue>=0.2.0,<3.0.0
 ml_datasets==0.2.0a0
 # Third-party dependencies
-pydantic>=1.4.0,<2.0.0
+pydantic>=1.5.0,<2.0.0
 numpy>=1.7.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     # Third-party dependencies
     setuptools
     numpy>=1.7.0
-    pydantic>=1.4.0,<2.0.0
+    pydantic>=1.5.0,<2.0.0
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"
     typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"


### PR DESCRIPTION
Need to have `pydantic>=1.5` to use `field.default_factory`
cf https://pydantic-docs.helpmanual.io/changelog/#v15-2020-04-18