### PR TITLE
Make dataclasses work with Pydantic >= 1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wasabi>=0.4.0,<1.1.0
 catalogue>=0.2.0,<3.0.0
 ml_datasets==0.2.0a0
 # Third-party dependencies
-pydantic>=1.5.0,<1.7.0
+pydantic>=1.5.0,<1.8.0
 numpy>=1.7.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wasabi>=0.4.0,<1.1.0
 catalogue>=0.2.0,<3.0.0
 ml_datasets==0.2.0a0
 # Third-party dependencies
-pydantic>=1.5.0,<1.8.0
+pydantic>=1.7.1,<1.8.0
 numpy>=1.7.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     # Third-party dependencies
     setuptools
     numpy>=1.7.0
-    pydantic>=1.5.0,<1.8.0
+    pydantic>=1.7.1,<1.8.0
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"
     typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     # Third-party dependencies
     setuptools
     numpy>=1.7.0
-    pydantic>=1.5.0,<1.7.0
+    pydantic>=1.5.0,<1.8.0
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"
     typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -800,7 +800,7 @@ class Ragged:
     data: Array2d
     lengths: Ints1d
     data_shape: Tuple[int, ...]
-    _cumsums: Optional[Ints1d] = None
+    cumsums: Optional[Ints1d] = None
 
     def __init__(self, data: _Array, lengths: Ints1d):
         self.lengths = lengths
@@ -844,9 +844,9 @@ class Ragged:
             return Ragged(data.reshape(self.data_shape), self.lengths[index])
 
     def _get_cumsums(self) -> Ints1d:
-        if self._cumsums is None:
-            self._cumsums = self.lengths.cumsum()
-        return self._cumsums
+        if self.cumsums is None:
+            self.cumsums = self.lengths.cumsum()
+        return self.cumsums
 
     def _get_starts(self) -> Ints1d:
         cumsums = self._get_cumsums()


### PR DESCRIPTION
Don't use private dataclass fields for now (which conflict with the way Pydantic validates dataclasses in > 1.7).  This should make Thinc and by extension spaCy work with the latest Pydantic and Python 3.9.