### PR TITLE
Add tuplify

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -35,6 +35,7 @@ from .layers import with_padded, with_list, with_ragged, with_flatten
 from .layers import with_reshape, with_getitem, strings2arrays, list2array
 from .layers import list2ragged, ragged2list, list2padded, padded2list, remap_ids
 from .layers import array_getitem, with_cpu, with_debug
+from .layers import tuplify
 
 from .layers import reduce_first, reduce_last, reduce_max, reduce_mean, reduce_sum
 

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -33,6 +33,7 @@ from .noop import noop
 from .residual import residual
 from .uniqued import uniqued
 from .siamese import siamese
+from .tuplify import tuplify
 
 # Pooling
 from .reduce_first import reduce_first

--- a/thinc/layers/tuplify.py
+++ b/thinc/layers/tuplify.py
@@ -10,12 +10,19 @@ MidT = TypeVar("MidT")
 
 @registry.layers("tuplify.v1")
 def tuplify(layer1: Model, layer2: Model, *layers) -> Model:
+    """Send a separate copy of the input to each child layer, and join the
+    outputs of the children into a tuple on the way out.
+
+    Typically used to provide both modified data and the original input to a
+    downstream layer.
+    """
+
     layers = (layer1, layer2) + layers
     names = [layer.name for layer in layers]
     return Model(
-            "tuple(" + ", ".join(names) + ")", 
-            tuplify_forward, 
-            layers=layers,
+        "tuple(" + ", ".join(names) + ")",
+        tuplify_forward,
+        layers=layers,
     )
 
 

--- a/thinc/layers/tuplify.py
+++ b/thinc/layers/tuplify.py
@@ -1,0 +1,37 @@
+from typing import Callable, Optional, Tuple, Any, TypeVar
+
+from ..model import Model
+from ..config import registry
+
+InT = TypeVar("InT")
+OutT = TypeVar("OutT")
+MidT = TypeVar("MidT")
+
+
+@registry.layers("tuplify.v1")
+def tuplify(layer1: Model, layer2: Model, *layers) -> Model:
+    layers = (layer1, layer2) + layers
+    names = [layer.name for layer in layers]
+    return Model(
+            "tuple(" + ", ".join(names) + ")", 
+            tuplify_forward, 
+            layers=layers,
+    )
+
+
+def tuplify_forward(model, X, is_train):
+    Ys = []
+    backprops = []
+    for layer in model.layers:
+        Y, backprop = layer(X, is_train)
+        Ys.append(Y)
+        backprops.append(backprop)
+
+    def backprop_tuplify(dYs):
+        dXs = [bp(dY) for bp, dY in zip(backprops, dYs)]
+        dX = dXs[0]
+        for dx in dXs[1:]:
+            dX += dx
+        return dX
+
+    return tuple(Ys), backprop_tuplify

--- a/thinc/layers/tuplify.py
+++ b/thinc/layers/tuplify.py
@@ -9,7 +9,7 @@ MidT = TypeVar("MidT")
 
 
 @registry.layers("tuplify.v1")
-def tuplify(layer1: Model, layer2: Model, *layers) -> Model:
+def tuplify(layer1: Model[InT, Any], layer2: Model[InT, Any], *layers) -> Model[InT, Tuple]:
     """Send a separate copy of the input to each child layer, and join the
     outputs of the children into a tuple on the way out.
 

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -773,6 +773,24 @@ residual connections directly, helping the network to learn more smoothly.
 https://github.com/explosion/thinc/blob/master/thinc/layers/residual.py
 ```
 
+### tuplify {#tuplify tag="function"}
+
+Give each child layer a separate copy of the input, and the combine the output
+of the child layers into a tuple. Useful for providing original and modified
+input to a downstream layer.
+
+On the backward pass the loss from each child is added together, so when using
+custom datatypes they should define an addition operator.
+
+| Argument    | Type                             | Description                      |
+| ----------- | -------------------------------- | -------------------------------- |
+| `*layers`   | <tt>Model[ArrayXd, ArrayXd]</tt> | The models to compose.           |
+| **RETURNS** | <tt>Model[ArrayXd, ArrayXd]</tt> | The composed feed-forward model. |
+
+```python
+https://github.com/explosion/thinc/blob/master/thinc/layers/tuplify.py
+```
+
 ### siamese {#siamese tag="function"}
 
 Combine and encode a layer and a similarity function to form a


### PR DESCRIPTION
Tuplify replicates the input so that it can be modified separately by
downstream layers.

This needs tests and probably other metadata settings added still.