### PR TITLE
Separate with_array and with_array2d layers

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -28,7 +28,8 @@ from .layers import TensorFlowWrapper, keras_subclass, MXNetWrapper
 
 from .layers import add, bidirectional, chain, clone, concatenate, noop
 from .layers import residual, uniqued, siamese, list2ragged, ragged2list
-from .layers import with_array, with_padded, with_list, with_ragged, with_flatten
+from .layers import with_array, with_array2d
+from .layers import with_padded, with_list, with_ragged, with_flatten
 from .layers import with_reshape, with_getitem, strings2arrays, list2array
 from .layers import list2ragged, ragged2list, list2padded, padded2list, remap_ids
 from .layers import array_getitem, with_cpu, with_debug

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -50,6 +50,7 @@ from .padded2list import padded2list
 from .remap_ids import remap_ids
 from .strings2arrays import strings2arrays
 from .with_array import with_array
+from .with_array2d import with_array2d
 from .with_cpu import with_cpu
 from .with_flatten import with_flatten
 from .with_padded import with_padded
@@ -103,6 +104,7 @@ __all__ = [
     "with_reshape",
     "with_getitem",
     "with_array",
+    "with_array2d",
     "with_cpu",
     "with_list",
     "with_ragged",

--- a/thinc/layers/with_array.py
+++ b/thinc/layers/with_array.py
@@ -2,16 +2,15 @@ from typing import Tuple, Callable, Optional, TypeVar, Union, cast
 
 from ..model import Model
 from ..config import registry
-from ..types import Array2d, Floats2d, Padded, Ragged, ArrayXd
+from ..types import Array2d, Floats2d, Padded, Ragged, ArrayXd, Floats3d
 from ..types import List2d
 
 
-ValT = TypeVar("ValT", bound=ArrayXd)
 SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d, ArrayXd])
 
 
 @registry.layers("with_array.v1")
