### PR TITLE
require_cpu

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.0a44"
+__version__ = "8.0.0a45"
 __release__ = True

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -12,7 +12,7 @@ from .schedules import cyclic_triangular, warmup_linear, constant, constant_then
 from .schedules import decaying, slanted_triangular, compounding
 from .types import Ragged, Padded, ArgsKwargs, Unserializable
 from .util import fix_random_seed, is_cupy_array, set_active_gpu
-from .util import prefer_gpu, require_gpu, DataValidationError, data_validation
+from .util import prefer_gpu, require_gpu, require_cpu, DataValidationError, data_validation
 from .util import to_categorical, get_width, get_array_module, to_numpy
 from .util import torch2xp, xp2torch, tensorflow2xp, xp2tensorflow, mxnet2xp, xp2mxnet
 from .backends import get_ops, set_current_ops, get_current_ops, use_ops

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -75,10 +75,6 @@ class NumpyOps(Ops):
         return self.xp.zeros(shape, dtype=dtype)
 
     def gemm(self, np.ndarray x, np.ndarray y, *, np.ndarray out=None, trans1=False, trans2=False):
-        if x.ndim < 2:
-            raise ValueError("Provided 'x' array should have at least 2 dimensions.")
-        if y.ndim < 2:
-            raise ValueError("Provided 'y' array should have at least 2 dimensions.")
         if not self.use_blis:  # delegate to base Ops
             return super().gemm(x, y, out=out, trans1=trans1, trans2=trans2)
         x = self.as_contig(x)

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -75,6 +75,10 @@ class NumpyOps(Ops):
         return self.xp.zeros(shape, dtype=dtype)
 
     def gemm(self, np.ndarray x, np.ndarray y, *, np.ndarray out=None, trans1=False, trans2=False):
+        if x.ndim < 2:
+            raise ValueError("Provided 'x' array should have at least 2 dimensions.")
+        if y.ndim < 2:
+            raise ValueError("Provided 'y' array should have at least 2 dimensions.")
         if not self.use_blis:  # delegate to base Ops
             return super().gemm(x, y, out=out, trans1=trans1, trans2=trans2)
         x = self.as_contig(x)

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -537,7 +537,7 @@ class ConfigValidationError(ValueError):
         config (Union[Config, Dict[str, Dict[str, Any]], str]): The
             config the validation error refers to.
         errors (Iterable[Dict[str, Any]]): A list of errors as dicts with keys
-            "loc" (list of trings describing the path of the value), "msg"
+            "loc" (list of strings describing the path of the value), "msg"
             (validation message to show) and optional "type" (mostly internals).
             Same format as produced by pydantic's validation error (e.errors()).
         title (str): The error title.

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -148,6 +148,14 @@ def set_active_gpu(gpu_id: int) -> "cupy.cuda.Device":  # pragma: no cover
     return device
 
 
+def require_cpu() -> bool:  # pragma: no cover
+    """Use CPU through NumpyOps"""
+    from .backends import set_current_ops, NumpyOps
+
+    set_current_ops(NumpyOps())
+    return True
+
+
 def prefer_gpu(gpu_id: int = 0) -> bool:  # pragma: no cover
     """Use GPU if it's available. Returns True if so, False otherwise."""
     from .backends.cupy_ops import CupyOps

--- a/website/docs/api-util.md
+++ b/website/docs/api-util.md
@@ -18,6 +18,22 @@ fix_random_seed(0)
 | -------- | ------------ | -------------------------- |
 | `seed`   | <tt>int</tt> | The seed. Defaults to `0`. |
 
+### require_cpu {#require_cpu tag="function"}
+
+Allocate data and perform operations on CPU. 
+If data has already been allocated on GPU, it will not be moved.
+Ideally, this function should be called right after importing Thinc.
+
+```python
+### Example
+from thinc.api import require_cpu
+require_cpu()
+```
+
+| Argument    | Type          | Description |
+| ----------- | ------------- | ----------- |
+| **RETURNS** | <tt>bool</tt> | `True`.     |
+
 ### prefer_gpu {#prefer_gpu tag="function"}
 
 Allocate data and perform operations on GPU, if available. If data has already


### PR DESCRIPTION
Add convenience method `require_cpu` that makes sure to use `NumpyOps`.
Implemented after reading the discussion here: https://github.com/explosion/spaCy/issues/5018