### PR TITLE
Fix list2padded op

### DIFF
--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -313,14 +313,17 @@ class Ops:
         lengths_indices.sort(reverse=True)
         indices_ = [i for length, i in lengths_indices]
         lengths_ = [length for length, i in lengths_indices]
-        seqs = [seqs[i] for i in indices_]
-        nS = max([len(seq) for seq in seqs])
+        nS = max([seq.shape[0] for seq in seqs])
+        nB = len(seqs)
+        nO = seqs[0].shape[1]
         # Reorder the sequences, by length. This looks the same in either
         # direction: you're swapping elements between their original and sorted
         # position.
-        seqs = [seqs[x] for x in indices_]
+        seqs = [seqs[i] for i in indices_]
         arr: Floats3d = self.pad(seqs)
+        assert arr.shape == (nB, nS, nO), (nB, nS, nO)
         arr = self.as_contig(arr.transpose((1, 0, 2)))
+        assert arr.shape == (nS, nB, nO)
         # Build a lookup table so we can find how big the batch is at point t.
         batch_size_at_t_ = [0 for _ in range(nS)]
         current_size = len(lengths_)

--- a/thinc/tests/layers/test_with_transforms.py
+++ b/thinc/tests/layers/test_with_transforms.py
@@ -1,7 +1,9 @@
 import pytest
 import numpy
-from thinc.api import NumpyOps, Model, Linear
-from thinc.api import with_array2d, with_padded, with_list, with_ragged, with_getitem
+import numpy.testing
+from thinc.api import NumpyOps, Model, Linear, noop
+from thinc.api import with_array2d, with_array, with_padded, with_list
+from thinc.api import with_ragged, with_getitem
 from thinc.types import Padded, Ragged
 
 
@@ -20,7 +22,13 @@ def ops():
 
 @pytest.fixture
 def list_input(shapes):
-    return [numpy.zeros(shape, dtype="f") for shape in shapes]
+    data = [numpy.zeros(shape, dtype="f") for shape in shapes]
+    for i, x in enumerate(data):
+        # Give values that make it easy to see where rows or columns mismatch.
+        x += i * 100
+        x += numpy.arange(x.shape[0]).reshape((-1, 1)) * 10 
+        x += numpy.arange(x.shape[1]).reshape((1, -1)) 
+    return data
 
 
 @pytest.fixture
@@ -53,6 +61,15 @@ def ragged_data_input(ragged_input):
     return (ragged_input.data, ragged_input.lengths)
 
 
+@pytest.fixture
+def noop_models():
+    return [
+        with_padded(noop()),
+        with_array(noop()),
+        with_array2d(noop()),
+        with_list(noop()),
+        with_ragged(noop())
+    ]
 # As an example operation, lets just trim the last dimension. That
 # should catch stuff that confuses the input and output.
 
@@ -137,6 +154,40 @@ def check_transform_produces_correct_output_type_backward(model, inputs, checker
     assert checker(inputs, d_inputs)
 
 
+def check_transform_doesnt_change_noop_values(model, inputs, d_outputs):
+    # Check that if we're wrapping a noop() layer in the transform, we don't
+    # change the output values.
+    outputs, backprop = model.begin_update(inputs)
+    d_inputs = backprop(d_outputs)
+    if isinstance(outputs, list):
+        for i in range(len(outputs)):
+            numpy.testing.assert_equal(inputs[i], outputs[i])
+            numpy.testing.assert_equal(d_outputs[i], d_inputs[i])
+    elif isinstance(outputs, numpy.ndarray):
+        numpy.testing.assert_equal(inputs, outputs)
+        numpy.testing.assert_equal(d_outputs, d_inputs)
+    elif isinstance(outputs, Ragged):
+        numpy.testing.assert_equal(inputs.data, outputs.data)
+        numpy.testing.assert_equal(d_outputs.data, d_inputs.data)
+    elif isinstance(outputs, Padded):
+        numpy.testing.assert_equal(inputs.data, outputs.data)
+        numpy.testing.assert_equal(d_inputs.data, d_inputs.data)
+
+
+def test_noop_transforms(noop_models, ragged_input, padded_input, list_input):
+    # Make distinct backprop values,
+    # to check that the gradients get passed correctly
+    d_ragged = Ragged(ragged_input.data + 1, ragged_input.lengths)
+    d_padded = padded_input.copy()
+    d_padded.data += 1
+    d_list = [dx+1 for dx in list_input]
+    for model in noop_models:
+        print(model.name)
+        check_transform_doesnt_change_noop_values(model, padded_input, d_padded)
+        check_transform_doesnt_change_noop_values(model, list_input, d_list)
+        check_transform_doesnt_change_noop_values(model, ragged_input, d_ragged)
+
+    
 def test_with_array_initialize(ragged_input, padded_input, list_input, array_input):
     for inputs in (ragged_input, padded_input, list_input, array_input):
         check_initialize(get_array_model(), inputs)

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -788,6 +788,14 @@ class Padded:
     lengths: Ints1d
     indices: Ints1d
 
+    def copy(self):
+        return Padded(
+            self.data.copy(),
+            self.size_at_t.copy(),
+            self.lengths.copy(),
+            self.indices.copy()
+        )
+
     def __len__(self) -> int:
         return self.lengths.shape[0]
 


### PR DESCRIPTION
The list2padded op was doing the "get indexes by length" step twice, which left the sequences unsorted by length. This messes up a bunch of logic, meaning that layers wrapped with `with_padded` wouldn't converge (oops).

The fix comes with a better test for these transforms, to check that they don't disrupt the values when wrapping a noop layer.