### PR TITLE
{set,use}_ops: switch PyTorch Tensor type

### DIFF
--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -10,7 +10,7 @@ from .numpy_ops import NumpyOps
 from ._cupy_allocators import cupy_tensorflow_allocator, cupy_pytorch_allocator
 from ._param_server import ParamServer
 from ..util import assert_tensorflow_installed, assert_pytorch_installed
-from ..util import is_cupy_array
+from ..util import is_cupy_array, set_torch_tensor_type_for_ops
 from .. import registry
 
 
@@ -127,6 +127,7 @@ def set_current_ops(ops: Ops) -> None:
     """Change the current backend object."""
     context_ops.set(ops)
     _get_thread_state().ops = ops
+    set_torch_tensor_type_for_ops(ops)
 
 
 def contextvars_eq_thread_ops() -> bool:


### PR DESCRIPTION
`{set,use}_ops` did not change the default PyTorch Tensor type, whereas `require_{cpu, gpu}` do. As a result, these set/use functions require more work to use correctly with PyTorch

This change rectifies this by also changing the default PyTorch Tensor type when `{set,use}_ops` are used.