### PR TITLE
Add wrap_model_recursive

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -4,7 +4,7 @@ from .initializers import configure_normal_init
 from .loss import CategoricalCrossentropy, L2Distance, CosineDistance
 from .loss import SequenceCategoricalCrossentropy
 from .model import Model, serialize_attr, deserialize_attr
-from .model import set_dropout_rate, change_attr_values
+from .model import set_dropout_rate, change_attr_values, wrap_model_recursive
 from .shims import Shim, PyTorchShim, TensorFlowShim, keras_model_fns, MXNetShim
 from .shims import maybe_handshake_model
 from .optimizers import Adam, RAdam, SGD, Optimizer

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -1,25 +1,10 @@
 import pytest
 import threading
 import time
-from thinc.api import (
-    CupyOps,
-    prefer_gpu,
-    Linear,
-    Dropout,
-    Model,
-    Shim,
-    change_attr_values,
-)
-from thinc.api import (
-    set_dropout_rate,
-    chain,
-    concatenate,
-    with_debug,
-    wrap_model_recursive,
-    Relu,
-    Softmax,
-    Adam,
-)
+from thinc.api import Adam, CupyOps, Dropout, Linear, Model, Relu
+from thinc.api import Shim, Softmax, chain, change_attr_values
+from thinc.api import concatenate, prefer_gpu, set_dropout_rate
+from thinc.api import with_debug, wrap_model_recursive
 import numpy
 
 from ..util import make_tempdir

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -473,3 +473,8 @@ def test_recursive_double_wrap():
     # * One around each chain in concatenate. (= 2)
     # * One around each relu in the chain. (= 2)
     assert n_debug == 5
+
+    assert concat_debug.layers[0].layers[0].layers[0].layers[0].name == "debug(relu)"
+    assert concat_debug.layers[0].layers[0].layers[0].layers[1].name == "debug(relu)"
+    assert concat_debug.layers[0].layers[1].layers[0].layers[0].name == "debug(relu)"
+    assert concat_debug.layers[0].layers[1].layers[0].layers[1].name == "debug(relu)"


### PR DESCRIPTION
This is a simple wrapper function that recursively wraps a Model and its layers recursively.

Useful for e.g. recursively wrapping forward/backprop passes in NVTX ranges.
