### PR TITLE
fix(pathy): don't force input paths to Path when de/serializing objects

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,17 +82,16 @@ jobs:
   - bash: |
       pip freeze > installed.txt
       pip uninstall -y -r installed.txt
-      SDIST=$(python -c "import os;print(os.listdir('./dist')[-1])" 2>&1)
-      pip install dist/$SDIST
-    displayName: 'Install from sdist'
-
-  - script: |
-      pip install 'numpy<1.19.4'
       pip install -r requirements.txt
       pip install tensorflow
       pip install "mxnet; sys_platform != 'win32'"
-      pip install "torch==1.6.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch==1.7.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
       pip install ipykernel pydot graphviz
+      SDIST=$(python -c "import os;print(os.listdir('./dist')[-1])" 2>&1)
+      pip install --no-build-isolation dist/$SDIST
+    displayName: 'Install from sdist'
+
+  - script: |
       python -m ipykernel install --name thinc-notebook-tests --user
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
     displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,16 +82,16 @@ jobs:
   - bash: |
       pip freeze > installed.txt
       pip uninstall -y -r installed.txt
+      SDIST=$(python -c "import os;print(os.listdir('./dist')[-1])" 2>&1)
+      PIP_CONSTRAINT="build-constraints.txt" pip install dist/$SDIST
+    displayName: 'Install from sdist'
+
+  - script: |
       pip install -r requirements.txt
       pip install tensorflow
       pip install "mxnet; sys_platform != 'win32'"
       pip install "torch==1.7.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
       pip install ipykernel pydot graphviz
-      SDIST=$(python -c "import os;print(os.listdir('./dist')[-1])" 2>&1)
-      pip install --no-build-isolation dist/$SDIST
-    displayName: 'Install from sdist'
-
-  - script: |
       python -m ipykernel install --name thinc-notebook-tests --user
       python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
     displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
       architecture: 'x64'
 
   - script: |
-      python -m pip install --upgrade pip setuptools
+      python -m pip install --upgrade pip setuptools wheel
       pip install -r requirements.txt
     displayName: 'Install dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,7 @@ jobs:
     displayName: 'Install from sdist'
 
   - script: |
+      pip install 'numpy<1.19.4'
       pip install -r requirements.txt
       pip install tensorflow
       pip install "mxnet; sys_platform != 'win32'"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ mypy
 ipykernel>=5.1.4,<5.2.0
 nbconvert==5.6.1,<5.7.0
 nbformat==5.0.4,<5.1.0
+# Test to_disk/from_disk against pathlib.Path subclasses
+pathy

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ ipykernel>=5.1.4,<5.2.0
 nbconvert==5.6.1,<5.7.0
 nbformat==5.0.4,<5.1.0
 # Test to_disk/from_disk against pathlib.Path subclasses
-pathy
+pathy>=0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ mypy
 ipykernel>=5.1.4,<5.2.0
 nbconvert==5.6.1,<5.7.0
 nbformat==5.0.4,<5.1.0
+# Test to_disk/from_disk against pathlib.Path subclasses
+pathy>=0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ catalogue>=0.2.0,<3.0.0
 ml_datasets==0.2.0a0
 # Third-party dependencies
 pydantic>=1.7.1,<1.8.0
-numpy>=1.15.0
+numpy>=1.15.0,<1.20.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"
 typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ catalogue>=0.2.0,<3.0.0
 ml_datasets==0.2.0a0
 # Third-party dependencies
 pydantic>=1.7.1,<1.8.0
-numpy>=1.15.0,<1.20.0
+numpy>=1.15.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"
 typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,3 @@ mypy
 ipykernel>=5.1.4,<5.2.0
 nbconvert==5.6.1,<5.7.0
 nbformat==5.0.4,<5.1.0
-# Test to_disk/from_disk against pathlib.Path subclasses
-pathy>=0.3.5

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -432,7 +432,7 @@ class Config(dict):
 
     def to_disk(self, path: Union[str, Path], *, interpolate: bool = True):
         """Serialize the config to a file."""
-        path = Path(path)
+        path = Path(path) if isinstance(path, str) else path
         with path.open("w", encoding="utf8") as file_:
             file_.write(self.to_str(interpolate=interpolate))
 
@@ -444,7 +444,8 @@ class Config(dict):
         overrides: Dict[str, Any] = {},
     ) -> "Config":
         """Load config from a file."""
-        with Path(path).open("r", encoding="utf8") as file_:
+        path = Path(path) if isinstance(path, str) else path
+        with path.open("r", encoding="utf8") as file_:
             text = file_.read()
         return self.from_str(text, interpolate=interpolate, overrides=overrides)
 

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -452,7 +452,7 @@ class Model(Generic[InT, OutT]):
         """Serialize the model to disk. Most models will serialize to a single
         file, which should just be the bytes contents of model.to_bytes().
         """
