### PR TITLE
Disable code cov in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,8 +93,5 @@ jobs:
       pip install "torch==1.7.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
-      python -m pytest --pyargs thinc --cov=thinc --cov-report=xml
+      python -m pytest --pyargs thinc
     displayName: 'Run tests'
-
-  - bash: bash <(curl -s https://codecov.io/bash)
-    displayName: 'Upload to codecov.io'


### PR DESCRIPTION
Seems to currently cause segfaults for python 3.9 in linux in the CI, although no idea what the underlying cause might be.