### PR TITLE
Update pydantic requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wasabi>=0.8.1,<1.1.0
 catalogue>=2.0.3,<2.1.0
 ml_datasets>=0.2.0,<0.3.0
 # Third-party dependencies
-pydantic>=1.7.1,<1.8.2
+pydantic>=1.7.4,!=1.8,!=1.8.1,<1.9.0
 numpy>=1.15.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     # Third-party dependencies
     setuptools
     numpy>=1.15.0
-    pydantic>=1.7.1,<1.8.2
+    pydantic>=1.7.4,!=1.8,!=1.8.1,<1.9.0
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"
     typing_extensions>=3.7.4.1,<4.0.0.0; python_version < "3.8"


### PR DESCRIPTION
Increase upper pin to `<1.9.0`. Forbid versions with security vulnerability:
https://github.com/samuelcolvin/pydantic/security/advisories/GHSA-5jqp-qgf6-3pvh