### PR TITLE
CategoricalCrossEntropy: support missing values for int arrays

### DIFF
--- a/thinc/loss.py
+++ b/thinc/loss.py
@@ -97,7 +97,7 @@ class CategoricalCrossentropy(Loss):
             truths = xp.asarray(truths, dtype="i")
             mask = _make_mask(guesses, missing)
         else:
-            mask = _make_xp_mask(truths, guesses, missing_value)
+            mask = _make_mask_by_value(truths, guesses, missing_value)
         if truths.ndim != guesses.ndim:
             # transform categorical values to one-hot encoding
             truths = to_categorical(cast(Ints1d, truths), n_classes=guesses.shape[-1])
@@ -351,7 +351,7 @@ def _make_mask(guesses, missing) -> Floats2d:
     return mask
 
 
-def _make_xp_mask(truths, guesses, missing_value) -> Floats2d:
+def _make_mask_by_value(truths, guesses, missing_value) -> Floats2d:
     xp = get_array_module(guesses)
     mask = xp.ones(guesses.shape, dtype="f")
 

--- a/thinc/loss.py
+++ b/thinc/loss.py
@@ -95,9 +95,9 @@ class CategoricalCrossentropy(Loss):
                             negatives_mask[i][neg_index] = -1  # type: ignore
                     truths = [self._name_to_i[name] for name in truths]
             truths = xp.asarray(truths, dtype="i")
-            mask = _make_mask(missing, guesses)
+            mask = _make_mask(guesses, missing)
         else:
-            mask = _make_xp_mask(guesses, truths, missing_value)
+            mask = _make_xp_mask(truths, guesses, missing_value)
         if truths.ndim != guesses.ndim:
             # transform categorical values to one-hot encoding
             truths = to_categorical(cast(Ints1d, truths), n_classes=guesses.shape[-1])
@@ -344,14 +344,14 @@ def configure_CosineDistance(
     return CosineDistance(normalize=normalize, ignore_zeros=ignore_zeros)
 
 
-def _make_mask(missing, guesses) -> Floats2d:
+def _make_mask(guesses, missing) -> Floats2d:
     xp = get_array_module(guesses)
     mask = xp.ones(guesses.shape, dtype="f")
     mask[missing] = 0
     return mask
 
 
-def _make_xp_mask(guesses, truths, missing_value) -> Floats2d:
+def _make_xp_mask(truths, guesses, missing_value) -> Floats2d:
     xp = get_array_module(guesses)
     mask = xp.ones(guesses.shape, dtype="f")
 

--- a/thinc/tests/test_loss.py
+++ b/thinc/tests/test_loss.py
@@ -66,11 +66,62 @@ def test_categorical_crossentropy(guesses, labels):
 
 
 @pytest.mark.parametrize(
+    "guesses, labels",
+    [(guesses1, [2, 1, 0, 2])],
+)
+def test_categorical_crossentropy_int_list_missing(guesses, labels):
+    d_scores = CategoricalCrossentropy(normalize=True, missing_value=0).get_grad(
+        guesses, labels
+    )
+    assert d_scores.shape == guesses.shape
+
+    # The normalization divides the difference (e.g. 0.4) by the number of vectors (4)
+    assert d_scores[1][0] == pytest.approx(0.1, eps)
+    assert d_scores[1][1] == pytest.approx(-0.1, eps)
+
+    # Label 0 is masked, because it represents the missing value
+    assert d_scores[2][0] == 0.0
+    assert d_scores[2][1] == 0.0
+    assert d_scores[2][2] == 0.0
+
+    # The fourth vector predicted no labels but should have predicted the last one
+    assert d_scores[3][0] == pytest.approx(0, eps)
+    assert d_scores[3][1] == pytest.approx(0, eps)
+    assert d_scores[3][2] == pytest.approx(-0.25, eps)
+
+    loss = CategoricalCrossentropy(normalize=True, missing_value=0).get_loss(
+        guesses, labels
+    )
+    assert loss == pytest.approx(0.114375, eps)
+
+
+@pytest.mark.parametrize(
     "guesses, labels", [(guesses1, labels1), (guesses1, labels1_full)]
 )
 def test_categorical_crossentropy_missing(guesses, labels):
-    d_scores = CategoricalCrossentropy(normalize=True).get_grad(guesses, labels)
+    d_scores = CategoricalCrossentropy(normalize=True, missing_value=0).get_grad(
+        guesses, labels
+    )
     assert d_scores.shape == guesses.shape
+
+    # The normalization divides the difference (e.g. 0.4) by the number of vectors (4)
+    assert d_scores[1][0] == pytest.approx(0.1, eps)
+    assert d_scores[1][1] == pytest.approx(-0.1, eps)
+
+    # Label 0 is masked, because it represents the missing value
+    assert d_scores[2][0] == 0.0
+    assert d_scores[2][1] == 0.0
+    assert d_scores[2][2] == 0.0
+
+    # The fourth vector predicted no labels but should have predicted the last one
+    assert d_scores[3][0] == pytest.approx(0, eps)
+    assert d_scores[3][1] == pytest.approx(0, eps)
+    assert d_scores[3][2] == pytest.approx(-0.25, eps)
+
+    loss = CategoricalCrossentropy(normalize=True, missing_value=0).get_loss(
+        guesses, labels
+    )
+    assert loss == pytest.approx(0.114375, eps)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`CategoricalCrossEntropy` provides a `missing_value` option that can be used
to mask instances that have a special label. However, this functionality
only works with non-integer categorical labels.

This change adds support for masking missing values for int lists and xp
arrays.