### PR TITLE
get_ops: support returning the best avilable CPU backend

### DIFF
--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -434,6 +434,13 @@ def test_lstm_forward_training_fuzz(ops, args):
 def test_get_ops():
     assert isinstance(get_ops("numpy"), NumpyOps)
     assert isinstance(get_ops("cupy"), CupyOps)
+    # If Apple ops are available, "cpu" should return AppleOps or
+    # NumpyOps otherwise.
+    try:
+        from thinc_apple_ops import AppleOps
+        assert isinstance(get_ops("cpu"), AppleOps)
+    except ImportError:
+        assert isinstance(get_ops("cpu"), NumpyOps)
     with pytest.raises(ValueError):
         get_ops("blah")
     ops = Ops(numpy)


### PR DESCRIPTION
When using `{get,use}_ops`, we often do no want a particular CPU backend, but the best CPU backend that is available (e.g. Accelerate-based thinc ops on a Mac).

This change adds a special op value `cpu` that returns the best available CPU backend. E.g.:

```python
with use_ops("cpu"):
   # ...
```