### PR TITLE
Skip tests if packages are missing

### DIFF
--- a/thinc/tests/layers/test_basic_tagger.py
+++ b/thinc/tests/layers/test_basic_tagger.py
@@ -2,11 +2,13 @@ import pytest
 import random
 from thinc.api import Model, Relu, Softmax, HashEmbed, expand_window
 from thinc.api import chain, with_array, Adam, strings2arrays
-import ml_datasets
 
 
 @pytest.fixture(scope="module")
 def ancora():
+    pytest.importorskip("ml_datasets")
+    import ml_datasets
+    print("ancora")
     return ml_datasets.ud_ancora_pos_tags()
 
 

--- a/thinc/tests/layers/test_basic_tagger.py
+++ b/thinc/tests/layers/test_basic_tagger.py
@@ -8,7 +8,6 @@ from thinc.api import chain, with_array, Adam, strings2arrays
 def ancora():
     pytest.importorskip("ml_datasets")
     import ml_datasets
-    print("ancora")
     return ml_datasets.ud_ancora_pos_tags()
 
 

--- a/thinc/tests/layers/test_mnist.py
+++ b/thinc/tests/layers/test_mnist.py
@@ -2,11 +2,12 @@ import pytest
 from thinc.api import Relu, Softmax, chain, clone, Adam
 from thinc.api import PyTorchWrapper, TensorFlowWrapper
 from thinc.util import has_torch, has_tensorflow
-import ml_datasets
 
 
 @pytest.fixture(scope="module")
 def mnist(limit=5000):
+    pytest.importorskip("ml_datasets")
+    import ml_datasets
     (train_X, train_Y), (dev_X, dev_Y) = ml_datasets.mnist()
     return (train_X[:limit], train_Y[:limit]), (dev_X[:limit], dev_Y[:limit])
 

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -1,7 +1,6 @@
 import pytest
 import threading
 import time
-import ml_datasets
 from thinc.api import (
     CupyOps,
     prefer_gpu,
@@ -382,6 +381,8 @@ def test_unique_id_multithreading():
 
 
 def test_model_gpu():
+    pytest.importorskip("ml_datasets")
+    import ml_datasets
     prefer_gpu()
     n_hidden = 32
     dropout = 0.2

--- a/thinc/tests/mypy/test_mypy.py
+++ b/thinc/tests/mypy/test_mypy.py
@@ -6,8 +6,6 @@ import sys
 
 import pytest
 
-from mypy import api as mypy_api
-
 # You can change the following variable to True during development to overwrite expected output with generated output
 GENERATE = False
 
@@ -23,6 +21,8 @@ cases = [
 def test_mypy_results(
     config_filename, python_filename, output_filename, tmpdir, monkeypatch
 ):
+    pytest.importorskip("mypy")
+    from mypy import api as mypy_api
     os.chdir(tmpdir)
     root_dir = Path(__file__).parent
     thinc_root_dir = Path(__file__).parent.parent.parent.parent
@@ -80,4 +80,5 @@ def test_generation_is_disabled():
     """
     Makes sure we don't accidentally leave generation on
     """
+    pytest.importorskip("mypy")
     assert not GENERATE

--- a/thinc/tests/test_examples.py
+++ b/thinc/tests/test_examples.py
@@ -1,13 +1,17 @@
 import os
 from pathlib import Path
 
-import nbformat
 import pytest
-from nbconvert.preprocessors import ExecutePreprocessor
 
 
 @pytest.fixture
 def test_files(nb_file):
+    pytest.importorskip("nbconvert")
+    pytest.importorskip("nbformat")
+    import nbconvert
+    import nbformat
+    from nbconvert.preprocessors import ExecutePreprocessor
+
     if not Path(nb_file).exists():
         return
     kernel_name = os.environ.get("NOTEBOOK_KERNEL", "python3")


### PR DESCRIPTION
Skip mypy, ml_datasets and notebook tests if those (dev-only) requirements are missing. (Primarily due to problems running the test suite on conda-forge.)