### PR TITLE
Add map_list layer

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -29,6 +29,7 @@ from .layers import TensorFlowWrapper, keras_subclass, MXNetWrapper
 
 from .layers import add, bidirectional, chain, clone, concatenate, noop
 from .layers import residual, uniqued, siamese, list2ragged, ragged2list
+from .layers import map_list
 from .layers import with_array, with_array2d
 from .layers import with_padded, with_list, with_ragged, with_flatten
 from .layers import with_reshape, with_getitem, strings2arrays, list2array

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -28,6 +28,7 @@ from .bidirectional import bidirectional
 from .chain import chain
 from .clone import clone
 from .concatenate import concatenate
+from .map_list import map_list
 from .noop import noop
 from .residual import residual
 from .uniqued import uniqued

--- a/thinc/layers/map_list.py
+++ b/thinc/layers/map_list.py
@@ -1,0 +1,36 @@
+from typing import Callable, TypeVar, List, Tuple, Optional
+from ..model import Model
+
+
+InT = TypeVar("InT")
+OutT = TypeVar("OutT")
+
+
+def map_list(layer: Model[InT, OutT]) -> Model[List[InT], List[OutT]]:
+    """Create a model that maps a child layer across list inputs."""
+    return Model("map_list", forward, layers=[layer], init=init)
+
+
+def forward(
+    model: Model[List[InT], List[OutT]], Xs: List[InT], is_train: bool
+) -> Tuple[List[OutT], Callable[[List[OutT]], List[InT]]]:
+    layer = model.layers[0]
+    Ys = []
+    callbacks = []
+    for X in Xs:
+        Y, get_dX = layer(X, is_train)
+        Ys.append(Y)
+        callbacks.append(get_dX)
+
+    def backprop_map_list(dYs: List[OutT]) -> List[InT]:
+        return [callback(dY) for callback, dY in zip(callbacks, dYs)]
+
+    return Ys, backprop_map_list
+
+
+def init(
+    model: Model[List[InT], List[OutT]],
+    X: Optional[List[InT]] = None,
+    Y: Optional[List[OutT]] = None,
+):
+    model.layers[0].initialize(X=X[0] if X else None, Y=Y[0] if Y else None)

--- a/thinc/tests/layers/test_combinators.py
+++ b/thinc/tests/layers/test_combinators.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy
-from thinc.api import clone, concatenate, noop, add
+from thinc.api import clone, concatenate, noop, add, map_list
 from thinc.api import Linear, Dropout, Model, NumpyOps
 from thinc.layers import chain
 
@@ -216,3 +216,22 @@ def test_concatenate():
     assert Y.shape[1] == sum([layer.predict(data).shape[1] for layer in model.layers])
     dX = backprop(Y)
     assert dX.shape == data.shape
+
+
+def test_map_list():
+    data = [
+        numpy.asarray([[1, 2, 3], [4, 5, 6]], dtype="f"),
+        numpy.asarray([[7, 8, 9], [10, 11, 12]], dtype="f"),
+    ]
+    model = map_list(Linear())
+    model.initialize(X=data, Y=data)
+    Y, backprop = model(data, is_train=True)
+    assert isinstance(Y, list)
+    assert len(Y) == len(data)
+    assert Y[0].shape == data[0].shape
+    assert Y[1].shape == data[1].shape
+    dX = backprop(Y)
+    assert isinstance(dX, list)
+    assert len(dX) == len(data)
+    assert dX[0].shape == dX[0].shape
+    assert dX[1].shape == dX[1].shape

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -700,6 +700,19 @@ concatenated, i.e. `concatenate(f, g)(x)` computes `hstack(f(x), g(x))`.
 https://github.com/explosion/thinc/blob/master/thinc/layers/concatenate.py
 ```
 
+### map_list {#map_list tag="function"}
+
+Map a child layer across list inputs.
+
+| Argument    | Type                                  | Description             |
+| ----------- | ------------------------------------- | ----------------------- |
+| `layer`   | <tt>Model[InT, OutT]</tt>               | The child layer to map. |
+| **RETURNS** | <tt>Model[List[InT], List[OutT]]</tt> | The composed model.     |
+
+```python
+https://github.com/explosion/thinc/blob/master/thinc/layers/map_list.py
+```
+
 ### expand_window {#expand_window tag="function"}
 
 <inline-list>


### PR DESCRIPTION
Add a combinator layer that maps a child layer across list inputs. I happened to need this to show how to do something for spaCy, and I thought I'd added this already but it wasn't there.

I think in Thinc v7 there was a similar layer called `foreach`. A name with `map` seems better, and apparently in list it's called `maplist`. I hate arbitrary non-underscore names, hence `map_list`.