### PR TITLE
Forbid torch==1.7.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,9 @@ jobs:
       Python36Mac:
         imageName: 'macos-10.15'
         python.version: '3.6'
+      Python37Linux:
+        imageName: 'ubuntu-16.04'
+        python.version: '3.7'
       Python38Linux:
         imageName: 'ubuntu-16.04'
         python.version: '3.8'
@@ -75,7 +78,7 @@ jobs:
       pip install "mxnet; sys_platform != 'win32'"
       # NOTE: need this to close for 1.5 on windows: https://github.com/pytorch/pytorch/issues/37209
       pip install "torch==1.4; sys_platform == 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
-      pip install "torch==1.6.0; sys_platform != 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch!=1.7.0; sys_platform != 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ cuda101 =
 datasets =
     ml_datasets==0.2.0a0
 torch =
-    torch>=1.5.0,<1.7.0
+    torch>=1.5.0,!=1.7.0
 tensorflow =
     tensorflow>=2.0.0,<2.3.0
 mxnet =


### PR DESCRIPTION
The next release of torch after 1.7.0 should fix this, so just forbid 1.7.0 specifically.