### PR TITLE
PyTorchShim: add support for mixed-precision

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -5,8 +5,8 @@ from .loss import CategoricalCrossentropy, L2Distance, CosineDistance
 from .loss import SequenceCategoricalCrossentropy
 from .model import Model, serialize_attr, deserialize_attr
 from .model import set_dropout_rate, change_attr_values, wrap_model_recursive
-from .shims import Shim, PyTorchShim, TensorFlowShim, keras_model_fns, MXNetShim
-from .shims import maybe_handshake_model
+from .shims import Shim, PyTorchGradScaler, PyTorchShim, TensorFlowShim, keras_model_fns
+from .shims import MXNetShim, maybe_handshake_model
 from .optimizers import Adam, RAdam, SGD, Optimizer
 from .schedules import cyclic_triangular, warmup_linear, constant, constant_then
 from .schedules import decaying, slanted_triangular, compounding

--- a/thinc/layers/pytorchwrapper.py
+++ b/thinc/layers/pytorchwrapper.py
@@ -34,6 +34,46 @@ def PyTorchWrapper(
     pytorch_model,
     convert_inputs: Optional[Callable] = None,
     convert_outputs: Optional[Callable] = None,
+) -> Model[Any, Any]:
+    """Wrap a PyTorch model, so that it has the same API as Thinc models.
+    To optimize the model, you'll need to create a PyTorch optimizer and call
+    optimizer.step() after each batch. See examples/wrap_pytorch.py
+
+    Your PyTorch model's forward method can take arbitrary args and kwargs,
+    but must return either a single tensor as output or a tuple. You may find the
+    PyTorch register_forward_hook helpful if you need to adapt the output.
+
+    The convert functions are used to map inputs and outputs to and from your
+    PyTorch model. Each function should return the converted output, and a callback
+    to use during the backward pass. So:
+
+        Xtorch, get_dX = convert_inputs(X)
+        Ytorch, torch_backprop = model.shims[0](Xtorch, is_train)
+        Y, get_dYtorch = convert_outputs(Ytorch)
+
+    To allow maximum flexibility, the PyTorchShim expects ArgsKwargs objects
+    on the way into the forward and backward passed. The ArgsKwargs objects
+    will be passed straight into the model in the forward pass, and straight
+    into `torch.autograd.backward` during the backward pass.
+    """
+    if convert_inputs is None:
+        convert_inputs = convert_pytorch_default_inputs
+    if convert_outputs is None:
+        convert_outputs = convert_pytorch_default_outputs
+    return Model(
+        "pytorch",
+        forward,
+        attrs={"convert_inputs": convert_inputs, "convert_outputs": convert_outputs},
+        shims=[PyTorchShim(pytorch_model)],
+        dims={"nI": None, "nO": None},
+    )
+
+
+@registry.layers("PyTorchWrapper.v2")
+def PyTorchWrapper_v2(
+    pytorch_model,
+    convert_inputs: Optional[Callable] = None,
+    convert_outputs: Optional[Callable] = None,
     mixed_precision: bool = False,
     grad_scaler: Optional[PyTorchGradScaler] = None,
 ) -> Model[Any, Any]:
