### PR TITLE
Fix name of the layer created with with_nvtx_range

### DIFF
--- a/thinc/layers/with_nvtx_range.py
+++ b/thinc/layers/with_nvtx_range.py
@@ -32,4 +32,4 @@ def with_nvtx_range(
     def init(_model: Model, X: Any, Y: Any) -> Model:
         return layer.initialize(X, Y)
 
-    return wrap_with_callbacks(layer, f"debug({name})", forward, init=init)
+    return wrap_with_callbacks(layer, f"ntvx_range({name})", forward, init=init)


### PR DESCRIPTION
The layer was named `debug(...)`, should be `nvtx_range(...)`. This is
only a cosmetic change, but looks nicer when debugging models.