### PR TITLE
mixed-precision: do not backprop Inf/NaN out of PyTorch layers

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -25,6 +25,7 @@ from .layers import CauchySimilarity, ParametricAttention, Logistic
 from .layers import resizable, sigmoid_activation, Sigmoid, SparseLinear
 from .layers import PyTorchWrapper, PyTorchRNNWrapper, PyTorchLSTM
 from .layers import TensorFlowWrapper, keras_subclass, MXNetWrapper
+from .layers import PyTorchWrapper_v2
 
 from .layers import add, bidirectional, chain, clone, concatenate, noop
 from .layers import residual, uniqued, siamese, list2ragged, ragged2list

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -12,7 +12,8 @@ from .maxout import Maxout
 from .mish import Mish
 from .multisoftmax import MultiSoftmax
 from .parametricattention import ParametricAttention
-from .pytorchwrapper import PyTorchWrapper, PyTorchRNNWrapper
+from .pytorchwrapper import PyTorchWrapper, PyTorchWrapper_v2
+from .pytorchwrapper import PyTorchRNNWrapper
 from .relu import Relu
 from .resizable import resizable
 from .sigmoid_activation import sigmoid_activation
@@ -82,6 +83,7 @@ __all__ = [
     "ParametricAttention",
     "PyTorchLSTM",
     "PyTorchWrapper",
+    "PyTorchWrapper_v2",
     "PyTorchRNNWrapper",
     "Relu",
     "sigmoid_activation",

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -88,7 +88,7 @@ class PyTorchShim(Shim):
             # backprop'ed through the succeeding layer to get the same effect as loss
             # scaling.
             grads.kwargs["grad_tensors"] = self._grad_scaler.scale(
-                grads.kwargs["grad_tensors"]
+                grads.kwargs["grad_tensors"], inplace=True
             )
 
             torch.autograd.backward(*grads.args, **grads.kwargs)

--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, cast
 import contextlib
 from io import BytesIO
+import itertools
 import srsly
 
 try:
@@ -11,7 +12,7 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
-from ..util import torch2xp, xp2torch, convert_recursive
+from ..util import torch2xp, xp2torch, convert_recursive, iterate_recursive
 from ..backends import get_current_ops
 from ..optimizers import Optimizer
 from ..types import ArgsKwargs, FloatsXd
@@ -91,23 +92,33 @@ class PyTorchShim(Shim):
             )
 
             torch.autograd.backward(*grads.args, **grads.kwargs)
-            return convert_recursive(
-                lambda x: hasattr(x, "grad"), lambda x: x.grad, inputs
-            )
+
+            # Unscale weights and check for overflows during backprop.
+            grad_tensors = []
+            for torch_data in itertools.chain(
+                self._model.parameters(),
+                iterate_recursive(lambda x: hasattr(x, "grad"), inputs),
+            ):
+                if torch_data.grad is not None:
+                    grad_tensors.append(torch_data.grad)
+            found_inf = self._grad_scaler.unscale(grad_tensors)
+
+            # If there was an over/underflow, return zeroed-out gradients.
+            if found_inf:
+                grad_get = lambda x: x.grad.zero_() if x.grad is not None else x.grad
+            else:
+                grad_get = lambda x: x.grad
+
+            return convert_recursive(lambda x: hasattr(x, "grad"), grad_get, inputs)
 
         return output, backprop
 
     def finish_update(self, optimizer: Optimizer):
-        # Unscale weights and check for overflows during backprop.
-        grad_tensors = []
         for name, torch_data in self._model.named_parameters():
             if torch_data.grad is not None:
