### PR TITLE
Remove upper pin for torch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
       pip install "mxnet; sys_platform != 'win32'"
       # NOTE: need this to close for 1.5 on windows: https://github.com/pytorch/pytorch/issues/37209
       pip install "torch==1.4; sys_platform == 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
-      pip install "torch==1.6.0; sys_platform != 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch; sys_platform != 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ setup_requires =
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
     murmurhash>=0.28.0,<1.1.0
+    blis>=0.4.1,<0.8
 install_requires =
     # Explosion-provided dependencies
     blis>=0.4.1,<0.8
@@ -70,7 +71,7 @@ cuda101 =
 datasets =
     ml_datasets==0.2.0a0
 torch =
-    torch>=1.5.0,<1.7.0
+    torch>=1.5.0
 tensorflow =
     tensorflow>=2.0.0,<2.3.0
 mxnet =


### PR DESCRIPTION
`dataclasses` 0.8 should fix the python version compatibility issues for `torch` 1.7.0.