### PR TITLE
Fix circular import related to ops registry

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,11 @@ jobs:
   - script: |
       pip uninstall -y tensorflow
       pip install thinc-apple-ops
+      python -m pytest --pyargs thinc_apple_ops
+    displayName: 'Run tests for thinc-apple-ops'
+    condition: and(startsWith(variables['imageName'], 'macos'), eq(variables['python.version'], '3.9'))
+
+  - script: |
       python -m pytest --pyargs thinc
     displayName: 'Run tests with thinc-apple-ops'
     condition: and(startsWith(variables['imageName'], 'macos'), eq(variables['python.version'], '3.9'))

--- a/thinc/__init__.py
+++ b/thinc/__init__.py
@@ -3,8 +3,3 @@ import numpy
 
 from .about import __version__
 from .config import registry
-from .util import require_cpu
-
-
-# default to AppleOps instead of NumpyOps
-require_cpu()

--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -19,7 +19,7 @@ context_pools: ContextVar[dict] = ContextVar("context_pools", default={})
 
 # Internal use of thread-local storage only for detecting cases where a Jupyter
 # notebook might not have preserved contextvars across cells.
-_GLOBAL_STATE = {"ops": NumpyOps()}
+_GLOBAL_STATE = {"ops": None}
 
 
 def set_gpu_allocator(allocator: str) -> None:  # pragma: no cover


### PR DESCRIPTION
It's currently not possible to import `thinc_apple_ops` because of a circular import related to a change from #540.

This works:

```python
import thinc
import thinc_apple_ops
```

This does not:

```python
import thinc_apple_ops
```