### PR TITLE
Improve wrapping in with_{debug,nvtx_range}

### DIFF
--- a/thinc/layers/with_debug.py
+++ b/thinc/layers/with_debug.py
@@ -1,7 +1,6 @@
 from typing import Optional, Callable, Any, Tuple
 
-from ..model import Model
-
+from ..model import Model, wrap_with_callbacks
 
 do_nothing = lambda *args, **kwargs: None
 
@@ -35,4 +34,4 @@ def with_debug(
         on_init(model, X, Y)
         return layer.initialize(X, Y)
 
-    return Model(f"debug({name})", forward, init=init, layers=[layer])
+    return wrap_with_callbacks(layer, f"debug({name})", forward, init=init)

--- a/thinc/layers/with_nvtx_range.py
+++ b/thinc/layers/with_nvtx_range.py
@@ -1,6 +1,6 @@
 from typing import Optional, Callable, Any, Tuple
 
-from ..model import Model
+from ..model import Model, wrap_with_callbacks
 from ..util import use_nvtx_range
 
 
@@ -32,6 +32,4 @@ def with_nvtx_range(
     def init(_model: Model, X: Any, Y: Any) -> Model:
         return layer.initialize(X, Y)
 
-    return Model(
-        f"nvtx_range({name})", forward, init=init, layers=[layer], shims=layer.shims
-    )
+    return wrap_with_callbacks(layer, f"debug({name})", forward, init=init)

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -380,6 +380,24 @@ class Model(Generic[InT, OutT]):
                 if ref is not None and ref not in tree:
                     node.set_ref(name, None)
 
+    def replace_node(self, old: "Model", new: "Model") -> bool:
+        """Replace a node anywhere it occurs within the model. Returns a boolean
+        indicating whether the replacement was made."""
+        seen = False
+
+        for node in list(self.walk()):
+            if node is old:
+                seen = True
+            else:
+                node._layers = [
+                    new if layer is old else layer for layer in node._layers
+                ]
+                for name in node.ref_names:
+                    if node.get_ref(name) is old:
+                        node.set_ref(name, new)
+
+        return seen
+
     def get_gradients(self) -> Dict[Tuple[int, str], Tuple[FloatsXd, FloatsXd]]:
         """Get non-zero gradients of the model's parameters, as a dictionary
         keyed by the parameter ID. The values are (weights, gradients) tuples.
@@ -767,20 +785,13 @@ def set_dropout_rate(model: _ModelT, drop: float, attrs=["dropout_rate"]) -> _Mo
     return model
 
 
-def wrap_model_recursive(
-    model: _ModelT, wrapper: Callable[[_ModelT], _ModelT]
-) -> Model:
+def wrap_model_recursive(model: Model, wrapper: Callable[[Model], _ModelT]) -> _ModelT:
     """Recursively wrap a model and its submodules. The model is updated
     in-place."""
+    for node in list(model.walk()):
+        model.replace_node(node, wrapper(node))
 
-    def wrap_recursive_(model, wrapper, seen):
-        # Only wrap child layers if we haven't done so yet.
-        if id(model) not in seen:
-            model._layers = [wrap_recursive_(x, wrapper, seen) for x in model.layers]
-            seen.add(id(model))
-        return wrapper(model)
-
-    return wrap_recursive_(model, wrapper, set())
+    return wrapper(model)
 
 
 __all__ = [

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -794,6 +794,23 @@ def wrap_model_recursive(model: Model, wrapper: Callable[[Model], _ModelT]) -> _
     return wrapper(model)
 
 
+def wrap_with_callbacks(
+    layer: _ModelT, name: str, forward: Callable, *, init: Optional[Callable] = None
+) -> Model:
+    """Wrap a layer with the given forward and init callbacks. Returns the wrapper."""
+    return Model(
+        name,
+        forward,
+        init=init,
+        dims=layer._dims,
+        layers=[layer],
+        refs=layer._refs,
+        shims=layer.shims,
+        attrs=layer.attrs,
+        ops=layer.ops,
+    )
+
+
 __all__ = [
     "Model",
     "serialize_attr",

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -483,6 +483,19 @@ def test_recursive_wrap():
     assert chained_debug.layers[0].layers[1].layers[0] is relu
 
 
+def test_wrap_refs():
+    relu = Relu(5)
+    model = Model(
+        "model", lambda X: (X, lambda dY: dY), layers=[relu], refs={"relu": relu}
+    )
+    model_debug = wrap_model_recursive(model, with_debug)
+    assert model_debug.name == "debug(model)"
+    assert model_debug.layers[0].name == "model"
+    assert model_debug.layers[0].layers[0].name == "debug(relu)"
+    assert model_debug.get_ref("relu").name == "debug(relu)"
+    assert model_debug.layers[0].get_ref("relu").name == "debug(relu)"
+
+
 def test_recursive_double_wrap():
     relu = Relu(5)
     chained = chain(relu, relu)


### PR DESCRIPTION
This PR combines two changes:

1. In `wrap_model_recursive`, also make sure that node references are pointing to the wrapped nodes.
2. Pass through dims, refs, attrs, and ops, so that these can be queried when a layer is wrapped.