### PR TITLE
Wrap layer callbacks in with_{debug,nvtx_range}

### DIFF
--- a/thinc/layers/with_debug.py
+++ b/thinc/layers/with_debug.py
@@ -1,28 +1,32 @@
-from typing import Optional, Callable, Any, Tuple
+from typing import Optional, Callable, Any, Tuple, TypeVar
 
 from ..model import Model, wrap_with_callbacks
+
+_ModelT = TypeVar("_ModelT", bound=Model)
 
 do_nothing = lambda *args, **kwargs: None
 
 
 def with_debug(
-    layer: Model,
+    layer: _ModelT,
     name: Optional[str] = None,
     *,
     on_init: Callable[[Model, Any, Any], None] = do_nothing,
     on_forward: Callable[[Model, Any, bool], None] = do_nothing,
     on_backprop: Callable[[Any], None] = do_nothing,
-):
+) -> _ModelT:
     """Debugging layer that wraps any layer and allows executing callbacks
     during the forward pass, backward pass and initialization. The callbacks
     will receive the same arguments as the functions they're called in.
     """
     name = layer.name if name is None else name
 
+    orig_forward = layer._func
+    orig_init = layer.init
+
     def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
-        layer = model.layers[0]
         on_forward(model, X, is_train)
-        layer_Y, layer_callback = layer(X, is_train=is_train)
+        layer_Y, layer_callback = orig_forward(layer, X, is_train=is_train)
 
         def backprop(dY: Any) -> Any:
             on_backprop(dY)
@@ -32,6 +36,11 @@ def with_debug(
 
     def init(model: Model, X: Any, Y: Any) -> Model:
         on_init(model, X, Y)
-        return layer.initialize(X, Y)
+        if orig_init is not None:
+            return orig_init(layer, X, Y)
+        else:
+            return layer
 
-    return wrap_with_callbacks(layer, f"debug({name})", forward, init=init)
+    layer.replace_callbacks(forward, init=init)
+
+    return layer

--- a/thinc/layers/with_debug.py
+++ b/thinc/layers/with_debug.py
@@ -1,6 +1,6 @@
 from typing import Optional, Callable, Any, Tuple, TypeVar
 
-from ..model import Model, wrap_with_callbacks
+from ..model import Model
 
 _ModelT = TypeVar("_ModelT", bound=Model)
 

--- a/thinc/layers/with_nvtx_range.py
+++ b/thinc/layers/with_nvtx_range.py
@@ -1,27 +1,33 @@
-from typing import Optional, Callable, Any, Tuple
+from typing import Optional, Callable, Any, Tuple, TypeVar
 
 from ..model import Model, wrap_with_callbacks
 from ..util import use_nvtx_range
 
 
+_ModelT = TypeVar("_ModelT", bound=Model)
+
+
 def with_nvtx_range(
-    layer: Model,
+    layer: _ModelT,
     name: Optional[str] = None,
     *,
     forward_color: int = -1,
     backprop_color: int = -1,
-):
-    """Layer that wraps any layer and marks the forward and backprop
-    phases as NVTX ranges for CUDA profiling.
+) -> _ModelT:
+    """Wraps any layer and marks the forward and backprop phases as
+    NVTX ranges for CUDA profiling.
 
     By default, the name of the layer is used as the name of the range,
     followed by the name of the pass.
     """
     name = layer.name if name is None else name
 
+    orig_forward = layer._func
+    orig_init = layer.init
+
     def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
         with use_nvtx_range(f"{name} forward", forward_color):
-            layer_Y, layer_callback = layer(X, is_train=is_train)
+            layer_Y, layer_callback = orig_forward(model, X, is_train=is_train)
 
         def backprop(dY: Any) -> Any:
             with use_nvtx_range(f"{name} backprop", backprop_color):
@@ -30,6 +36,11 @@ def with_nvtx_range(
         return layer_Y, backprop
 
     def init(_model: Model, X: Any, Y: Any) -> Model:
-        return layer.initialize(X, Y)
+        if orig_init is not None:
+            return orig_init(layer, X, Y)
+        else:
+            return layer
 
-    return wrap_with_callbacks(layer, f"debug({name})", forward, init=init)
+    layer.replace_callbacks(forward, init=init)
+
+    return layer

--- a/thinc/layers/with_nvtx_range.py
+++ b/thinc/layers/with_nvtx_range.py
@@ -1,6 +1,6 @@
 from typing import Optional, Callable, Any, Tuple, TypeVar
 
-from ..model import Model, wrap_with_callbacks
+from ..model import Model
 from ..util import use_nvtx_range
 
 

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -840,23 +840,6 @@ def wrap_model_recursive(model: Model, wrapper: Callable[[Model], _ModelT]) -> _
     return wrapper(model)
 
 
-def wrap_with_callbacks(
-    layer: Model, name: str, forward: Callable, *, init: Optional[Callable] = None
-) -> Model:
-    """Wrap a layer with the given forward and init callbacks. Returns the wrapper."""
-    return Model(
-        name,
-        forward,
-        init=init,
-        dims=layer._dims,
-        layers=[layer],
-        refs=layer._refs,
-        shims=layer.shims,
-        attrs=layer.attrs,
-        ops=layer.ops,
-    )
-
-
 __all__ = [
     "Model",
     "serialize_attr",

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -417,6 +417,12 @@ class Model(Generic[InT, OutT]):
                 if ref is not None and ref not in tree:
                     node.set_ref(name, None)
 
+    def replace_callbacks(
+        self, forward: Callable, *, init: Optional[Callable] = None
+    ) -> None:
+        setattr(self, "_func", forward)
+        setattr(self, "init", init)
+
     def replace_node(self, old: "Model", new: "Model") -> bool:
         """Replace a node anywhere it occurs within the model. Returns a boolean
         indicating whether the replacement was made."""
@@ -835,7 +841,7 @@ def wrap_model_recursive(model: Model, wrapper: Callable[[Model], _ModelT]) -> _
 
 
 def wrap_with_callbacks(
-    layer: _ModelT, name: str, forward: Callable, *, init: Optional[Callable] = None
+    layer: Model, name: str, forward: Callable, *, init: Optional[Callable] = None
 ) -> Model:
     """Wrap a layer with the given forward and init callbacks. Returns the wrapper."""
     return Model(


### PR DESCRIPTION
Before this change, with_{debug,nvtx_range} instrumented a `Model`'s init/forward/backprop by wrapping it in another `Model`. However, this turns out to be tricky, since in some cases we have to propagate information from the wrapped nodes (e.g. references) while in other cases we shouldn't.
    
With this change, we instead add instumentation by wrapping a `Model`'s init and forward callbacks. This makes the nodes in the graph appear as they were before wrapping, but adds behavior in the wrapped callbacks.
    
The with_{debug,nvtx_range} still returns `Model` to maintain compatibility with the existing API. Though the returned `Model` is the `Model` that is wrapped.