-        path = Path(path)
+        path = Path(path) if isinstance(path, str) else path
         with path.open("wb") as file_:
             file_.write(self.to_bytes())
 
@@ -529,7 +529,7 @@ class Model(Generic[InT, OutT]):
         """Deserialize the model from disk. Most models will serialize to a single
         file, which should just be the bytes contents of model.to_bytes().
         """
-        path = Path(path)
+        path = Path(path) if isinstance(path, str) else path
         with path.open("rb") as file_:
             bytes_data = file_.read()
         return self.from_bytes(bytes_data)
@@ -570,7 +570,7 @@ class Model(Generic[InT, OutT]):
         If 'strict', the function returns False if the model has an attribute
         already loaded that would be changed.
         """
-        path = Path(path)
+        path = Path(path) if isinstance(path, str) else path
         if path.is_dir() or not path.exists():
             return False
         with path.open("rb") as file_:

--- a/thinc/shims/shim.py
+++ b/thinc/shims/shim.py
@@ -56,11 +56,13 @@ class Shim:  # pragma: no cover
 
     def to_disk(self, path: Union[str, Path]):
         bytes_data = self.to_bytes()
-        with Path(path).open("wb") as file_:
+        path = Path(path) if isinstance(path, str) else path
+        with path.open("wb") as file_:
             file_.write(bytes_data)
 
     def from_disk(self, path: Union[str, Path]) -> "Shim":
-        with Path(path).open("rb") as file_:
+        path = Path(path) if isinstance(path, str) else path
+        with path.open("rb") as file_:
             bytes_data = file_.read()
         return self.from_bytes(bytes_data)
 

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -15,7 +15,7 @@ from ..strategies import ndarrays_of_shape
 
 MAX_EXAMPLES = 10
 
-VANILLA_OPS = Ops(numpy)
+VANILLA_OPS = Ops(numpy)  # type:ignore
 NUMPY_OPS = NumpyOps()
 BLIS_OPS = NumpyOps(use_blis=True)
 CPU_OPS = [NUMPY_OPS, VANILLA_OPS]
@@ -365,7 +365,7 @@ def get_lstm_args(depth, dirs, nO, batch_size, nI, draw=None):
     if draw:
         params = draw(ndarrays_of_shape(n_params))
         # For some reason this is crashing hypothesis?
-        #size_at_t = draw(ndarrays_of_shape(shape=(batch_size,), lo=1, dtype="int32"))
+        # size_at_t = draw(ndarrays_of_shape(shape=(batch_size,), lo=1, dtype="int32"))
         size_at_t = numpy.ones(shape=(batch_size,), dtype="int32")
         X = draw(ndarrays_of_shape((int(size_at_t.sum()), nI)))
     else:

--- a/thinc/tests/conftest.py
+++ b/thinc/tests/conftest.py
@@ -18,20 +18,3 @@ def pytest_runtest_setup(item):
     for opt in ["slow"]:
         if opt in item.keywords and not getopt(opt):
             pytest.skip(f"need --{opt} option to run")
-
-
-@pytest.fixture()
-def pathy_fixture():
-    import tempfile
-    import shutil
-    from pathy import use_fs, Pathy
-
-    temp_folder = tempfile.mkdtemp(prefix="thinc-pathy")
-    use_fs(temp_folder)
-
-    root = Pathy("gs://test-bucket")
-    root.mkdir(exist_ok=True)
-
-    yield root
-    use_fs(False)
-    shutil.rmtree(temp_folder)

--- a/thinc/tests/conftest.py
+++ b/thinc/tests/conftest.py
@@ -18,3 +18,20 @@ def pytest_runtest_setup(item):
     for opt in ["slow"]:
         if opt in item.keywords and not getopt(opt):
             pytest.skip(f"need --{opt} option to run")
+
+
+@pytest.fixture()
+def pathy_fixture():
+    import tempfile
+    import shutil
+    from pathy import use_fs, Pathy
+
+    temp_folder = tempfile.mkdtemp(prefix="thinc-pathy")
+    use_fs(temp_folder)
+
+    root = Pathy("gs://test-bucket")
+    root.mkdir(exist_ok=True)
+
+    yield root
+    use_fs(False)
+    shutil.rmtree(temp_folder)

--- a/thinc/tests/layers/test_shim.py
+++ b/thinc/tests/layers/test_shim.py
@@ -1,0 +1,33 @@
+from typing import List
+from thinc.shims.shim import Shim
+from ..util import make_tempdir
+
+
+class TestShim(Shim):
+    def __init__(self, data: List[int]):
+        super().__init__(None, config=None, optimizer=None)
+        self.data = data
+
+    def to_bytes(self):
+        return bytes(self.data)
+
+    def from_bytes(self, data: bytes) -> "TestShim":
+        return TestShim(data=list(data))
+
+
+def test_shim_can_roundtrip_with_path():
+
+    with make_tempdir() as path:
+        shim_path = path / "cool_shim.data"
+        shim = TestShim([1, 2, 3])
+        shim.to_disk(shim_path)
+        copy_shim = shim.from_disk(shim_path)
+    assert copy_shim.to_bytes() == shim.to_bytes()
+
+
+def test_shim_can_roundtrip_with_path_subclass(pathy_fixture):
+    shim_path = pathy_fixture / "cool_shim.data"
+    shim = TestShim([1, 2, 3])
+    shim.to_disk(shim_path)
+    copy_shim = shim.from_disk(shim_path)
+    assert copy_shim.to_bytes() == shim.to_bytes()

--- a/thinc/tests/layers/test_shim.py
+++ b/thinc/tests/layers/test_shim.py
@@ -3,7 +3,7 @@ from thinc.shims.shim import Shim
 from ..util import make_tempdir
 
 
-class TestShim(Shim):
+class MockShim(Shim):
     def __init__(self, data: List[int]):
         super().__init__(None, config=None, optimizer=None)
         self.data = data
@@ -11,15 +11,15 @@ class TestShim(Shim):
     def to_bytes(self):
         return bytes(self.data)
 
-    def from_bytes(self, data: bytes) -> "TestShim":
-        return TestShim(data=list(data))
+    def from_bytes(self, data: bytes) -> "MockShim":
+        return MockShim(data=list(data))
 
 
 def test_shim_can_roundtrip_with_path():
 
     with make_tempdir() as path:
         shim_path = path / "cool_shim.data"
-        shim = TestShim([1, 2, 3])
+        shim = MockShim([1, 2, 3])
         shim.to_disk(shim_path)
         copy_shim = shim.from_disk(shim_path)
     assert copy_shim.to_bytes() == shim.to_bytes()
@@ -27,7 +27,7 @@ def test_shim_can_roundtrip_with_path():
 
 def test_shim_can_roundtrip_with_path_subclass(pathy_fixture):
     shim_path = pathy_fixture / "cool_shim.data"
-    shim = TestShim([1, 2, 3])
+    shim = MockShim([1, 2, 3])
     shim.to_disk(shim_path)
     copy_shim = shim.from_disk(shim_path)
     assert copy_shim.to_bytes() == shim.to_bytes()

--- a/thinc/tests/layers/test_shim.py
+++ b/thinc/tests/layers/test_shim.py
@@ -23,11 +23,3 @@ def test_shim_can_roundtrip_with_path():
         shim.to_disk(shim_path)
         copy_shim = shim.from_disk(shim_path)
     assert copy_shim.to_bytes() == shim.to_bytes()
-
-
-def test_shim_can_roundtrip_with_path_subclass(pathy_fixture):
-    shim_path = pathy_fixture / "cool_shim.data"
-    shim = MockShim([1, 2, 3])
-    shim.to_disk(shim_path)
-    copy_shim = shim.from_disk(shim_path)
-    assert copy_shim.to_bytes() == shim.to_bytes()

--- a/thinc/tests/layers/test_shim.py
+++ b/thinc/tests/layers/test_shim.py
@@ -23,3 +23,11 @@ def test_shim_can_roundtrip_with_path():
         shim.to_disk(shim_path)
         copy_shim = shim.from_disk(shim_path)
     assert copy_shim.to_bytes() == shim.to_bytes()
+
+
+def test_shim_can_roundtrip_with_path_subclass(pathy_fixture):
+    shim_path = pathy_fixture / "cool_shim.data"
+    shim = MockShim([1, 2, 3])
+    shim.to_disk(shim_path)
+    copy_shim = shim.from_disk(shim_path)
+    assert copy_shim.to_bytes() == shim.to_bytes()

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -169,13 +169,6 @@ def test_model_can_load_from_disk(model_with_no_args):
     assert model_with_no_args.to_bytes() == m2.to_bytes()
 
 
-def test_model_can_roundtrip_with_path_subclass(model_with_no_args, pathy_fixture):
-    path = pathy_fixture / "thinc_model"
-    model_with_no_args.to_disk(path)
-    m2 = model_with_no_args.from_disk(path)
-    assert model_with_no_args.to_bytes() == m2.to_bytes()
-
-
 def test_change_attr_values(model_with_no_args):
     model = model_with_no_args
     model.name = "target"

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -169,6 +169,13 @@ def test_model_can_load_from_disk(model_with_no_args):
     assert model_with_no_args.to_bytes() == m2.to_bytes()
 
 
+def test_model_can_roundtrip_with_path_subclass(model_with_no_args, pathy_fixture):
+    path = pathy_fixture / "thinc_model"
+    model_with_no_args.to_disk(path)
+    m2 = model_with_no_args.from_disk(path)
+    assert model_with_no_args.to_bytes() == m2.to_bytes()
+
+
 def test_change_attr_values(model_with_no_args):
     model = model_with_no_args
     model.name = "target"

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -349,14 +349,6 @@ def test_config_roundtrip_disk():
     assert new_cfg.to_str().strip() == OPTIMIZER_CFG.strip()
 
 
-def test_config_roundtrip_disk_respects_path_subclasses(pathy_fixture):
-    cfg = Config().from_str(OPTIMIZER_CFG)
-    cfg_path = pathy_fixture / "config.cfg"
-    cfg.to_disk(cfg_path)
-    new_cfg = Config().from_disk(cfg_path)
-    assert new_cfg.to_str().strip() == OPTIMIZER_CFG.strip()
-
-
 def test_config_to_str_invalid_defaults():
     """Test that an error is raised if a config contains top-level keys without
     a section that would otherwise be interpreted as [DEFAULT] (which causes

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -349,6 +349,14 @@ def test_config_roundtrip_disk():
     assert new_cfg.to_str().strip() == OPTIMIZER_CFG.strip()
 
 
+def test_config_roundtrip_disk_respects_path_subclasses(pathy_fixture):
+    cfg = Config().from_str(OPTIMIZER_CFG)
+    cfg_path = pathy_fixture / "config.cfg"
+    cfg.to_disk(cfg_path)
+    new_cfg = Config().from_disk(cfg_path)
+    assert new_cfg.to_str().strip() == OPTIMIZER_CFG.strip()
+
+
 def test_config_to_str_invalid_defaults():
     """Test that an error is raised if a config contains top-level keys without
     a section that would otherwise be interpreted as [DEFAULT] (which causes
@@ -505,7 +513,9 @@ def test_make_config_positional_args_dicts():
 
 def test_validation_generators_iterable():
     @my_registry.optimizers("test_optimizer.v1")
-    def test_optimizer_v1(rate: float,) -> None:
+    def test_optimizer_v1(
+        rate: float,
+    ) -> None:
         return None
 
     @my_registry.schedules("test_schedule.v1")

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -349,6 +349,14 @@ def test_config_roundtrip_disk():
     assert new_cfg.to_str().strip() == OPTIMIZER_CFG.strip()
 
 
+def test_config_roundtrip_disk_respects_path_subclasses(pathy_fixture):
+    cfg = Config().from_str(OPTIMIZER_CFG)
+    cfg_path = pathy_fixture / "config.cfg"
+    cfg.to_disk(cfg_path)
+    new_cfg = Config().from_disk(cfg_path)
+    assert new_cfg.to_str().strip() == OPTIMIZER_CFG.strip()
+
+
 def test_config_to_str_invalid_defaults():
     """Test that an error is raised if a config contains top-level keys without
     a section that would otherwise be interpreted as [DEFAULT] (which causes

--- a/thinc/tests/test_util.py
+++ b/thinc/tests/test_util.py
@@ -13,13 +13,13 @@ from thinc.types import ArgsKwargs
         (numpy.array(1), 0),
         (numpy.array([1, 2]), 3),
         ([numpy.zeros((1, 2)), numpy.zeros((1))], 2),
-        (Ragged(numpy.zeros((1, 2)), numpy.zeros(1)), 2),
+        (Ragged(numpy.zeros((1, 2)), numpy.zeros(1)), 2),  # type:ignore
         (
             Padded(
-                numpy.zeros((2, 1, 2)),
-                numpy.zeros(2),
-                numpy.array([1, 0]),
-                numpy.array([0, 1]),
+                numpy.zeros((2, 1, 2)),  # type:ignore
+                numpy.zeros(2),  # type:ignore
+                numpy.array([1, 0]),  # type:ignore
+                numpy.array([0, 1]),  # type:ignore
             ),
             2,
         ),


### PR DESCRIPTION
With spaCy 3, saving models to Pathy paths has stopped working. 

It turns out that thinc is forcing the input paths to be a Path class by wrapping them "just to be sure". It's friendly and concise, but it messes with inputs that are already path-like objects.

I added tests to demonstrate the failure, and as a fix, I only coerce the type to Path if it is a string.

Related to: https://github.com/justindujardin/pathy/pull/44