### PR TITLE
Disable default input/output validation on initialize

### DIFF
--- a/thinc/tests/model/test_validation.py
+++ b/thinc/tests/model/test_validation.py
@@ -6,12 +6,13 @@ from thinc.util import DataValidationError
 
 def test_validation():
     model = chain(Relu(10), Relu(10), with_ragged(reduce_max()), Softmax())
-    with pytest.raises(DataValidationError):
-        model.initialize(X=model.ops.alloc2f(1, 10), Y=model.ops.alloc2f(1, 10))
-    with pytest.raises(DataValidationError):
-        model.initialize(X=model.ops.alloc3f(1, 10, 1), Y=model.ops.alloc2f(1, 10))
-    with pytest.raises(DataValidationError):
-        model.initialize(X=[model.ops.alloc2f(1, 10)], Y=model.ops.alloc2f(1, 10))
+    with data_validation(True):
+        with pytest.raises(DataValidationError):
+            model.initialize(X=model.ops.alloc2f(1, 10), Y=model.ops.alloc2f(1, 10))
+        with pytest.raises(DataValidationError):
+            model.initialize(X=model.ops.alloc3f(1, 10, 1), Y=model.ops.alloc2f(1, 10))
+        with pytest.raises(DataValidationError):
+            model.initialize(X=[model.ops.alloc2f(1, 10)], Y=model.ops.alloc2f(1, 10))
 
 
 def test_validation_complex():
@@ -29,5 +30,6 @@ def test_validation_complex():
         ParametricAttention(12),
         Relu(1),
     )
-    with pytest.raises(DataValidationError):
-        bad_model.initialize(X, Y)
+    with data_validation(True):
+        with pytest.raises(DataValidationError):
+            bad_model.initialize(X, Y)

--- a/thinc/tests/model/test_validation.py
+++ b/thinc/tests/model/test_validation.py
@@ -1,7 +1,7 @@
 import pytest
 from thinc.api import chain, Relu, reduce_max, Softmax, with_ragged
 from thinc.api import ParametricAttention, list2ragged, reduce_sum
-from thinc.util import DataValidationError
+from thinc.util import DataValidationError, data_validation
 
 
 def test_validation():

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -12,7 +12,7 @@ import threading
 import contextlib
 from contextvars import ContextVar
 
-DATA_VALIDATION: ContextVar[bool] = ContextVar("DATA_VALIDATION", default=True)
+DATA_VALIDATION: ContextVar[bool] = ContextVar("DATA_VALIDATION", default=False)
 
 try:  # pragma: no cover
     import cupy


### PR DESCRIPTION
This PR disables the default type validation that would happen on `model.initialize()`, as it causes runtime errors if types are wrong. Specifying types entirely correctly can be fiddly, so raising runtime errors from the types can lead to problems.

A particular problem at the moment is that the `chain()` combinator cheats and passes in the Y output into non-final layers to assist with shape inference. This means that layers which define a type on that Y variable during init can fail validation. While the current state is a hack, more generally I think it's a bad idea to have a default that raises a runtime error on the types. The type errors also are not necessarily easier to debug than the runtime error.