### PR TITLE
Add context manager and layer wrapper for marking NVTX ranges

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -33,7 +33,7 @@ from .layers import with_array, with_array2d
 from .layers import with_padded, with_list, with_ragged, with_flatten
 from .layers import with_reshape, with_getitem, strings2arrays, list2array
 from .layers import list2ragged, ragged2list, list2padded, padded2list, remap_ids
-from .layers import array_getitem, with_cpu, with_debug
+from .layers import array_getitem, with_cpu, with_debug, with_nvtx_range
 from .layers import tuplify
 
 from .layers import reduce_first, reduce_last, reduce_max, reduce_mean, reduce_sum

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -64,6 +64,7 @@ from .with_ragged import with_ragged
 from .with_reshape import with_reshape
 from .with_getitem import with_getitem
 from .with_debug import with_debug
+from .with_nvtx_range import with_nvtx_range
 
 
 __all__ = [
@@ -119,5 +120,6 @@ __all__ = [
     "with_padded",
     "with_flatten",
     "with_debug",
+    "with_nvtx_range",
     "remap_ids",
 ]

--- a/thinc/layers/with_nvtx_range.py
+++ b/thinc/layers/with_nvtx_range.py
@@ -1,0 +1,38 @@
+from typing import Optional, Callable, Any, Tuple
+
+from ..model import Model
+from ..util import use_nvtx_range
+
+
+def with_nvtx_range(
+    layer: Model,
+    name: Optional[str] = None,
+    *,
+    forward_color: int = -1,
+    backprop_color: int = -1,
+):
+    """Layer that adds wraps any layer and marks the forward and backprop
+    phases as NVTX ranges for CUDA profiling.
+
+    By default, the name of the layer is used as the name of the range,
+    followed by the name of the pass.
+    """
+    name = layer.name if name is None else name
+
+    def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
+        layer = model.layers[0]
+
+        with use_nvtx_range(f"{name} forward", forward_color):
+            layer_Y, layer_callback = layer(X, is_train=is_train)
+
+        def backprop(dY: Any) -> Any:
+            with use_nvtx_range(f"{name} backprop", backprop_color):
+                return layer_callback(dY)
+
+        return layer_Y, backprop
+
+    def init(_model: Model, X: Any, Y: Any) -> Model:
+        return layer.initialize(X, Y)
+
+    return Model(f"nvtx_range({name})", forward, init=init, layers=[layer])
+

--- a/thinc/layers/with_nvtx_range.py
+++ b/thinc/layers/with_nvtx_range.py
@@ -11,7 +11,7 @@ def with_nvtx_range(
     forward_color: int = -1,
     backprop_color: int = -1,
 ):
-    """Layer that adds wraps any layer and marks the forward and backprop
+    """Layer that wraps any layer and marks the forward and backprop
     phases as NVTX ranges for CUDA profiling.
 
     By default, the name of the layer is used as the name of the range,

--- a/thinc/layers/with_nvtx_range.py
+++ b/thinc/layers/with_nvtx_range.py
@@ -20,8 +20,6 @@ def with_nvtx_range(
     name = layer.name if name is None else name
 
     def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
-        layer = model.layers[0]
-
         with use_nvtx_range(f"{name} forward", forward_color):
             layer_Y, layer_callback = layer(X, is_train=is_train)
 
@@ -34,5 +32,6 @@ def with_nvtx_range(
     def init(_model: Model, X: Any, Y: Any) -> Model:
         return layer.initialize(X, Y)
 
-    return Model(f"nvtx_range({name})", forward, init=init, layers=[layer])
-
+    return Model(
+        f"nvtx_range({name})", forward, init=init, layers=[layer], shims=layer.shims
+    )

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -462,6 +462,16 @@ def data_validation(validation):
         yield
         DATA_VALIDATION.set(prev)
 
+@contextlib.contextmanager
+def use_nvtx_range(message: int, id_color: int = -1):
+    """Context manager to register the executed code as an NVTX range. The
+    ranges are can be used as markers in CUDA profiling."""
+    if has_cupy:
+        cupy.cuda.nvtx.RangePush(message, id_color)
+        yield
+        cupy.cuda.nvtx.RangePop()
+    else:
+        yield
 
 __all__ = [
     "get_array_module",
@@ -481,4 +491,5 @@ __all__ = [
     "validate_fwd_input_output",
     "DataValidationError",
     "make_tempfile",
+    "use_nvtx_range",
 ]

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -465,7 +465,7 @@ def data_validation(validation):
 @contextlib.contextmanager
 def use_nvtx_range(message: int, id_color: int = -1):
     """Context manager to register the executed code as an NVTX range. The
-    ranges are can be used as markers in CUDA profiling."""
+    ranges can be used as markers in CUDA profiling."""
     if has_cupy:
         cupy.cuda.nvtx.RangePush(message, id_color)
         yield

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1222,7 +1222,7 @@ model.initialize()
 https://github.com/explosion/thinc/blob/master/thinc/layers/with_debug.py
 ```
 
-### with_nvtx_range {#with_debug tag="function"}
+### with_nvtx_range {#with_nvtx_range tag="function"}
 
 <inline-list>
 
@@ -1245,7 +1245,7 @@ model.initialize()
 | Argument         | Type                   | Description                                                                                               |
 | ---------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------|
 | `layer`          | <tt>Model</tt>         | The layer to wrap.                                                                                        |
-| `name`           | <tt>Optional[str]</tt> | Optional name for the wrapped layer, will be prefixed by `debug:`. Defaults to name of the wrapped layer. |
+| `name`           | <tt>Optional[str]</tt> | Optional name for the wrapped layer. Defaults to the name of the wrapped layer. |
 | _keyword-only_   |                        |                                                                                                           |
 | `forward_color`  | <tt>int</tt>           | Identifier of the color to use for the forward pass                                                       |
 | `backprop_color` | <tt>int</tt>           | Identifier of the color to use for the backward pass                                                      |

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1222,6 +1222,40 @@ model.initialize()
 https://github.com/explosion/thinc/blob/master/thinc/layers/with_debug.py
 ```
 
+### with_nvtx_range {#with_debug tag="function"}
+
+<inline-list>
+
+- **Input:** <tt>Any</tt>
+- **Output:** <tt>Any</tt>
+
+</inline-list>
+
+Layer that wraps any layer and marks the forward and backprop passes as an
+NVTX range. This can be helpful when profiling GPU performance of a layer.
+
+```python
+### Example
+from thinc.api import Linear, with_nvtx_range
+
+model = with_nvtx_range(Linear(2, 5))
+model.initialize()
+```
+
+| Argument         | Type                   | Description                                                                                               |
+| ---------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------|
+| `layer`          | <tt>Model</tt>         | The layer to wrap.                                                                                        |
+| `name`           | <tt>Optional[str]</tt> | Optional name for the wrapped layer, will be prefixed by `debug:`. Defaults to name of the wrapped layer. |
+| _keyword-only_   |                        |                                                                                                           |
+| `forward_color`  | <tt>int</tt>           | Identifier of the color to use for the forward pass                                                       |
+| `backprop_color` | <tt>int</tt>           | Identifier of the color to use for the backward pass                                                      |
+| **RETURNS**      | <tt>Model</tt>         | The wrapped layer.                                                                                        |
+
+```python
+https://github.com/explosion/thinc/blob/master/thinc/layers/with_nvtx_range.py
+```
+
+
 ---
 
 ## Wrappers {#wrappers}


### PR DESCRIPTION
This PR adds the following:

* the `with_nvtx_range` layer that wraps any layer and marks the `forward` and `backprop` passes as an NVTX range. This can be helpful when profiling GPU performance of one or more layers.
* the `use_nvtx_range` context manager, which can be used to mark a scope as an NVTX range.

The ranges are used to mark executions in nvprof or NSight profiles and make it easier to see to which layers/code CUDA operations are associated.