### PR TITLE
allow negated values in CategoricalCrossentropy

### DIFF
--- a/thinc/loss.py
+++ b/thinc/loss.py
@@ -45,10 +45,12 @@ class CategoricalCrossentropy(Loss):
         normalize: bool = True,
         names: Optional[List[str]] = None,
         missing_value: Optional[Union[str, int]] = None,
+        neg_prefix: Optional[str] = None,
     ):
         self.normalize = normalize
         self.names = names
         self.missing_value = missing_value
+        self.neg_prefix = neg_prefix
         if names is not None:
             self._name_to_i = {name: i for i, name in enumerate(names)}
         else:
@@ -57,6 +59,7 @@ class CategoricalCrossentropy(Loss):
     def convert_truths(self, truths, guesses: Floats2d) -> Tuple[Floats2d, Floats2d]:
         xp = get_array_module(guesses)
         missing = []
+        negatives_mask = xp.ones((len(truths), len(self.names)), dtype="f")
         missing_value = self.missing_value
         # Convert list of ints or list of strings
         if isinstance(truths, list):
@@ -74,14 +77,23 @@ class CategoricalCrossentropy(Loss):
                     if value == missing_value:
                         truths[i] = self.names[0]
                         missing.append(i)
+                    elif value and value.startswith(self.neg_prefix):
+                        truths[i] = value[len(self.neg_prefix):]
+                        neg_index = self._name_to_i[truths[i]]
+                        negatives_mask[i] = 0
+                        negatives_mask[i][neg_index] = -1
                 truths = [self._name_to_i[name] for name in truths]
             truths = xp.asarray(truths, dtype="i")
-        else:
-            missing = []
         if truths.ndim != guesses.ndim:
             # transform categorical values to one-hot encoding
             truths = to_categorical(cast(Ints1d, truths), n_classes=guesses.shape[-1])
         mask = _make_mask(missing, guesses)
