### PR TITLE
Fix default ops for get_array_ops

### DIFF
--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -86,10 +86,11 @@ def get_ops(name: str, **kwargs) -> Ops:
 
 
 def get_array_ops(arr):
-    """Return CupyOps for a cupy array, the current ops otherwise."""
+    """Return CupyOps for a cupy array, NumpyOps otherwise."""
     if is_cupy_array(arr):
         return CupyOps()
-    return get_current_ops()
+    else:
+        return NumpyOps()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
`get_array_ops` should default to `NumpyOps` rather than the current ops so that numpy arrays are handled correctly.