### PR TITLE
avoid initializing with Y if X is set

### DIFF
--- a/thinc/layers/layernorm.py
+++ b/thinc/layers/layernorm.py
@@ -44,7 +44,7 @@ def init(
         X_width = get_width(X)
         model.set_dim("nI", X_width)
         model.set_dim("nO", X_width)
-    if Y is not None:
+    elif Y is not None:
         Y_width = get_width(Y)
         model.set_dim("nI", Y_width)
         model.set_dim("nO", Y_width)


### PR DESCRIPTION
Inspired by [this issue](https://github.com/explosion/spaCy/issues/6946). The "trouble" is being caused by the shape inference code in `chain`, but it can't hurt to add some additional robustness into `layernorm` to avoid using `Y` if not necessary.