### PR TITLE
Update torch pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ pip install thinc --pre
 
 See the [extended installation docs](https://thinc.ai/docs/install#extended) for details on optional dependencies for different backends and GPU. You might also want to [set up static type checking](https://thinc.ai/docs/install#type-checking) to take advantage of Thinc's type system.
 
+> ⚠️ If you have installed PyTorch and you are using Python 3.7+, uninstall the
+> package `dataclasses` with `pip uninstall dataclasses`, since it may have
+> been installed by PyTorch and is incompatible with Python 3.7+.
+
 ### 📓 Selected examples and notebooks
 
 Also see the [`/examples`](examples) directory and [usage documentation](https://thinc.ai/docs) for more examples. Most examples are Jupyter notebooks – to launch them on [Google Colab](https://colab.research.google.com) (with GPU support!) click on the button next to the notebook name.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,8 +80,8 @@ jobs:
       pip install tensorflow
       pip install "mxnet; sys_platform != 'win32'"
       # NOTE: need this to close for 1.5 on windows: https://github.com/pytorch/pytorch/issues/37209
-      pip install "torch==1.4; sys_platform == 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
-      pip install "torch==1.6.0; sys_platform != 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch==1.4.0+cpu; sys_platform == 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch==1.6.0+cpu; sys_platform != 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,15 @@ trigger:
   branches:
     include:
     - '*'
+  paths:
+    exclude:
+    - 'website/*'
+    - '*.md'
+pr:
+  paths:
+    exclude:
+    - 'website/*'
+    - '*.md'
 
 jobs:
 - job: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,9 +88,7 @@ jobs:
       pip install -r requirements.txt
       pip install tensorflow
       pip install "mxnet; sys_platform != 'win32'"
-      # NOTE: need this to close for 1.5 on windows: https://github.com/pytorch/pytorch/issues/37209
-      pip install "torch==1.4.0+cpu; sys_platform == 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
-      pip install "torch==1.6.0+cpu; sys_platform != 'win32'" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch==1.6.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ cuda101 =
 datasets =
     ml_datasets==0.2.0a0
 torch =
-    torch>=1.5.0,<1.7.0
+    torch>=1.5.0
 tensorflow =
     tensorflow>=2.0.0,<2.3.0
 mxnet =

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -41,6 +41,14 @@ $ conda install -c conda-forge thinc
 
 <quickstart title="Extended installation" id="extended" suffix=" --pre"></quickstart>
 
+<infobox variant="warning">
+
+If you have installed PyTorch and you are using Python 3.7+, uninstall the
+package `dataclasses` with `pip uninstall dataclasses`, since it may have been
+installed by PyTorch and is incompatible with Python 3.7+.
+
+</infobox>
+
 If you know your CUDA version, using the more explicit specifier allows `cupy`
 to be installed from a wheel, saving some compilation time. Once you have a
 GPU-enabled installation, the best way to activate it is to call


### PR DESCRIPTION
* Remove upper torch pin in extras, users are on their own to uninstall `dataclasses`
* Switch to `+cpu` in CI tests for smaller downloads