-                grad_tensors.append(torch_data.grad)
-        found_inf = self._grad_scaler.unscale(grad_tensors)
-
-        for name, torch_data in self._model.named_parameters():
-            if torch_data.grad is not None:
-                if not found_inf:  # Skip weight update if any gradient overflowed.
+                if (
+                    not self._grad_scaler.found_inf
+                ):  # Skip weight update if any gradient overflowed.
                     param, grad = optimizer(
                         (self.id, name),
                         cast(FloatsXd, torch2xp(torch_data.data)),

--- a/thinc/shims/pytorch_grad_scaler.py
+++ b/thinc/shims/pytorch_grad_scaler.py
@@ -89,6 +89,10 @@ class PyTorchGradScaler:
 
         return tensors_per_device
 
+    @property
+    def found_inf(self):
+        return bool(self._found_inf) != 0
+
     def unscale(self, tensors):
         """Unscale the given tensors. Returns True if any of the gradients were infinite."""
         if not self._enabled:

--- a/thinc/tests/layers/test_pytorch_wrapper.py
+++ b/thinc/tests/layers/test_pytorch_wrapper.py
@@ -1,9 +1,18 @@
-from thinc.api import Linear, SGD, PyTorchWrapper, xp2torch, torch2xp, ArgsKwargs
-from thinc.util import has_torch
+from thinc.api import Linear, SGD, PyTorchWrapper, PyTorchWrapper_v2
+from thinc.api import xp2torch, torch2xp, ArgsKwargs, use_ops
+from thinc.api import chain, get_current_ops, Relu
+from thinc.shims.pytorch_grad_scaler import PyTorchGradScaler
+from thinc.util import has_torch, has_torch_amp, has_torch_gpu
 import numpy
 import pytest
 
 from ..util import make_tempdir, check_input_converters
+
+
+if has_torch_amp:
+    TORCH_MIXED_PRECISION = [False, True]
+else:
+    TORCH_MIXED_PRECISION = [False]
 
 
 def check_learns_zero_output(model, sgd, X, Y):
@@ -51,6 +60,42 @@ def test_pytorch_wrapper(nN, nI, nO):
     assert dX.shape == (nN, nI)
     check_learns_zero_output(model, sgd, X, Y)
     assert isinstance(model.predict(X), numpy.ndarray)
+
+
+@pytest.mark.skipif(not has_torch_gpu, reason="needs PyTorch with CUDA-capable GPU")
+@pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
+@pytest.mark.parametrize("mixed_precision", TORCH_MIXED_PRECISION)
+def test_pytorch_wrapper_thinc_input(nN, nI, nO, mixed_precision):
+    import torch.nn
+
+    with use_ops("cupy"):
+        ops = get_current_ops()
+        pytorch_layer = torch.nn.Linear(nO, nO)
+        # Initialize with large weights to trigger overflow of FP16 in
+        # mixed-precision training.
+        torch.nn.init.uniform_(pytorch_layer.weight, 9.0, 11.0)
+        model = chain(
+            Relu(),
+            PyTorchWrapper_v2(
+                pytorch_layer.cuda(),
+                mixed_precision=mixed_precision,
+                grad_scaler=PyTorchGradScaler(enabled=True, init_scale=2.0 ** 16),
+            ).initialize(),
+        )
+        sgd = SGD(0.001)
+        X = ops.xp.zeros((nN, nI), dtype="f")
+        X += ops.xp.random.uniform(size=X.size).reshape(X.shape)
+        Y = ops.xp.zeros((nN, nO), dtype="f")
+        model.initialize(X, Y)
+        Yh, get_dX = model.begin_update(X)
+        assert isinstance(Yh, ops.xp.ndarray)
+        assert Yh.shape == (nN, nO)
+        dYh = (Yh - Y) / Yh.shape[0]
+        dX = get_dX(dYh)
+        model.finish_update(sgd)
+        assert dX.shape == (nN, nI)
+        check_learns_zero_output(model, sgd, X, Y)
+        assert isinstance(model.predict(X), ops.xp.ndarray)
 
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")

--- a/thinc/tests/shims/test_pytorch_grad_scaler.py
+++ b/thinc/tests/shims/test_pytorch_grad_scaler.py
@@ -20,6 +20,13 @@ def test_grad_scaler():
     assert scaler.scale([torch.tensor([1.0], device=device_id)]) == [
         torch.tensor([2.0 ** 16], device=device_id)
     ]
+    assert scaler.scale(torch.tensor([1.0], device=device_id)) == torch.tensor(
+        [2.0 ** 16], device=device_id
+    )
+    with pytest.raises(ValueError):
+        scaler.scale("bogus")
+    with pytest.raises(ValueError):
+        scaler.scale(42)
 
     # Test infinity detection.
     g = [

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -292,6 +292,24 @@ def convert_recursive(
         return obj
 
 
+def iterate_recursive(is_match: Callable[[Any], bool], obj: Any) -> Any:
+    """Either yield a single value if it matches a given function, or recursively
+    walk over potentially nested lists, tuples and dicts yielding matching
+    values. Also supports the ArgsKwargs dataclass.
+    """
+    if is_match(obj):
+        yield obj
+    elif isinstance(obj, ArgsKwargs):
+        yield from iterate_recursive(is_match, list(obj.items()))
+    elif isinstance(obj, dict):
+        for key, value in obj.items():
+            yield from iterate_recursive(is_match, key)
+            yield from iterate_recursive(is_match, value)
+    elif isinstance(obj, list) or isinstance(obj, tuple):
+        for item in obj:
+            yield from iterate_recursive(is_match, item)
+
+
 def xp2torch(
     xp_tensor: ArrayXd, requires_grad: bool = False
 ) -> "torch.Tensor":  # pragma: no cover

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -30,9 +30,11 @@ try:  # pragma: no cover
 
     has_torch = True
     has_torch_gpu = torch.cuda.device_count() != 0
+    has_torch_amp = not torch.cuda.amp.common.amp_definitely_not_available()
 except ImportError:  # pragma: no cover
     has_torch = False
     has_torch_gpu = False
+    has_torch_amp = False
 
 try:  # pragma: no cover
     import tensorflow.experimental.dlpack


### PR DESCRIPTION
With mixed-precision enabled in a PyTorchWrapper, an update is skipped and the gradient scale is adjusted when one or more of the gradients is Inf/NaN. However, Inf/NaN gradients were still backpropagated into preceding Thinc layers.

This change fixes this issue by clearing gradients of inputs to PyTorchWrapper if Inf/NaN occurs in any of the gradients.

Also:

* Change `PyTorchGradScaler.scale` to accept `Tensor` besides `Sequence[Tensor]`.
* Expose `PyTorchWrapper_v2` in the API
* Add a unit test for mixed-precision training.

---

~Set to draft because:~

- [x] ~Still needs testing on a transformer model.~ Similar accuracies in a tagger -> morphologizer pipeline ✅ 
- [x] ~Needs to be rebased after #553  and #554.~ ✅