### PR TITLE
Allow config overrides to add new keys

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.8"
+__version__ = "8.0.9"
 __release__ = True

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -352,7 +352,8 @@ class Config(dict):
             if "." not in key:
                 raise ConfigValidationError(errors=err, title=err_title)
             section, option = key.rsplit(".", 1)
-            if section not in config or option not in config[section]:
+            # Check for section and accept if option not in config[section]
+            if section not in config:
                 raise ConfigValidationError(errors=err, title=err_title)
             config.set(section, option, try_dump_json(value, overrides))
 

--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -992,12 +992,14 @@ def test_config_from_str_overrides():
     assert config["a"]["b"] == 10
     assert config["a"]["c"]["d"] == 20
     assert config["a"]["c"]["e"] == 3
+    # Valid values that previously weren't in config
+    config = Config().from_str(config_str, overrides={"a.c.f": 100})
+    assert config["a"]["c"]["d"] == 2
+    assert config["a"]["c"]["e"] == 3
+    assert config["a"]["c"]["f"] == 100
     # Invalid keys and sections
     with pytest.raises(ConfigValidationError):
         Config().from_str(config_str, overrides={"f": 10})
-    # Adding new keys that are not in initial config via overrides
-    with pytest.raises(ConfigValidationError):
-        Config().from_str(config_str, overrides={"a.b": 10, "a.c.f": 200})
     # This currently isn't expected to work, because the dict in f.g is not
     # interpreted as a section while the config is still just the configparser
     with pytest.raises(ConfigValidationError):


### PR DESCRIPTION
Still need to test this against spaCy to check if we need to adjust any tests here. Also a bit worried about potential unitended side-effects (or some important reason why we included this feature that I forgot).

Related: https://github.com/explosion/spacy-transformers/pull/283#issuecomment-903513318

---

The config system currently only allows passing on overrides for existing settings, not new keys. For instance, given a config like this:

```ini
[section]
foo = 1
bar = 2
```

Passing in the overrides `{"section.foo": 3}` is valid, whereas `{"section.baz": 3}` would raise an error. In a lot of scenarios, this makes sense, because you'd expect the config to be complete and describing all available settings – so anything unexpected is likely a problem. But there are other cases where the config is more flexible (e.g. a dictionary with arbitrary keys passed to a function as an argument).