### PR TITLE
avoid initializing with Y if not necessary

### DIFF
--- a/thinc/layers/parametricattention.py
+++ b/thinc/layers/parametricattention.py
@@ -53,7 +53,7 @@ def _get_attention(ops, Q, X, lengths):
     return attention, get_attention_bwd
 
 
-def _apply_attention(self, attention, X, lengths):
+def _apply_attention(ops, attention, X, lengths):
     output = X * attention
 
     def apply_attention_bwd(d_output):

--- a/thinc/layers/residual.py
+++ b/thinc/layers/residual.py
@@ -53,7 +53,10 @@ def init(
     model: Model[InT, InT], X: Optional[InT] = None, Y: Optional[InT] = None
 ) -> Model[InT, InT]:
     first_layer = model.layers[0]
-    first_layer.initialize(X=X, Y=Y)
+    if first_layer.has_dim("nO") is None:
+        first_layer.initialize(X=X, Y=Y)
+    else:
+        first_layer.initialize(X=X)
     if first_layer.has_dim("nO"):
         model.set_dim("nO", first_layer.get_dim("nO"))
     if first_layer.has_dim("nI"):


### PR DESCRIPTION
Only initialize the internal layer of `residual` with `Y` if the output dim `nO` is yet to be determined.

This is necessary to avoid wrong shape inferences stemming from the `chain` layer. This is all a bit brittle, and perhaps we want to rethink the whole shape inference mechanism at some point, but for now I think this works.