### PR TITLE
Fix config override & interpolate interaction

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.2"
+__version__ = "8.0.3"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -373,6 +373,8 @@ class Config(dict):
     ) -> "Config":
         """Load the config from a string."""
         config = get_configparser(interpolate=interpolate)
+        if overrides:
+            config = get_configparser(interpolate=False)
         try:
             config.read_string(text)
         except ParsingError as e:
@@ -382,6 +384,9 @@ class Config(dict):
         self._set_overrides(config, overrides)
         self.clear()
         self.interpret_config(config)
+        if overrides and interpolate:
+            # do the interpolation. Avoids recursion because the new call from_str call will have overrides as empty
+            self = self.interpolate()
         self.is_interpolated = interpolate
         return self
 

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1432,6 +1432,4 @@ def test_config_overrides(greeting, value, expected):
     overrides = {"vars.a": greeting}
     assert "${vars.a}" in str_cfg
     cfg = Config().from_str(str_cfg, overrides=overrides)
-    print()
-    print("3 from str", cfg)
     assert expected in str(cfg)

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1364,3 +1364,52 @@ def test_config_dataclasses():
     result = my_registry.resolve(config)["cfg"]
     assert isinstance(result, Ragged)
     assert list(result._get_cumsums()) == [4, 6, 14, 15, 19]
+
+
+@pytest.mark.parametrize(
+    "greeting,value,expected", [
+        # simple substitution should go fine
+        ["hello 342", "${vars.a}", "hello 342"],
+        ["hello everyone", "${vars.a}", "hello everyone"],
+        ["hello tout le monde", "${vars.a}", "hello tout le monde"],
+        ["hello 42", "${vars.a}", "hello 42"],
+        # substituting an element in a list
+        ["hello 342", "[1, ${vars.a}, 3]", "hello 342"],
+        ["hello everyone", "[1, ${vars.a}, 3]", "hello everyone"],
+        ["hello tout le monde", "[1, ${vars.a}, 3]", "hello tout le monde"],
+        ["hello 42", "[1, ${vars.a}, 3]", "hello 42"],
+        # substituting part of a string
+        [342, "hello ${vars.a}", "hello 342"],
+        ["everyone", "hello ${vars.a}", "hello everyone"],
+        ["tout le monde", "hello ${vars.a}", "hello tout le monde"],
+        ["42", "hello ${vars.a}", "hello 42"],
+        # substituting part of a implicit string inside a list
+        [342, "[1, hello ${vars.a}, 3]", "hello 342"],
+        ["everyone", "[1, hello ${vars.a}, 3]", "hello everyone"],
+        ["tout le monde", "[1, hello ${vars.a}, 3]", "hello tout le monde"],
+        ["42", "[1, ${vars.a}, 3]", "hello 42"],
+        # substituting part of a explicit string inside a list
+        [342, "[1, 'hello ${vars.a}', '3']", "hello 342"],
+        ["everyone", "[1, 'hello ${vars.a}', '3']", "hello everyone"],
+        ["tout le monde", "[1, 'hello ${vars.a}', '3']", "hello tout le monde"],
+        ["42", "[1, 'hello ${vars.a}', '3']", "hello 42"],
+        # more complicated example
+        [342, "[{'name':'x','script':['hello ${vars.a}']}]", "hello 342"],
+        ["everyone", "[{'name':'x','script':['hello ${vars.a}']}]", "hello everyone"],
+        ["tout le monde", "[{'name':'x','script':['hello ${vars.a}']}]", "hello tout le monde"],
+        ["42", "[{'name':'x','script':['hello ${vars.a}']}]", "hello 42"]]
+)
+def test_config_overrides(greeting, value, expected):
+    str_cfg = f"""
+    [project]
+    commands = {value}
+
+    [vars]
+    a = "world"
+    """
+    overrides = {"vars.a": greeting}
+    assert "${vars.a}" in str_cfg
+    cfg = Config().from_str(str_cfg, overrides=overrides)
+    print()
+    print("3 from str", cfg)
+    assert expected in str(cfg)


### PR DESCRIPTION
Before this PR, the `config.from_str` method would interpolate before setting the overrides. This meant that a string such as `"hello ${vars.a}"` would get interpolated first - i.e. changing `vars.a` with the value from the config, and only afterwards would this value be changed again into the correct one from `overrides`.

This mechanism resulted in unnecessary quotes when strings were being inserted into other strings, as examplified by the unit tests. Before this PR, most of the `test_config_overrides` configurations would fail (especially the ones more down the bottom).

Instead, this PR ensures that interpolation only happens after setting the overrides, circumventing the quoting behaviour.

While that fixes most of the tests, one additional issue couldn't be resolved: if you have an integer value in quotes like `"42"`, internally this will be parsed as an integer first, then converted into a backslashed version to ensure the value remains a string, and all this does not play well when that string is again inserted in a larger string like `"hello ${vars.a}"`. Long story short - this can be resolved by just putting `42` instead of `"42"` and I've probably already spent too much time on this to keep digging here. I kept the unit tests on `xfail` in case someone else wants to have a stab at it though :-) 

Releasing this, including the version bump to 8.0.3, should make https://github.com/explosion/spaCy/pull/7755 go green.