### PR TITLE
Propagate dims

### DIFF
--- a/thinc/layers/lstm.py
+++ b/thinc/layers/lstm.py
@@ -57,11 +57,12 @@ def PyTorchLSTM(
         return noop()  # type: ignore
     if bi:
         nO = nO // 2
-    return with_padded(
-        PyTorchRNNWrapper(
+    pytorch_rnn = PyTorchRNNWrapper(
             torch.nn.LSTM(nI, nO, depth, bidirectional=bi, dropout=dropout)
         )
-    )
+    pytorch_rnn.set_dim("nO", nO)
+    pytorch_rnn.set_dim("nI", nI)
+    return with_padded(pytorch_rnn)
 
 
 def init(

--- a/thinc/layers/pytorchwrapper.py
+++ b/thinc/layers/pytorchwrapper.py
@@ -65,6 +65,7 @@ def PyTorchWrapper(
         forward,
         attrs={"convert_inputs": convert_inputs, "convert_outputs": convert_outputs},
         shims=[PyTorchShim(pytorch_model)],
+        dims={"nI": None, "nO": None},
     )
 
 

--- a/thinc/layers/with_array.py
+++ b/thinc/layers/with_array.py
@@ -6,12 +6,11 @@ from ..types import Array2d, Floats2d, Padded, Ragged, ArrayXd
 from ..types import List2d
 
 
-ValT = TypeVar("ValT", bound=Array2d)
 SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d, Array2d])
 
 
 @registry.layers("with_array.v1")
-def with_array(layer: Model[ValT, ValT], pad: int = 0) -> Model[SeqT, SeqT]:
+def with_array(layer: Model[Array2d, Array2d], pad: int = 0) -> Model[SeqT, SeqT]:
     """Transform sequence data into a contiguous 2d array on the way into and
     out of a model. Handles a variety of sequence types: lists, padded and ragged.
     If the input is a 2d array, it is passed through unchanged.

--- a/thinc/layers/with_array.py
+++ b/thinc/layers/with_array.py
@@ -6,11 +6,12 @@ from ..types import Array2d, Floats2d, Padded, Ragged, ArrayXd
 from ..types import List2d
 
 
+ValT = TypeVar("ValT", bound=Array2d)
 SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d, Array2d])
 
 
 @registry.layers("with_array.v1")
-def with_array(layer: Model[Array2d, Array2d], pad: int = 0) -> Model[SeqT, SeqT]:
+def with_array(layer: Model[ValT, ValT], pad: int = 0) -> Model[SeqT, SeqT]:
     """Transform sequence data into a contiguous 2d array on the way into and
     out of a model. Handles a variety of sequence types: lists, padded and ragged.
     If the input is a 2d array, it is passed through unchanged.

--- a/thinc/layers/with_cpu.py
+++ b/thinc/layers/with_cpu.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Callable, Any, Dict, Optional
+from typing import Tuple, Callable, Any
 
 import numpy
 from thinc.backends import Ops
@@ -10,16 +10,14 @@ from ..config import registry
 @registry.layers("with_cpu.v1")
 def with_cpu(layer: Model, ops: Ops) -> Model:
     layer.to_cpu()
-    dims: Dict[str, Optional[int]] = {"nO": None}
-    # set input dimension only if included layer has one - should be "False" otherwise
-    if layer.has_dim("nI") is True:
-        dims["nI"] = layer.get_dim("nI")
-    if layer.has_dim("nI") is None:
-        dims["nI"] = None
-    # set output dimension according to included layer
-    if layer.has_dim("nO") is True:
-        dims["nO"] = layer.get_dim("nO")
-    return Model(f"with_cpu({layer.name})", forward, layers=[layer], ops=ops, init=init, dims=dims)
+    return Model(
+        f"with_cpu({layer.name})",
+        forward,
+        layers=[layer],
+        ops=ops,
+        init=init,
+        dims={name: layer.maybe_get_dim(name) for name in layer.dim_names},
+    )
 
 
 def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:

--- a/thinc/layers/with_list.py
+++ b/thinc/layers/with_list.py
@@ -10,7 +10,13 @@ SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d])
 
 @registry.layers("with_list.v1")
 def with_list(layer: Model[List2d, List2d]) -> Model[SeqT, SeqT]:
-    return Model(f"with_list({layer.name})", forward, init=init, layers=[layer])
+    return Model(
+        f"with_list({layer.name})",
+        forward,
+        init=init,
+        layers=[layer],
+        dims={name: layer.maybe_get_dim(name) for name in layer.dim_names},
+    )
 
 
 def forward(

--- a/thinc/layers/with_padded.py
+++ b/thinc/layers/with_padded.py
@@ -7,13 +7,18 @@ from ..util import is_xp_array
 
 
 PaddedData = Tuple[Floats3d, Ints1d, Ints1d, Ints1d]
-ValT = TypeVar("ValT", bound=Array2d)
 SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d, Floats3d, PaddedData])
 
 
 @registry.layers("with_padded.v1")
 def with_padded(layer: Model[Padded, Padded]) -> Model[SeqT, SeqT]:
-    return Model(f"with_padded({layer.name})", forward, init=init, layers=[layer])
+    return Model(
+        f"with_padded({layer.name})",
+        forward,
+        init=init,
+        layers=[layer],
+        dims={name: layer.maybe_get_dim(name) for name in layer.dim_names},
+    )
 
 
 def forward(


### PR DESCRIPTION
spaCy issue https://github.com/explosion/spaCy/issues/6318 pointed towards some issues with inferring dimensions. To better support chaining layers and shape inference, this PR:
- transfers dimensions from the encapsulated layer in the `with_X` type-transformation layers
- sets an appropriate `nO` and `nI` dimension on the `PyTorchLSTM`