### PR TITLE
CI failing with pip 21.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
       python -m pip install pip==21.0
       python -m pip install --upgrade setuptools wheel
       pip install -r requirements.txt
-    displayName: 'Install dependencies (test)'
+    displayName: 'Install dependencies'
 
   - script: |
       python setup.py build_ext --inplace

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools wheel
       pip install -r requirements.txt
-    displayName: 'Install dependencies'
+    displayName: 'Install dependencies (test)'
 
   - script: |
       python setup.py build_ext --inplace

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,8 @@ jobs:
       architecture: 'x64'
 
   - script: |
-      python -m pip install --upgrade pip setuptools wheel
+      python -m pip install pip==21.0
+      python -m pip install --upgrade setuptools wheel
       pip install -r requirements.txt
     displayName: 'Install dependencies (test)'
 


### PR DESCRIPTION
It turns out that the recently released `pip` 21.1 makes our CI fail on Windows. The `pip uninstall` command runs into permission issues with `shutil`, stopping the CI early. 

Pinning `pip` to 21.0 on the CI, as in this PR, resolves the failures, but this solution is obviously not great for longer term. Still, we might consider patching this for now so we can get on with Thinc PRs.