### PR TITLE
Remove detailed numpy build constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,6 @@ requires = [
     "preshed>=1.0.1,<3.1.0",
     "blis>=0.4.0,<0.5.0; python_version<'3.6'",
     "blis>=0.4.0,<0.8.0; python_version>='3.6'",
-    "numpy==1.15.0; python_version<='3.7'",
-    "numpy==1.17.3; python_version=='3.8'",
-    "numpy==1.19.3; python_version=='3.9'",
-    "numpy; python_version>='3.10'",
+    "numpy>=1.15.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
* Remove detailed numpy build constraints from `pyproject.toml` because
  it is too difficult to maintain for many architectures
  * These constraints are more a reflection of what is available on
    pypi as binary wheels rather than any real build requirements that
    it is necessary for users to follow when building from source
  * Users building their own binary packages will need to enforce the
    constraints that make sense in their environments, e.g., the `conda`
    compatible numpy pins

* Keep the build constraints in `build-constraints.txt` for use with our
  builds
  * Our builds with wheelwright are built against the earliest
    compatible binary versions of numpy on pypi
  * These constraints are documented within the distribution