### PR TITLE
Use newer releases of nbconvert and nbformat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ types-contextvars>=0.1.2; python_version < "3.7"
 types-dataclasses>=0.1.3; python_version < "3.7"
 # Executing notebook tests
 ipykernel>=5.1.4,<5.2.0
-nbconvert==5.6.1,<5.7.0
-nbformat==5.0.4,<5.1.0
+nbconvert>=5.6.1,<6.2.0
+nbformat>=5.0.4,<5.2.0
 # Test to_disk/from_disk against pathlib.Path subclasses
 pathy>=0.3.5


### PR DESCRIPTION
I have only increased the upper ranges. Some combination of older versions and newer dependencies (`nbclient`?) is incompatible, but I'm not sure exactly what.