+        # Transform negative annotations to a 0 for the negated value
+        # + mask all other values for that row
+        truths *= negatives_mask
+        truths[truths == -1] = 0
+        negatives_mask[negatives_mask == -1] = 1
+        mask *= negatives_mask
         return truths, mask
 
     def __call__(
@@ -117,7 +129,7 @@ class CategoricalCrossentropy(Loss):
 
 
 @registry.losses("CategoricalCrossentropy.v1")
-def configure_CategoricalCrossentropy(
+def configure_CategoricalCrossentropy_v1(
     *,
     normalize: bool = True,
     names: Optional[List[str]] = None,
@@ -128,6 +140,19 @@ def configure_CategoricalCrossentropy(
     )
 
 
+@registry.losses("CategoricalCrossentropy.v2")
+def configure_CategoricalCrossentropy_v2(
+    *,
+    normalize: bool = True,
+    names: Optional[List[str]] = None,
+    missing_value: Optional[Union[str, int]] = None,
+    neg_prefix: Optional[str] = None,
+) -> CategoricalCrossentropy:
+    return CategoricalCrossentropy(
+        normalize=normalize, names=names, missing_value=missing_value, neg_prefix=neg_prefix
+    )
+
+
 class SequenceCategoricalCrossentropy(Loss):
     def __init__(
         self,
@@ -135,9 +160,10 @@ class SequenceCategoricalCrossentropy(Loss):
         normalize: bool = True,
         names: Optional[List[str]] = None,
         missing_value: Optional[Union[str, int]] = None,
+        neg_prefix: Optional[str] = None,
     ):
         self.cc = CategoricalCrossentropy(
-            normalize=False, names=names, missing_value=missing_value
+            normalize=False, names=names, missing_value=missing_value, neg_prefix=neg_prefix
         )
         self.normalize = normalize
 
@@ -176,10 +202,17 @@ class SequenceCategoricalCrossentropy(Loss):
 
 
 @registry.losses("SequenceCategoricalCrossentropy.v1")
-def configure_SequenceCategoricalCrossentropy(
+def configure_SequenceCategoricalCrossentropy_v1(
     *, normalize: bool = True, names: Optional[List[str]] = None
 ) -> SequenceCategoricalCrossentropy:
     return SequenceCategoricalCrossentropy(normalize=normalize, names=names)
+
+
+@registry.losses("SequenceCategoricalCrossentropy.v2")
+def configure_SequenceCategoricalCrossentropy_v2(
+    *, normalize: bool = True, names: Optional[List[str]] = None, neg_prefix: Optional[str] = None
+) -> SequenceCategoricalCrossentropy:
+    return SequenceCategoricalCrossentropy(normalize=normalize, names=names, neg_prefix=neg_prefix)
 
 
 class L2Distance(Loss):

--- a/thinc/loss.py
+++ b/thinc/loss.py
@@ -59,7 +59,9 @@ class CategoricalCrossentropy(Loss):
     def convert_truths(self, truths, guesses: Floats2d) -> Tuple[Floats2d, Floats2d]:
         xp = get_array_module(guesses)
         missing = []
-        negatives_mask = xp.ones((len(truths), len(self.names)), dtype="f")
+        negatives_mask = None
+        if self.names:
+            negatives_mask = xp.ones((len(truths), len(self.names)), dtype="f")
         missing_value = self.missing_value
         # Convert list of ints or list of strings
         if isinstance(truths, list):
@@ -90,10 +92,11 @@ class CategoricalCrossentropy(Loss):
         mask = _make_mask(missing, guesses)
         # Transform negative annotations to a 0 for the negated value
         # + mask all other values for that row
-        truths *= negatives_mask
-        truths[truths == -1] = 0
-        negatives_mask[negatives_mask == -1] = 1
-        mask *= negatives_mask
+        if negatives_mask is not None:
+            truths *= negatives_mask
+            truths[truths == -1] = 0
+            negatives_mask[negatives_mask == -1] = 1
+            mask *= negatives_mask
         return truths, mask
 
     def __call__(

--- a/thinc/loss.py
+++ b/thinc/loss.py
@@ -79,7 +79,7 @@ class CategoricalCrossentropy(Loss):
                     if value == missing_value:
                         truths[i] = self.names[0]
                         missing.append(i)
-                    elif value and value.startswith(self.neg_prefix):
+                    elif value and self.neg_prefix and value.startswith(self.neg_prefix):
                         truths[i] = value[len(self.neg_prefix):]
                         neg_index = self._name_to_i[truths[i]]
                         negatives_mask[i] = 0

--- a/thinc/loss.py
+++ b/thinc/loss.py
@@ -79,11 +79,13 @@ class CategoricalCrossentropy(Loss):
                     if value == missing_value:
                         truths[i] = self.names[0]
                         missing.append(i)
-                    elif value and self.neg_prefix and value.startswith(self.neg_prefix):
-                        truths[i] = value[len(self.neg_prefix):]
+                    elif (
+                        value and self.neg_prefix and value.startswith(self.neg_prefix)
+                    ):
+                        truths[i] = value[len(self.neg_prefix) :]
                         neg_index = self._name_to_i[truths[i]]
-                        negatives_mask[i] = 0
-                        negatives_mask[i][neg_index] = -1
+                        negatives_mask[i] = 0  # type: ignore
+                        negatives_mask[i][neg_index] = -1  # type: ignore
                 truths = [self._name_to_i[name] for name in truths]
             truths = xp.asarray(truths, dtype="i")
         if truths.ndim != guesses.ndim:
@@ -152,7 +154,10 @@ def configure_CategoricalCrossentropy_v2(
     neg_prefix: Optional[str] = None,
 ) -> CategoricalCrossentropy:
     return CategoricalCrossentropy(
-        normalize=normalize, names=names, missing_value=missing_value, neg_prefix=neg_prefix
+        normalize=normalize,
+        names=names,
+        missing_value=missing_value,
+        neg_prefix=neg_prefix,
     )
 
 
@@ -166,7 +171,10 @@ class SequenceCategoricalCrossentropy(Loss):
         neg_prefix: Optional[str] = None,
     ):
         self.cc = CategoricalCrossentropy(
-            normalize=False, names=names, missing_value=missing_value, neg_prefix=neg_prefix
+            normalize=False,
+            names=names,
+            missing_value=missing_value,
+            neg_prefix=neg_prefix,
         )
         self.normalize = normalize
 
@@ -213,9 +221,14 @@ def configure_SequenceCategoricalCrossentropy_v1(
 
 @registry.losses("SequenceCategoricalCrossentropy.v2")
 def configure_SequenceCategoricalCrossentropy_v2(
-    *, normalize: bool = True, names: Optional[List[str]] = None, neg_prefix: Optional[str] = None
+    *,
+    normalize: bool = True,
+    names: Optional[List[str]] = None,
+    neg_prefix: Optional[str] = None,
 ) -> SequenceCategoricalCrossentropy:
-    return SequenceCategoricalCrossentropy(normalize=normalize, names=names, neg_prefix=neg_prefix)
+    return SequenceCategoricalCrossentropy(
+        normalize=normalize, names=names, neg_prefix=neg_prefix
+    )
 
 
 class L2Distance(Loss):

--- a/thinc/tests/test_loss.py
+++ b/thinc/tests/test_loss.py
@@ -12,9 +12,11 @@ labels0 = numpy.asarray([0, 1, 1], dtype="i")
 guesses1 = numpy.asarray([[0.1, 0.5, 0.6], [0.4, 0.6, 0.3], [1, 1, 1], [0, 0, 0]])
 labels1 = numpy.asarray([2, 1, 0, 2])
 labels1_full = numpy.asarray([[0, 0, 1], [0, 1, 0], [1, 0, 0], [0, 0, 1]])
+labels1_strings = ["C", "B", "A", "C"]
 
-guesses2 = numpy.asarray([[0.2, 0.3]])
+guesses2 = numpy.asarray([[0.2, 0.3, 0.0]])
 labels2 = numpy.asarray([1])
+labels2_strings = ["B"]
 
 eps = 0.0001
 
@@ -72,14 +74,15 @@ def test_categorical_crossentropy_missing(guesses, labels):
 
 
 @pytest.mark.parametrize(
-    "guesses, labels",
+    "guesses, labels, names",
     [
-        ([guesses1, guesses2], [labels1, labels2]),
-        ([guesses1, guesses2], [labels1_full, labels2]),
+        ([guesses1, guesses2], [labels1, labels2], []),
+        ([guesses1, guesses2], [labels1_full, labels2], []),
+        ([guesses1, guesses2], [labels1_strings, labels2_strings], ["A", "B", "C"]),
     ],
 )
-def test_sequence_categorical_crossentropy(guesses, labels):
-    d_scores = SequenceCategoricalCrossentropy(normalize=False).get_grad(
+def test_sequence_categorical_crossentropy(guesses, labels, names):
+    d_scores = SequenceCategoricalCrossentropy(normalize=False, names=names).get_grad(
         guesses, labels
     )
     d_scores1 = d_scores[0]
@@ -89,7 +92,7 @@ def test_sequence_categorical_crossentropy(guesses, labels):
     assert d_scores1[1][0] == pytest.approx(0.4, eps)
     assert d_scores1[1][1] == pytest.approx(-0.4, eps)
     # The normalization divides the difference (e.g. 0.4) by the number of seqs
-    d_scores = SequenceCategoricalCrossentropy(normalize=True).get_grad(guesses, labels)
+    d_scores = SequenceCategoricalCrossentropy(normalize=True, names=names).get_grad(guesses, labels)
     d_scores1 = d_scores[0]
     d_scores2 = d_scores[1]
 
@@ -110,7 +113,7 @@ def test_sequence_categorical_crossentropy(guesses, labels):
     assert d_scores2[0][0] == pytest.approx(0.1, eps)
     assert d_scores2[0][1] == pytest.approx(-0.35, eps)
 
-    loss = SequenceCategoricalCrossentropy(normalize=True).get_loss(guesses, labels)
+    loss = SequenceCategoricalCrossentropy(normalize=True, names=names).get_loss(guesses, labels)
     assert loss == pytest.approx(1.09, eps)
 
 

--- a/thinc/tests/test_loss.py
+++ b/thinc/tests/test_loss.py
@@ -178,6 +178,8 @@ def test_cosine_unmatched():
     [
         ("CategoricalCrossentropy.v1", {}, (scores0, labels0)),
         ("SequenceCategoricalCrossentropy.v1", {}, ([scores0], [labels0])),
+        ("CategoricalCrossentropy.v2", {"neg_prefix": "!"}, (scores0, labels0)),
+        ("SequenceCategoricalCrossentropy.v2", {"neg_prefix": "!"}, ([scores0], [labels0])),
         ("L2Distance.v1", {}, (scores0, scores0)),
         (
             "CosineDistance.v1",

--- a/thinc/tests/test_loss.py
+++ b/thinc/tests/test_loss.py
@@ -117,6 +117,39 @@ def test_sequence_categorical_crossentropy(guesses, labels, names):
     assert loss == pytest.approx(1.09, eps)
 
 
+@pytest.mark.parametrize(
+    "guesses, labels, names",
+    [
+        ([guesses1], [["A", "!A", "", "!C"]], ["A", "B", "C"]),
+    ],
+)
+def test_sequence_categorical_missing_negative(guesses, labels, names):
+    d_scores = SequenceCategoricalCrossentropy(normalize=False, names=names, neg_prefix="!", missing_value="").get_grad(
+        guesses, labels
+    )
+    d_scores0 = d_scores[0]
+
+    # [0.1, 0.5, 0.6] should be A
+    assert d_scores0[0][0] == pytest.approx(-0.9, eps)
+    assert d_scores0[0][1] == pytest.approx(0.5, eps)
+    assert d_scores0[0][2] == pytest.approx(0.6, eps)
+
+    # [0.4, 0.6, 0.3] should NOT be A
+    assert d_scores0[1][0] == pytest.approx(0.4, eps)
+    assert d_scores0[1][1] == pytest.approx(0.0, eps)
+    assert d_scores0[1][2] == pytest.approx(0.0, eps)
+
+    # [1, 1, 1] has missing gold label
+    assert d_scores0[2][0] == pytest.approx(0.0, eps)
+    assert d_scores0[2][1] == pytest.approx(0.0, eps)
+    assert d_scores0[2][2] == pytest.approx(0.0, eps)
+
+    # [0.0, 0.0, 0.0] should NOT be C
+    assert d_scores0[3][0] == pytest.approx(0.0, eps)
+    assert d_scores0[3][1] == pytest.approx(0.0, eps)
+    assert d_scores0[3][2] == pytest.approx(0.0, eps)
+
+
 def test_L2():
     # L2 loss = 2²+4²=20 (or normalized: 1²+2²=5)
     vec1 = numpy.asarray([[1, 2], [8, 9]])


### PR DESCRIPTION
`SequenceCategoricalCrossentropy` can be called with a `truths` array consisting of strings. This PR allows a `neg_prefix` to be defined that signals to the loss function that a given string is negated - i.e. it is a negative annotation.

This way, calculation of the loss can directly take into account a negated value.

## Goal 
This will allow us to train the tagger on labels such as `"!NN"`, without changing much on the spaCy side. The only requirement will be to define the `neg_prefix`. I'll be adding a unit test to spaCy that nicely illustrates this.

## How it works

- input: `truths` array, e.g. `[['!N', 'V', 'J', 'N']]`
- ignoring the negative prefix `!`, this will be converted to indices according to the known labels: `[1, 2, 0, 1]`
- this PR additionally keeps track of a `negatives_mask` which is `1` for all normal values, `-1` for the negated value, and `0` for the other values in the same row. These other values will become masked because `!N` does not tell us whether `V` or `J` is correct, so we don't calculate a loss value on those.
- In this example, the `negatives_mask` will be: 
```
[[ 0. -1.  0.]
 [ 1.  1.  1.]
 [ 1.  1.  1.]
 [ 1.  1.  1.]]
````
the final `truths` array will be 
```
[[0. 0. 0.]
 [0. 0. 1.]
 [1. 0. 0.]
 [0. 1. 0.]]
```
(instead of `[0. 1. 0.]` on the first row)

and the final mask will be 
```
[[0. 1. 0.]
 [1. 1. 1.]
 [1. 1. 1.]
 [1. 1. 1.]]
```
effectively ignoring `V` and `J` for the first instance.
