### PR TITLE
Deprecate name 'Logistic' in favour of Sigmoid and sigmoid_activation layers

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -22,6 +22,7 @@ from .backends import use_pytorch_for_gpu_memory, use_tensorflow_for_gpu_memory
 from .layers import Dropout, Embed, expand_window, HashEmbed, LayerNorm, Linear
 from .layers import Maxout, Mish, MultiSoftmax, Relu, softmax_activation, Softmax, LSTM
 from .layers import CauchySimilarity, ParametricAttention, Logistic
+from .layers import sigmoid_activation, Sigmoid
 from .layers import SparseLinear
 from .layers import PyTorchWrapper, PyTorchRNNWrapper, PyTorchLSTM
 from .layers import TensorFlowWrapper, keras_subclass, MXNetWrapper

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -12,6 +12,7 @@ from ..util import get_array_module, is_xp_array, to_numpy
 
 ArrayT = TypeVar("ArrayT", bound=ArrayXd)
 FloatsT = TypeVar("FloatsT", bound=_Floats)
+FloatsType = TypeVar("FloatsType", bound=FloatsXd)
 
 
 class Ops:
@@ -558,16 +559,16 @@ class Ops:
         kwargs = {"dtype": dtype} if dtype is not None else {}
         return self.xp.ascontiguousarray(data, **kwargs)
 
-    def sigmoid(self, X: FloatsT, *, inplace: bool = False) -> FloatsT:
+    def sigmoid(self, X: FloatsType, *, inplace: bool = False) -> FloatsType:
         if inplace:
             self.xp.exp(-X, out=X)
-            X += 1.0
-            X **= -1.0
-            return X
+            X += 1.0 # type: ignore
+            X **= -1.0 # type: ignore
+            return cast(FloatsType, X)
         else:
-            return 1.0 / (1.0 + self.xp.exp(-X))
+            return cast(FloatsType, 1.0 / (1.0 + self.xp.exp(-X)))
 
-    def dsigmoid(self, Y: FloatsT, *, inplace: bool = False) -> FloatsT:
+    def dsigmoid(self, Y: FloatsType, *, inplace: bool = False) -> FloatsType:
         if inplace:
             Y *= 1 - Y
             return Y

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -6,6 +6,7 @@ from .expand_window import expand_window
 from .hashembed import HashEmbed
 from .layernorm import LayerNorm
 from .linear import Linear
+from .lstm import LSTM, PyTorchLSTM
 from .logistic import Logistic
 from .maxout import Maxout
 from .mish import Mish
@@ -13,10 +14,11 @@ from .multisoftmax import MultiSoftmax
 from .parametricattention import ParametricAttention
 from .pytorchwrapper import PyTorchWrapper, PyTorchRNNWrapper
 from .relu import Relu
+from .sigmoid_activation import sigmoid_activation
+from .sigmoid import Sigmoid
 from .softmax_activation import softmax_activation
 from .softmax import Softmax
 from .sparselinear import SparseLinear
-from .lstm import LSTM, PyTorchLSTM
 from .tensorflowwrapper import TensorFlowWrapper, keras_subclass
 from .mxnetwrapper import MXNetWrapper
 
