### PR TITLE
Add reduce_first and reduce_last layers

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -33,7 +33,7 @@ from .layers import with_reshape, with_getitem, strings2arrays, list2array
 from .layers import list2ragged, ragged2list, list2padded, padded2list, remap_ids
 from .layers import array_getitem, with_cpu, with_debug
 
-from .layers import reduce_max, reduce_mean, reduce_sum
+from .layers import reduce_first, reduce_last, reduce_max, reduce_mean, reduce_sum
 
 
 __all__ = list(locals().keys())

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -32,6 +32,8 @@ from .uniqued import uniqued
 from .siamese import siamese
 
 # Pooling
+from .reduce_first import reduce_first
+from .reduce_last import reduce_last
 from .reduce_max import reduce_max
 from .reduce_mean import reduce_mean
 from .reduce_sum import reduce_sum
@@ -88,6 +90,8 @@ __all__ = [
     "residual",
     "uniqued",
     "siamese",
+    "reduce_first",
+    "reduce_last",
     "reduce_max",
     "reduce_mean",
     "reduce_sum",

--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -62,7 +62,10 @@ def _array_forward(
         start = widths[0]
         for bwd, width in zip(callbacks[1:], widths[1:]):
             dY = model.ops.as_contig(d_output[:, start : start + width])
-            dX += bwd(dY)
+            if isinstance(dX, Ragged):
+                dX.data += bwd(dY).data
+            else:
+                dX += bwd(dY)
             start += width
         return dX
 

--- a/thinc/layers/reduce_first.py
+++ b/thinc/layers/reduce_first.py
@@ -1,0 +1,25 @@
+from typing import Callable, Tuple, cast
+
+from ..model import Model
+from ..config import registry
+from ..types import Floats2d, Ragged
+
+
+@registry.layers("reduce_fist.v1")
+def reduce_first() -> Model[Ragged, Floats2d]:
+    return Model("reduce_first", forward)
+
+
+def forward(model: Model[Ragged, Floats2d], Xr: Ragged, is_train: bool) -> Tuple[Floats2d, Callable]:
+    starts = model.ops.alloc1i(Xr.lengths.shape[0])
+    starts[1:] += Xr.lengths.cumsum()[:-1]
+    Y = Xr.dataXd[starts]
+    x_shape = Xr.dataXd.shape
+    lengths = Xr.lengths
+
+    def backprop(dY: Floats2d) -> Ragged:
+        dX = model.ops.alloc2f(*x_shape, dtype=dY.dtype)
+        dX[starts] = dY
+        return Ragged(dX, lengths)
+
+    return Y, backprop

--- a/thinc/layers/reduce_first.py
+++ b/thinc/layers/reduce_first.py
@@ -21,8 +21,8 @@ def forward(model: Model[Ragged, OutT], Xr: Ragged, is_train: bool) -> Tuple[Out
     lengths = Xr.lengths
 
     def backprop(dY: OutT) -> Ragged:
-        dX = cast(OutT, model.ops.alloc(*x_shape, dtype=dY.dtype))
-        dX[ends] = dY # type: ignore
+        dX = cast(OutT, model.ops.alloc(x_shape, dtype=dY.dtype))
+        dX[starts] = dY # type: ignore
         return Ragged(dX, lengths)
 
     return Y, backprop

--- a/thinc/layers/reduce_last.py
+++ b/thinc/layers/reduce_last.py
@@ -1,25 +1,27 @@
-from typing import Callable, Tuple, cast
+from typing import Callable, Tuple, cast, TypeVar
 
 from ..model import Model
 from ..config import registry
-from ..types import Floats2d, Ragged
+from ..types import Ragged, ArrayXd
 
+OutT = TypeVar("OutT", bound=ArrayXd)
 
 @registry.layers("reduce_last.v1")
-def reduce_last() -> Model[Ragged, Floats2d]:
+def reduce_last() -> Model[Ragged, OutT]:
+    """Reduce sequences to their last element."""
     return Model("reduce_last", forward)
 
 
-def forward(model: Model[Ragged, Floats2d], Xr: Ragged, is_train: bool) -> Tuple[Floats2d, Callable]:
+def forward(model: Model[Ragged, OutT], Xr: Ragged, is_train: bool) -> Tuple[OutT, Callable]:
     ends = Xr.lengths - 1
     ends[1:] += Xr.lengths.cumsum()[:-1]
-    Y = Xr.dataXd[ends]
+    Y = cast(OutT, Xr.dataXd[ends]) # type: ignore
     x_shape = Xr.dataXd.shape
     lengths = Xr.lengths
 
-    def backprop(dY: Floats2d) -> Ragged:
-        dX = model.ops.alloc2f(*x_shape, dtype=dY.dtype)
-        dX[ends] = dY
+    def backprop(dY: OutT) -> Ragged:
+        dX = cast(OutT, model.ops.alloc(*x_shape, dtype=dY.dtype))
+        dX[ends] = dY # type: ignore
         return Ragged(dX, lengths)
 
     return Y, backprop

--- a/thinc/layers/reduce_last.py
+++ b/thinc/layers/reduce_last.py
@@ -20,7 +20,7 @@ def forward(model: Model[Ragged, OutT], Xr: Ragged, is_train: bool) -> Tuple[Out
     lengths = Xr.lengths
 
     def backprop(dY: OutT) -> Ragged:
-        dX = cast(OutT, model.ops.alloc(*x_shape, dtype=dY.dtype))
+        dX = cast(OutT, model.ops.alloc(x_shape, dtype=dY.dtype))
         dX[ends] = dY # type: ignore
         return Ragged(dX, lengths)
 

--- a/thinc/layers/reduce_last.py
+++ b/thinc/layers/reduce_last.py
@@ -1,0 +1,25 @@
+from typing import Callable, Tuple, cast
+
+from ..model import Model
+from ..config import registry
+from ..types import Floats2d, Ragged
+
+
+@registry.layers("reduce_last.v1")
+def reduce_last() -> Model[Ragged, Floats2d]:
+    return Model("reduce_last", forward)
+
+
+def forward(model: Model[Ragged, Floats2d], Xr: Ragged, is_train: bool) -> Tuple[Floats2d, Callable]:
+    ends = Xr.lengths - 1
+    ends[1:] += Xr.lengths.cumsum()[:-1]
+    Y = Xr.dataXd[ends]
+    x_shape = Xr.dataXd.shape
+    lengths = Xr.lengths
+
+    def backprop(dY: Floats2d) -> Ragged:
+        dX = model.ops.alloc2f(*x_shape, dtype=dY.dtype)
+        dX[ends] = dY
+        return Ragged(dX, lengths)
+
+    return Y, backprop

--- a/thinc/tests/layers/test_reduce_first_last.py
+++ b/thinc/tests/layers/test_reduce_first_last.py
@@ -1,0 +1,47 @@
+import pytest
+import numpy
+from thinc.api import reduce_first, reduce_last
+from thinc.types import Ragged
+
+@pytest.fixture
+def Xs():
+    seqs = [numpy.zeros((10, 8), dtype="f"), numpy.zeros((4, 8), dtype="f")]
+    for x in seqs:
+        x[0] = 1
+        x[-1] = -1
+    return seqs
+
+
+def test_init_reduce_first():
+    model = reduce_first()
+
+def test_init_reduce_last():
+    model = reduce_last()
+
+
+def test_reduce_first(Xs):
+    model = reduce_first()
+    lengths = model.ops.asarray([x.shape[0] for x in Xs], dtype="i")
+    X = Ragged(model.ops.flatten(Xs), lengths)
+    Y, backprop = model(X, is_train=True)
+    assert isinstance(Y, numpy.ndarray)
+    assert Y.shape == (len(Xs), Xs[0].shape[1])
+    assert Y.dtype == Xs[0].dtype
+    assert list(Y[0]) == list(Xs[0][0])
+    assert list(Y[1]) == list(Xs[1][0])
+    dX = backprop(Y)
+    assert dX.dataXd.shape == X.dataXd.shape
+
+
+def test_reduce_last(Xs):
+    model = reduce_last()
+    lengths = model.ops.asarray([x.shape[0] for x in Xs], dtype="i")
+    X = Ragged(model.ops.flatten(Xs), lengths)
+    Y, backprop = model(X, is_train=True)
+    assert isinstance(Y, numpy.ndarray)
+    assert Y.shape == (len(Xs), Xs[0].shape[1])
+    assert Y.dtype == Xs[0].dtype
+    assert list(Y[0]) == list(Xs[0][-1])
+    assert list(Y[1]) == list(Xs[1][-1])
+    dX = backprop(Y)
+    assert dX.dataXd.shape == X.dataXd.shape

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -200,7 +200,7 @@ def to_categorical(Y: IntsXd, n_classes: Optional[int] = None) -> FloatsXd:
     if xp is cupy:  # pragma: no cover
         Y = Y.get()
     keep_shapes: List[int] = list(Y.shape)
-    Y = numpy.array(Y, dtype="int").ravel()
+    Y = numpy.array(Y, dtype="int").ravel() # type: ignore
     if n_classes is None:
         n_classes = int(numpy.max(Y) + 1)
     keep_shapes.append(n_classes)


### PR DESCRIPTION
I've wanted these for a while. They're especially useful after LSTM and transformer models, where it makes sense to interpret the first or last vector as the representation of the whole sequence.