### PR TITLE
tuplify: fix error when deducing nI

### DIFF
--- a/thinc/layers/tuplify.py
+++ b/thinc/layers/tuplify.py
@@ -24,6 +24,7 @@ def tuplify(layer1: Model[InT, Any], layer2: Model[InT, Any], *layers) -> Model[
         tuplify_forward,
         init=init,
         layers=layers,
+        dims={"nI": None},
     )
 
 

--- a/thinc/tests/layers/test_combinators.py
+++ b/thinc/tests/layers/test_combinators.py
@@ -69,6 +69,13 @@ def test_tuplify_dulicates_input():
     assert out == (ones, ones)
 
 
+def test_tuplify_initialize(nI, nO):
+    linear = Linear(nO)
+    model = tuplify(linear, linear)
+    ones = numpy.ones((1, nI), dtype="float")
+    model.initialize(X=ones)
+
+
 def test_tuplify_three(model1, model2, model3):
     model = tuplify(model1, model2, model3)
     assert len(model.layers) == 3


### PR DESCRIPTION
If `nI` can be deduced from the first layer, `tuplify`'s initialization
tries to set `nI`. However, this failed because the dimension `nI` is not
known.

This change adds `nI` to `tuplify` as a known dimension and adds a unit test
to check that `tuplify` can be initialized correctly.