@@ -69,18 +71,20 @@ __all__ = [
     "expand_window",
     "HashEmbed",
     "LayerNorm",
+    "LSTM",
     "Maxout",
     "Mish",
     "MultiSoftmax",
     "ParametricAttention",
+    "PyTorchLSTM",
     "PyTorchWrapper",
     "PyTorchRNNWrapper",
     "Relu",
+    "sigmoid_activation",
+    "Sigmoid"
     "softmax_activation",
     "Softmax",
     "SparseLinear",
-    "LSTM",
-    "PyTorchLSTM",
     "TensorFlowWrapper",
     "add",
     "bidirectional",

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -23,6 +23,15 @@ def HashEmbed(
     initializer: Callable = uniform_init,
     dropout: Optional[float] = None
 ) -> Model[InT, OutT]:
+    """
+    An embedding layer that uses the “hashing trick” to map keys to distinct values.
+    The hashing trick involves hashing each key four times with distinct seeds,
+    to produce four likely differing values. Those values are modded into the
+    table, and the resulting vectors summed to produce a single result. Because
+    it’s unlikely that two different keys will collide on all four “buckets”,
+    most distinct keys will receive a distinct vector under this scheme, even
+    when the number of vectors in the table is very low.
+    """
     attrs: Dict[str, Any] = {"column": column, "seed": seed}
     if dropout is not None:
         attrs["dropout_rate"] = dropout

--- a/thinc/layers/logistic.py
+++ b/thinc/layers/logistic.py
@@ -11,6 +11,9 @@ OutT = Floats2d
 
 @registry.layers("Logistic.v1")
 def Logistic() -> Model[InT, OutT]:
+    """Deprecated in favor of `sigmoid_activation` layer, for more consistent
+    naming.
+    """
     return Model("logistic", forward)
 
 

--- a/thinc/layers/sigmoid.py
+++ b/thinc/layers/sigmoid.py
@@ -1,0 +1,63 @@
+from typing import Tuple, Callable, Optional, cast
+
+from ..model import Model
+from ..config import registry
+from ..types import Floats2d, Floats1d
+from ..initializers import zero_init
+from ..util import get_width, partial
+
+
+InT = Floats2d
+OutT = Floats2d
+
+
+@registry.layers("Sigmoid.v1")
+def Sigmoid(
+    nO: Optional[int] = None,
+    nI: Optional[int] = None,
+    *,
+    init_W: Callable = zero_init,
+    init_b: Callable = zero_init
+) -> Model[InT, OutT]:
+    """A dense layer, followed by a sigmoid (logistic) activation function. This
+    is usually used instead of the Softmax layer as an output for multi-label
+    classification.
+    """
+    return Model(
+        "sigmoid",
+        forward,
+        init=partial(init, init_W, init_b),
+        dims={"nO": nO, "nI": nI},
+        params={"W": None, "b": None},
+    )
+
+
+def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
+    W = cast(Floats2d, model.get_param("W"))
+    b = cast(Floats1d, model.get_param("b"))
+    Y = model.ops.affine(X, W, b)
+    Y = model.ops.sigmoid(Y)
+
+    def backprop(dY: InT) -> OutT:
+        dY = dY * model.ops.dsigmoid(Y, inplace=False)
+        model.inc_grad("b", dY.sum(axis=0))
+        model.inc_grad("W", model.ops.gemm(dY, X, trans1=True))
+        return model.ops.gemm(dY, W)
+
+    return Y, backprop
+
+
+def init(
+    init_W: Callable,
+    init_b: Callable,
+    model: Model[InT, OutT],
+    X: Optional[InT] = None,
+    Y: Optional[OutT] = None,
+) -> Model[InT, OutT]:
+    if X is not None and model.has_dim("nI") is None:
+        model.set_dim("nI", get_width(X))
+    if Y is not None and model.has_dim("nO") is None:
+        model.set_dim("nO", get_width(Y))
+    model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
+    model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
+    return model

--- a/thinc/layers/sigmoid_activation.py
+++ b/thinc/layers/sigmoid_activation.py
@@ -1,0 +1,22 @@
+from typing import TypeVar, Tuple, Callable
+
+from ..model import Model
+from ..config import registry
+from ..types import FloatsXd
+
+
+InT = TypeVar(bound=FloatsXd)
+
+
+@registry.layers("sigmoid_activation.v1")
+def sigmoid_activation() -> Model[InT, InT]:
+    return Model("sigmoid_activation", forward)
+
+
+def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callable]:
+    Y = model.ops.sigmoid(X, inplace=False)
+
+    def backprop(dY: InT) -> InT:
+        return dY * model.ops.dsigmoid(Y, inplace=False)
+
+    return Y, backprop

--- a/thinc/layers/sigmoid_activation.py
+++ b/thinc/layers/sigmoid_activation.py
@@ -1,11 +1,11 @@
-from typing import TypeVar, Tuple, Callable
+from typing import TypeVar, Tuple, Callable, cast
 
 from ..model import Model
 from ..config import registry
 from ..types import FloatsXd
 
 
-InT = TypeVar(bound=FloatsXd)
+InT = TypeVar("InT", bound=FloatsXd)
 
 
 @registry.layers("sigmoid_activation.v1")
@@ -17,6 +17,6 @@ def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callab
     Y = model.ops.sigmoid(X, inplace=False)
 
     def backprop(dY: InT) -> InT:
-        return dY * model.ops.dsigmoid(Y, inplace=False)
+        return dY * model.ops.dsigmoid(Y, inplace=False) # type: ignore
 
     return Y, backprop

--- a/thinc/tests/layers/test_layers_api.py
+++ b/thinc/tests/layers/test_layers_api.py
@@ -69,6 +69,8 @@ TEST_CASES_SUMMABLE = [
     ("Mish.v1", {"normalize": True, "dropout": 0.2}, array2d, array2d),
     ("Relu.v1", {}, array2d, array2d),
     ("Relu.v1", {"normalize": True, "dropout": 0.2}, array2d, array2d),
+    ("Sigmoid.v1", {}, array2d, array2d),
+    ("sigmoid_activation.v1", {"nO": 4, "nI": 4}, array2d, array2d),
     ("Softmax.v1", {}, array2d, array2d),
     ("Softmax.v1", {"nO": 4, "nI": 4}, array2d, array2d),
     # fmt: off

--- a/thinc/tests/layers/test_layers_api.py
+++ b/thinc/tests/layers/test_layers_api.py
@@ -70,7 +70,9 @@ TEST_CASES_SUMMABLE = [
     ("Relu.v1", {}, array2d, array2d),
     ("Relu.v1", {"normalize": True, "dropout": 0.2}, array2d, array2d),
     ("Sigmoid.v1", {}, array2d, array2d),
-    ("sigmoid_activation.v1", {"nO": 4, "nI": 4}, array2d, array2d),
+    ("Sigmoid.v1", {"nO": 4, "nI": 4}, array2d, array2d),
+    ("sigmoid_activation.v1", {}, array2d, array2d),
+    ("softmax_activation.v1", {}, array2d, array2d),
     ("Softmax.v1", {}, array2d, array2d),
     ("Softmax.v1", {"nO": 4, "nI": 4}, array2d, array2d),
     # fmt: off


### PR DESCRIPTION
The current `Logistic` layer has a name that's inconsistent with the rest of the layers. You'd expect based on its name that it has a dense weight layer, like `Softmax` and `Relu` do. Instead `Logistic` is activation-only.

Changing the behaviour of the layer will be too breaking, and the name isn't great anyway. We should just follow Keras and call this the "sigmoid" activation (like it actually is in the `Ops` class anyway!).

I've added two layers: `sigmoid_activation()` does what `Logistic` currently does, and `Sigmoid` provides a linear layer in addition to the activation.