### PR TITLE
fix ResourceWarning for opening a file without explicitly closing it

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -34,10 +34,10 @@ def compile_mmh(src):
 
 
 PWD = Path(__file__).parent
-SRC = (PWD / "_custom_kernels.cu").open("r", encoding="utf8").read()
+SRC = (PWD / "_custom_kernels.cu").read_text(encoding="utf8")
 KERNELS = compile_kernels(SRC)
 
-MMH_SRC = (PWD / "_murmur3.cu").open("r", encoding="utf8").read()
+MMH_SRC = (PWD / "_murmur3.cu").read_text(encoding="utf8")
 KERNELS["hash"] = compile_mmh(MMH_SRC)
 
 seq2col_kernel = KERNELS["seq2col"]


### PR DESCRIPTION
Running pytest on my project results with the following error:
```shell
/usr/local/lib64/python3.8/site-packages/thinc/neural/_custom_kernels.py:36                                                                                                                                      
  /usr/local/lib64/python3.8/site-packages/thinc/neural/_custom_kernels.py:36: ResourceWarning: unclosed file <_io.TextIOWrapper name='/usr/local/lib64/python3.8/site-packages/thinc/neural/_custom_kernels.cu' mo
de='r' encoding='utf8'>                                                                                                                                                                                            
    SRC = (PWD / "_custom_kernels.cu").open("r", encoding="utf8").read() 
```

This happens because in `_custom_kernels.py` file you open a file without explicitly closing it. I replaced your `open` call with a `read_text` call.