@@ -57,6 +97,14 @@ def PyTorchWrapper(
     on the way into the forward and backward passed. The ArgsKwargs objects
     will be passed straight into the model in the forward pass, and straight
     into `torch.autograd.backward` during the backward pass.
+
+    mixed_precision:
+        Enable mixed-precision. This changes whitelisted ops to run
+        in half precision for better performance and lower memory use.
+    grad_scaler:
+        The gradient scaler to use for mixed-precision training. If this
+        argument is set to "None" and mixed precision is enabled, a gradient
+        scaler with the default configuration is used.
     """
     if convert_inputs is None:
         convert_inputs = convert_pytorch_default_inputs

--- a/thinc/layers/pytorchwrapper.py
+++ b/thinc/layers/pytorchwrapper.py
@@ -1,7 +1,7 @@
 from typing import Callable, Tuple, Optional, Any, cast
 
 from ..model import Model
-from ..shims import PyTorchShim
+from ..shims import PyTorchGradScaler, PyTorchShim
 from ..config import registry
 from ..util import is_xp_array, is_torch_array
 from ..util import xp2torch, torch2xp, convert_recursive
@@ -34,6 +34,8 @@ def PyTorchWrapper(
     pytorch_model,
     convert_inputs: Optional[Callable] = None,
     convert_outputs: Optional[Callable] = None,
+    mixed_precision: bool = False,
+    grad_scaler: Optional[PyTorchGradScaler] = None,
 ) -> Model[Any, Any]:
     """Wrap a PyTorch model, so that it has the same API as Thinc models.
     To optimize the model, you'll need to create a PyTorch optimizer and call
@@ -64,7 +66,11 @@ def PyTorchWrapper(
         "pytorch",
         forward,
         attrs={"convert_inputs": convert_inputs, "convert_outputs": convert_outputs},
-        shims=[PyTorchShim(pytorch_model)],
+        shims=[
+            PyTorchShim(
+                pytorch_model, mixed_precision=mixed_precision, grad_scaler=grad_scaler
+            )
+        ],
         dims={"nI": None, "nO": None},
     )
 

--- a/thinc/shims/__init__.py
+++ b/thinc/shims/__init__.py
@@ -1,4 +1,5 @@
 from .shim import Shim
 from .pytorch import PyTorchShim
+from .pytorch_grad_scaler import PyTorchGradScaler
 from .tensorflow import keras_model_fns, TensorFlowShim, maybe_handshake_model
 from .mxnet import MXNetShim

--- a/thinc/shims/pytorch_grad_scaler.py
+++ b/thinc/shims/pytorch_grad_scaler.py
@@ -1,0 +1,133 @@
+try:
+    import torch
+except ImportError:  # pragma: no cover
+    pass
+
+
+class PyTorchGradScaler:
+    """
+    Gradient scaler for the PyTorch shim.
+
+    Gradients with small magnitudes are not representable in half-precision and
+    will underflow to zero. A gradient scaler counters this issue by scaling
+    up the loss before backpropagation, increasing the gradients by the same
+    magnitude. A large enough scale will avoid that the gradients underflow.
+    The gradients are unscaled in single precision after backpropagation, to
+    provide the unscaled gradients to the optimizer.
+    """
+
+    def __init__(
+        self,
+        enabled: bool = False,
+        init_scale: float = 2.0 ** 16,
+        backoff_factor: float = 0.5,
+        growth_factor: float = 2.0,
+        growth_interval: int = 2000,
+    ):
+        """
+        Construct a gradient scaler for the PyTorch shim.
+
+        enabled (bool):
+            Sets whether the gradient scalar is enabled. If it is disabled, the
+            methods of the grad scaler are no-ops.
+
+        init_scale (float):
+            The initial scale used to increase the gradient magnitude.
+
+        backoff_factor (float):
+            The scale will be multiplied by this factor if any of the gradients
+            overflows.
+
+        growth_factor (float):
+            The scale will be multiplied by this factor when none of the gradients
+            overflowed for "growth_interval" steps.
+
+        growth_interval (int):
+            When no overflows were found for this number of steps, the scale will
+            be multiplied by "growth_factor".
+        """
+        self._enabled = enabled
+        self._growth_factor = growth_factor
+        self._backoff_factor = backoff_factor
+        self._growth_interval = growth_interval
+
+        self._found_inf = torch.full((1,), 0.0)
+        self._growth_tracker = torch.full((1,), 0, dtype=torch.int)
+        self._scale = torch.full((1,), init_scale)
+
+    def to_(self, device):
+        self._found_inf = self._found_inf.to(device)
+        self._growth_tracker = self._growth_tracker.to(device)
+        self._scale = self._scale.to(device)
+
+    def scale(self, tensors):
+        """Scale up the values in the given tensors."""
+        if not self._enabled:
+            return tensors
+
+        # Cache per-device scales to avoid unnecessary d2d copies of the current scale.
+        scale_per_device = dict()
+
+        scaled_tensors = []
+        for tensor in tensors:
+            assert tensor.is_cuda, "Gradient scaling is only supported for CUDA tensors"
+
+            device = tensor.device
+
+            if device not in scale_per_device:
+                scale_per_device[device] = self._scale.to(device=device)
+
+            scaled_tensors.append(tensor * scale_per_device[device])
+
+        return scaled_tensors
+
+    def _tensors_per_device(self, tensors):
+        tensors_per_device = dict()
+        for tensor in tensors:
+            device_tensors = tensors_per_device.setdefault(tensor.device, [])
+            device_tensors.append(tensor)
+
+        return tensors_per_device
+
+    def unscale(self, tensors):
+        """Unscale the given tensors. Returns True if any of the gradients were infinite."""
+        if not self._enabled:
+            return False
+
+        # Invert scale (in higher precision).
+        inv_scale = self._scale.double().reciprocal().float()
+
+        # Apply unscaling to tensors, per device.
+        tensors_per_device = self._tensors_per_device(tensors)
+        for device, device_tensors in tensors_per_device.items():
+            found_inf_device = torch.full((1,), 0.0, device=device)
+            inv_scale_device = inv_scale.to(device=device)
+
+            torch._amp_foreach_non_finite_check_and_unscale_(
+                device_tensors, found_inf_device, inv_scale_device
+            )
+
+            self._found_inf += found_inf_device.to(self._found_inf.device)
+
+        return bool(self._found_inf != 0)
+
+    def update(self):
+        """
+        Update the the scale factor and clear information about infinities.
+
+        This method should be called after each optimization step.
+        """
+        if not self._enabled:
+            return
+
+        torch._amp_update_scale_(
+            self._scale,
+            self._growth_tracker,
+            self._found_inf,
+            self._growth_factor,
+            self._backoff_factor,
+            self._growth_interval,
+        )
+
+        # Clear infinity found status
+        self._found_inf = torch.zeros_like(self._found_inf)

--- a/thinc/shims/pytorch_grad_scaler.py
+++ b/thinc/shims/pytorch_grad_scaler.py
@@ -113,7 +113,7 @@ class PyTorchGradScaler:
 
     def update(self):
         """
-        Update the the scale factor and clear information about infinities.
+        Update the scale factor and clear information about infinities.
 
         This method should be called after each optimization step.
         """

--- a/thinc/tests/shims/pytorch_grad_scaler.py
+++ b/thinc/tests/shims/pytorch_grad_scaler.py
@@ -1,0 +1,42 @@
+import pytest
+
+from thinc.util import has_torch, has_torch_gpu
+
+from thinc.api import PyTorchGradScaler
+
+
+@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not has_torch_gpu, reason="needs a GPU")
+def test_grad_scaler():
+    import torch
+
+    device_id = torch.cuda.current_device()
+
+    scaler = PyTorchGradScaler(enabled=True)
+    scaler.to_(device_id)
+
+    #  Test that scaling works as expected.
+    t = torch.tensor([1.0], device=device_id)
+    assert scaler.scale([torch.tensor([1.0], device=device_id)]) == [
+        torch.tensor([2.0 ** 16], device=device_id)
+    ]
+
+    # Test infinity detection.
+    g = [
+        torch.tensor([2.0 ** 16], device=device_id),
+        torch.tensor([float("Inf")], device=device_id),
+    ]
+
+    # Check that infinity was found.
+    assert scaler.unscale(g)
+
+    # Check whether unscale was succesful.
+    assert g[0] == torch.tensor([1.0]).cuda()
+
+    scaler.update()
+
+    # Since infinity was found, the scale should be halved from 2**16
+    # to 2**15 for the next step.
+    assert scaler.scale([torch.tensor([1.0], device=device_id)]) == [
+        torch.tensor([2.0 ** 15], device=device_id)
+    ]

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -29,8 +29,10 @@ try:  # pragma: no cover
     import torch.utils.dlpack
 
     has_torch = True
+    has_torch_gpu = torch.cuda.device_count() != 0
 except ImportError:  # pragma: no cover
     has_torch = False
+    has_torch_gpu = False
 
 try:  # pragma: no cover
     import tensorflow.experimental.dlpack


### PR DESCRIPTION
This change adds support for mixed-precision training and prediction to
the PyTorch shim. Mixed-precision support consists of two parts:

- Autocasting of the forward pass. This changes whitelisted ops to run
  in half precision rather than single precision.
- Gradient scaling. Gradients underflow quickly in half-precision.
  Gradient scaling increases the magnitude of the gradients during
  backprop to avoid underflow.

A separate class, PyTorchGradScaler is introduced to perform gradient
scaling and store the associated state.

---

I hope that I correctly implemented multi-GPU training, but I couldn't test it with my current single GPU workstation.