### PR TITLE
Require catalogue>=2.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ preshed>=3.0.2,<3.1.0
 blis>=0.4.0,<0.8.0
 srsly>=2.4.0,<3.0.0
 wasabi>=0.8.1,<1.1.0
-catalogue>=2.0.3,<2.1.0
+catalogue>=2.0.4,<2.1.0
 ml_datasets>=0.2.0,<0.3.0
 # Third-party dependencies
 pydantic>=1.7.4,!=1.8,!=1.8.1,<1.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     preshed>=3.0.2,<3.1.0
     wasabi>=0.8.1,<1.1.0
     srsly>=2.4.0,<3.0.0
-    catalogue>=2.0.3,<2.1.0
+    catalogue>=2.0.4,<2.1.0
     # Third-party dependencies
     setuptools
     numpy>=1.15.0


### PR DESCRIPTION
Require `catalogue>=2.0.4` due to bugs in v2.0.3 related to `importlib-metadata`.

