### PR TITLE
use_ops: always restore the original ops

### DIFF
--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -114,8 +114,10 @@ def use_ops(name: str, **kwargs):
     """Change the backend to execute on for the scope of the block."""
     current_ops = get_current_ops()
     set_current_ops(get_ops(name, **kwargs))
-    yield
-    set_current_ops(current_ops)
+    try:
+        yield
+    finally:
+        set_current_ops(current_ops)
 
 
 def get_current_ops() -> Ops:


### PR DESCRIPTION
If an exception was raised in a context, the original ops were not
restored. This is particularly annoying in unit tests, where an
exception in a single test would lead to failures in many other tests
because the default NumPy ops are not restored.