-def with_array(layer: Model[ValT, ValT], pad: int = 0) -> Model[SeqT, SeqT]:
+def with_array(layer: Model[ArrayXd, ArrayXd], pad: int = 0) -> Model[SeqT, SeqT]:
     """Transform sequence data into a contiguous 2d array on the way into and
     out of a model. Handles a variety of sequence types: lists, padded and ragged.
     If the input is a 2d array, it is passed through unchanged.
@@ -44,7 +43,7 @@ def forward(model: Model[SeqT, SeqT], Xseq: SeqT, is_train: bool):
 def init(
     model: Model[SeqT, SeqT], X: Optional[SeqT] = None, Y: Optional[SeqT] = None
 ) -> Model[SeqT, SeqT]:
-    layer: Model[Array2d, Array2d] = model.layers[0]
+    layer: Model[ArrayXd, ArrayXd] = model.layers[0]
     layer.initialize(
         X=_get_array(model, X) if X is not None else X,
         Y=_get_array(model, Y) if Y is not None else Y,
@@ -56,7 +55,7 @@ def init(
     return model
 
 
-def _get_array(model, X: SeqT) -> Array2d:
+def _get_array(model, X: SeqT) -> ArrayXd:
     if isinstance(X, Ragged):
         return X.dataXd
     elif isinstance(X, Padded):
@@ -99,7 +98,7 @@ def _ragged_forward(
 def _padded_forward(
     model: Model[Padded, Padded], Xp: Padded, is_train: bool
 ) -> Tuple[Padded, Callable]:
-    layer: Model[ArrayXd, ArrayXd] = model.layers[0]
+    layer: Model[Floats3d, Floats3d] = model.layers[0]
     Y, get_dX = layer(Xp.data, is_train)
 
     def backprop(dYp: Padded) -> Padded:

--- a/thinc/layers/with_array2d.py
+++ b/thinc/layers/with_array2d.py
@@ -1,0 +1,125 @@
+from typing import Tuple, Callable, Optional, TypeVar, Union, cast
+
+from ..model import Model
+from ..config import registry
+from ..types import Array2d, Floats2d, Padded, Ragged, ArrayXd
+from ..types import List2d
+
+
+ValT = TypeVar("ValT", bound=Array2d)
+SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, List2d, Array2d])
+
+
+@registry.layers("with_array2d.v1")
+def with_array2d(layer: Model[ValT, ValT], pad: int = 0) -> Model[SeqT, SeqT]:
+    """Transform sequence data into a contiguous 2d array on the way into and
+    out of a model. Handles a variety of sequence types: lists, padded and ragged.
+    If the input is a 2d array, it is passed through unchanged.
+    """
+    return Model(
+        f"with_array({layer.name})",
+        forward,
+        init=init,
+        layers=[layer],
+        attrs={"pad": pad},
+        dims={name: layer.maybe_get_dim(name) for name in layer.dim_names},
+    )
+
+
+def forward(model: Model[SeqT, SeqT], Xseq: SeqT, is_train: bool):
+    if isinstance(Xseq, Ragged):
+        return _ragged_forward(
+            cast(Model[Ragged, Ragged], model), cast(Ragged, Xseq), is_train
+        )
+    elif isinstance(Xseq, Padded):
+        return _padded_forward(
+            cast(Model[Padded, Padded], model), cast(Padded, Xseq), is_train
+        )
+    elif not isinstance(Xseq, (list, tuple)):
+        return model.layers[0](Xseq, is_train)
+    else:
+        return _list_forward(cast(Model[List2d, List2d], model), Xseq, is_train)
+
+
+def init(
+    model: Model[SeqT, SeqT], X: Optional[SeqT] = None, Y: Optional[SeqT] = None
+) -> Model[SeqT, SeqT]:
+    layer: Model[Array2d, Array2d] = model.layers[0]
+    layer.initialize(
+        X=_get_array(model, X) if X is not None else X,
+        Y=_get_array(model, Y) if Y is not None else Y,
+    )
+    for dim_name in layer.dim_names:
+        value = layer.maybe_get_dim(dim_name)
+        if value is not None:
+            model.set_dim(dim_name, value)
+    return model
+
+
+def _get_array(model, X: SeqT) -> Array2d:
+    if isinstance(X, Ragged):
+        return X.data
+    elif isinstance(X, Padded):
+        return model.ops.reshape2f(
+            X.data, X.data.shape[0] * X.data.shape[1], X.data.shape[2]
+        )
+    elif not isinstance(X, (list, tuple)):
+        return cast(Array2d, X)
+    else:
+        return model.ops.flatten(X)
+
+
+def _list_forward(
+    model: Model[List2d, List2d], Xs: List2d, is_train: bool
+) -> Tuple[List2d, Callable]:
+    layer = model.layers[0]
+    pad = model.attrs["pad"]
+    lengths = layer.ops.asarray1i([len(seq) for seq in Xs])
+    Xf = layer.ops.flatten(Xs, pad=pad)  # type: ignore
+    Yf, get_dXf = layer(Xf, is_train)
+
+    def backprop(dYs: List2d) -> List2d:
+        dYf = layer.ops.flatten(dYs, pad=pad)  # type: ignore
+        dXf = get_dXf(dYf)
+        return layer.ops.unflatten(dXf, lengths, pad=pad)
+
+    return layer.ops.unflatten(Yf, lengths, pad=pad), backprop
+
+
+def _ragged_forward(
+    model: Model[Ragged, Ragged], Xr: Ragged, is_train: bool
+) -> Tuple[Ragged, Callable]:
+    layer: Model[Array2d, ArrayXd] = model.layers[0]
+    Y, get_dX = layer(Xr.data, is_train)
+    x_shape = Xr.dataXd.shape
+
+    def backprop(dYr: Ragged) -> Ragged:
+        return Ragged(get_dX(dYr.dataXd).reshape(x_shape), dYr.lengths)
+    
+    return Ragged(Y, Xr.lengths), backprop
+
+
+def _padded_forward(
+    model: Model[Padded, Padded], Xp: Padded, is_train: bool
+) -> Tuple[Padded, Callable]:
+    layer: Model[Array2d, Array2d] = model.layers[0]
+    X = model.ops.reshape2f(
+        Xp.data, Xp.data.shape[0] * Xp.data.shape[1], Xp.data.shape[2]
+    )
+    Y2d, get_dX = layer(X, is_train)
+    Y = model.ops.reshape3f(
+        cast(Floats2d, Y2d), Xp.data.shape[0], Xp.data.shape[1], Y2d.shape[1]
+    )
+
+    def backprop(dYp: Padded) -> Padded:
+        assert isinstance(dYp, Padded)
+        dY = model.ops.reshape2f(
+            dYp.data, dYp.data.shape[0] * dYp.data.shape[1], dYp.data.shape[2]
+        )
+        dX2d = get_dX(dY)
+        dX = model.ops.reshape3f(
+            dX2d, dYp.data.shape[0], dYp.data.shape[1], dX2d.shape[1]
+        )
+        return Padded(dX, dYp.size_at_t, dYp.lengths, dYp.indices)
+
+    return Padded(Y, Xp.size_at_t, Xp.lengths, Xp.indices), backprop

--- a/thinc/tests/layers/test_with_transforms.py
+++ b/thinc/tests/layers/test_with_transforms.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy
 from thinc.api import NumpyOps, Model, Linear
-from thinc.api import with_array, with_padded, with_list, with_ragged, with_getitem
+from thinc.api import with_array2d, with_padded, with_list, with_ragged, with_getitem
 from thinc.types import Padded, Ragged
 
 
@@ -64,7 +64,7 @@ def get_array_model():
 
         return X[:, :-1], backprop
 
-    return with_array(Model("trimarray", _trim_array_forward))
+    return with_array2d(Model("trimarray", _trim_array_forward))
 
 
 def get_list_model():


### PR DESCRIPTION
When working on more examples, I've found I often need the `with_array` layer to behave differently than how we had it. I wanted it to not reshape the data, so that I can easily get at the `Array3d` that's behind a `Padded` layer. But other times you do want to get the concatenated sequence representation back out.

My answer is to have two layers, `with_array` and `with_array2d`. I think it's better to have a different wrapper than to have an argument, because with an argument the type signatures get out of control.