### PR TITLE
Include final ngram in NumpyOps.ngrams

### DIFF
--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -345,11 +345,13 @@ class NumpyOps(Ops):
         return weights, gradient, mom1, mom2
 
     def ngrams(self, int n, const uint64_t[::1] keys):
+        if n < 1:
+            return self.alloc((0,), dtype="uint64")
         keys_ = <uint64_t*>&keys[0]
-        length = max(0, keys.shape[0]-n)
+        length = max(0, keys.shape[0]-(n-1))
         cdef np.ndarray output_ = self.alloc((length,), dtype="uint64")
         output = <uint64_t*>output_.data
-        for i in range(keys.shape[0]-n):
+        for i in range(keys.shape[0]-(n-1)):
             output[i] = hash64(&keys_[i], n*sizeof(keys_[0]), 0)
         return output_
 

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -485,3 +485,12 @@ def test_multibatch():
         ops.multibatch(10, (i for i in range(100)), (i for i in range(100)))
     with pytest.raises(ValueError):
         ops.multibatch(10, arr1, (i for i in range(100)), arr2)
+
+
+def test_ngrams():
+    ops = get_current_ops()
+    arr1 = numpy.asarray([1, 2, 3, 4, 5], dtype=numpy.uint64)
+    for n in range(1, 10):
+        assert len(ops.ngrams(n, arr1)) == max(0, arr1.shape[0] - (n - 1))
+    assert len(ops.ngrams(-1, arr1)) == 0
+    assert len(ops.ngrams(arr1.shape[0] + 1, arr1)) == 0


### PR DESCRIPTION
* Additionally return empty lists for invalid n-gram lengths