### PR TITLE
sync pins with spacy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"
 contextvars>=2.4,<3; python_version < "3.7"
 # Development dependencies
 cython>=0.25.0
-hypothesis>=3.27.0,<6.0.0
+hypothesis>=3.27.0,<7.0.0
 pytest>=5.2.0
 pytest-cov>=2.7.0,<2.8.0
 mock>=2.0.0,<3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # Explosion-provided dependencies
 murmurhash>=0.28.0,<1.1.0
 cymem>=2.0.2,<2.1.0
-preshed>=1.0.1,<3.1.0
+preshed>=3.0.2,<3.1.0
 blis>=0.4.0,<0.8.0
-srsly>=2.0.0,<3.0.0
-wasabi>=0.4.0,<1.1.0
-catalogue>=0.2.0,<3.0.0
-ml_datasets==0.2.0a0
+srsly>=2.4.0,<3.0.0
+wasabi>=0.8.1,<1.1.0
+catalogue>=2.0.1,<2.1.0
+ml_datasets>=0.2.0,<0.3.0
 # Third-party dependencies
 pydantic>=1.7.1,<1.8.0
 numpy>=1.15.0
@@ -18,7 +18,7 @@ contextvars>=2.4,<3; python_version < "3.7"
 cython>=0.25.0
 hypothesis>=3.27.0,<6.0.0
 pytest>=5.2.0
-pytest-cov
+pytest-cov>=2.7.0,<2.8.0
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
 mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,9 @@ install_requires =
     murmurhash>=0.28.0,<1.1.0
     cymem>=2.0.2,<2.1.0
     preshed>=3.0.2,<3.1.0
-    wasabi>=0.4.0,<1.1.0
-    srsly>=2.0.0,<3.0.0
-    catalogue>=0.2.0,<3.0.0
+    wasabi>=0.8.1,<1.1.0
+    srsly>=2.4.0,<3.0.0
+    catalogue>=2.0.1,<2.1.0
     # Third-party dependencies
     setuptools
     numpy>=1.15.0
@@ -75,7 +75,7 @@ cuda110 =
 cuda111 =
     cupy-cuda111>=5.0.0b4
 datasets =
-    ml_datasets==0.2.0a0
+    ml_datasets>=0.2.0,<0.3.0
 torch =
     torch>=1.5.0
 tensorflow =


### PR DESCRIPTION
sync pins with spacy - cf https://github.com/explosion/spaCy/pull/7247

Triggered by the fact that `ml_datasets` still referred to a specific alpha version.