### PR TITLE
Fix finalization method name for Beam

### DIFF
--- a/thinc/extra/search.pyx
+++ b/thinc/extra/search.pyx
@@ -86,7 +86,7 @@ cdef class Beam:
             self._parents[i].content = init_func(self.mem, n, extra_args)
         self.del_func = del_func
 
-    def __del__(self):
+    def __dealloc__(self):
         for i in range(self.width):
             self.del_func(self.mem, self._states[i].content, NULL)
             self.del_func(self.mem, self._parents[i].content, NULL)


### PR DESCRIPTION
Rename `Beam.__del__` to `Beam.__dealloc__`.