### PR TITLE
WIP: homomorphic setting

### DIFF
--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -81,15 +81,17 @@ def init(
     # if a layer has an unset nO, we use the final Y (if provided). For other
     # layers, Y=None.
     curr_input = X
+    non_homomorphic = [layer for layer in model.layers if not layer.is_homomorphic]
     for layer in model.layers:
-        if layer.has_dim("nO") is None:
+        if layer.is_homomorphic:
+            layer.initialize(X=curr_input, Y=curr_input)
+        elif layer is non_homomorphic[-1]:
             layer.initialize(X=curr_input, Y=Y)
         else:
             layer.initialize(X=curr_input)
         if curr_input is not None:
             curr_input = layer.predict(curr_input)
-
-    if model.layers[0].has_dim("nI"):
+    if model.has_dim("nI") is None and model.layers[0].has_dim("nI"):
         model.set_dim("nI", model.layers[0].get_dim("nI"))
     if model.has_dim("nO") is None:
         try:

--- a/thinc/layers/dropout.py
+++ b/thinc/layers/dropout.py
@@ -15,7 +15,7 @@ def Dropout(rate: float = 0.0) -> Model[InT, InT]:
     during training.  Specifically, cells of the input are zeroed with
     probability determined by the `rate` argument.
     """
-    return Model("dropout", forward, attrs={"dropout_rate": rate, "is_enabled": True})
+    return Model("dropout", forward, attrs={"dropout_rate": rate, "is_enabled": True}, is_homomorphic=True)
 
 
 # We're getting type hell here, I think because of the instance checks?

--- a/thinc/layers/dropout.py
+++ b/thinc/layers/dropout.py
@@ -15,7 +15,12 @@ def Dropout(rate: float = 0.0) -> Model[InT, InT]:
     during training.  Specifically, cells of the input are zeroed with
     probability determined by the `rate` argument.
     """
-    return Model("dropout", forward, attrs={"dropout_rate": rate, "is_enabled": True}, is_homomorphic=True)
+    return Model(
+        "dropout",
+        forward,
+        attrs={"dropout_rate": rate, "is_enabled": True},
+        is_homomorphic=True,
+    )
 
 
 # We're getting type hell here, I think because of the instance checks?

--- a/thinc/layers/layernorm.py
+++ b/thinc/layers/layernorm.py
@@ -18,7 +18,7 @@ def LayerNorm(nI: Optional[int] = None) -> Model[InT, InT]:
         init=init,
         dims={"nI": nI, "nO": nI},
         params={"G": None, "b": None},
-        is_homomorphic=True
+        is_homomorphic=True,
     )
 
 

--- a/thinc/layers/layernorm.py
+++ b/thinc/layers/layernorm.py
@@ -17,7 +17,8 @@ def LayerNorm(nI: Optional[int] = None) -> Model[InT, InT]:
         forward,
         init=init,
         dims={"nI": nI, "nO": nI},
-        params={"G": None, "b": None}
+        params={"G": None, "b": None},
+        is_homomorphic=True
     )
 
 

--- a/thinc/layers/residual.py
+++ b/thinc/layers/residual.py
@@ -21,6 +21,7 @@ def residual(layer: Model[InT, InT]) -> Model[InT, InT]:
             "nO": layer.get_dim("nO") if layer.has_dim("nO") else None,
             "nI": layer.get_dim("nI") if layer.has_dim("nI") else None,
         },
+        is_homomorphic=True
     )
 
 

--- a/thinc/layers/residual.py
+++ b/thinc/layers/residual.py
@@ -21,7 +21,7 @@ def residual(layer: Model[InT, InT]) -> Model[InT, InT]:
             "nO": layer.get_dim("nO") if layer.has_dim("nO") else None,
             "nI": layer.get_dim("nI") if layer.has_dim("nI") else None,
         },
-        is_homomorphic=True
+        is_homomorphic=True,
     )
 
 

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -39,6 +39,7 @@ class Model(Generic[InT, OutT]):
     id: int
     _func: Callable
     init: Callable
+    is_homomorphic: Optional[bool]
     _params: ParamServer
     _dims: Dict[str, Optional[int]]
     _layers: List["Model"]
@@ -54,6 +55,7 @@ class Model(Generic[InT, OutT]):
         "ops",
         "_func",
         "init",
+        "_is_homomorphic",
         "_params",
         "_dims",
         "_attrs",
@@ -76,6 +78,7 @@ class Model(Generic[InT, OutT]):
         attrs: Dict[str, Any] = {},
         refs: Dict[str, Optional["Model"]] = {},
         ops: Optional[Union[NumpyOps, CupyOps]] = None,
+        is_homomorphic: Optional[bool]=None
     ):
         """Initialize a new model."""
         self.name = name
@@ -85,6 +88,7 @@ class Model(Generic[InT, OutT]):
         setattr(self, "_func", forward)
         setattr(self, "init", init)
         self.ops = ops if ops is not None else get_current_ops()
+        self._is_homomorphic = is_homomorphic
         self._params = ParamServer()
         self._dims = dict(dims)
         self._attrs = dict(attrs)
@@ -119,6 +123,10 @@ class Model(Generic[InT, OutT]):
         not reassign it.
         """
         return self._attrs
+
+    @property
+    def is_homomorphic(self) -> Optional[bool]:
+        return self._is_homomorphic
 
     @property
     def param_names(self) -> Tuple[str, ...]:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -77,7 +77,7 @@ class Model(Generic[InT, OutT]):
         attrs: Dict[str, Any] = {},
         refs: Dict[str, Optional["Model"]] = {},
         ops: Optional[Union[NumpyOps, CupyOps]] = None,
-        is_homomorphic: Optional[bool] = None
+        is_homomorphic: Optional[bool] = None,
     ):
         """Initialize a new model."""
         self.name = name

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -39,7 +39,6 @@ class Model(Generic[InT, OutT]):
     id: int
     _func: Callable
     init: Callable
-    is_homomorphic: Optional[bool]
     _params: ParamServer
     _dims: Dict[str, Optional[int]]
     _layers: List["Model"]
@@ -78,7 +77,7 @@ class Model(Generic[InT, OutT]):
         attrs: Dict[str, Any] = {},
         refs: Dict[str, Optional["Model"]] = {},
         ops: Optional[Union[NumpyOps, CupyOps]] = None,
-        is_homomorphic: Optional[bool]=None
+        is_homomorphic: Optional[bool] = None
     ):
         """Initialize a new model."""
         self.name = name
@@ -483,6 +482,7 @@ class Model(Generic[InT, OutT]):
             attrs=copy.deepcopy(self._attrs),
             layers=[layer.copy() for layer in self.layers],
             shims=[shim.copy() for shim in self.shims],
+            is_homomorphic=self.is_homomorphic,
         )
         for name in self.grad_names:
             copied.set_grad(name, self.get_grad(name).copy())

--- a/thinc/tests/layers/test_combinators.py
+++ b/thinc/tests/layers/test_combinators.py
@@ -116,6 +116,24 @@ def test_chain_three(model1, model2, model3):
     assert len(model.layers) == 3
 
 
+@pytest.mark.parametrize(
+    "layer1,layer2,layer3",
+    [
+        (Linear(nI=1), Linear(nI=2), Linear(nI=3)),
+        (Linear(), Linear(nI=2), Linear(nI=3)),
+        (Linear(), Linear(nI=2, nO=3), Linear()),
+        (Linear(nO=2), Linear(), Linear(nI=3)),
+        (Linear(nO=2), Linear(nO=3), Linear()),
+        (Linear(nI=1, nO=2), Linear(nI=2, nO=3), Linear(nI=3, nO=4)),
+    ],
+)
+def test_chain_shape_inference(layer1, layer2, layer3):
+    X_ones = numpy.ones((1, 1), dtype="f")
+    Y_ones = numpy.ones((1, 4), dtype="f")
+    model = chain(layer1.copy(), layer2.copy(), layer3.copy())
+    model.initialize(X=X_ones, Y=Y_ones)
+
+
 def test_chain_operator_three(model1, model2, model3):
     # Previously we 'flattened' these nested calls. We might opt to do so
     # again, especially for the operators.
@@ -275,10 +293,7 @@ def test_concatenate():
 def test_map_list():
     nI = 4
     nO = 9
-    Xs = [
-        numpy.zeros((6, nI), dtype="f"),
-        numpy.ones((3, nI), dtype="f")
-    ]
+    Xs = [numpy.zeros((6, nI), dtype="f"), numpy.ones((3, nI), dtype="f")]
     Y_shapes = [(x.shape[0], nO) for x in Xs]
     model = map_list(Linear())
     model.initialize(X=Xs, Y=[numpy.zeros(shape, dtype="f") for shape in Y_shapes])

--- a/thinc/tests/layers/test_combinators.py
+++ b/thinc/tests/layers/test_combinators.py
@@ -136,22 +136,26 @@ def test_chain_right_branch(model1, model2, model3):
 
 @pytest.mark.parametrize("ops", [NumpyOps(), NumpyOps(use_blis=True)])
 def test_chain(ops):
-    data = numpy.asarray([[1, 2, 3, 4]], dtype="f")
-    model = chain(Linear(1), Dropout(), Linear(1))
+    X = numpy.asarray([[1, 2, 3, 4]], dtype="f")
+    Y = numpy.asarray([[1, 2, 3, 4]], dtype="f")
+    nI = X.shape[1]
+    nO = Y.shape[1]
+    nH = 1
+    model = chain(Linear(1), Dropout(), Linear(nO))
     model.ops = ops
-    model.initialize(data, data)
-    Y, backprop = model(data, is_train=True)
-    backprop(Y)
+    model.initialize(X=X, Y=Y)
+    Yh, backprop = model(X, is_train=True)
+    backprop(Yh)
     # Layers with and without nO/nI
-    model = chain(Linear(1), Dropout(), Linear(1, 1))
-    model.initialize(data, data)
+    model = chain(Linear(nH), Dropout(), Linear(nO, nH))
+    model.initialize(X=X, Y=Y)
     # Setting dim on model
-    model = chain(Linear(1), Dropout(), Linear(1))
-    model.set_dim("nO", 1)
-    model.initialize(data, None)
-    model = chain(Linear(1, 1), Dropout(), Linear(1, 1))
-    model.set_dim("nI", 1)
-    model.initialize(None, data)
+    model = chain(Linear(nH), Dropout(), Linear(nO))
+    model.set_dim("nO", nO)
+    model.initialize(X=X, Y=None)
+    model = chain(Linear(nH, nI), Dropout(), Linear(nO, nH))
+    model.set_dim("nI", nI)
+    model.initialize(X=None, Y=Y)
     # Not enough arguments
     with pytest.raises(TypeError):
         chain(Linear())

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -518,11 +518,14 @@ def test_with_debug():
     def on_backprop(*_):
         counts["backprop"] += 1
 
-    relu = Relu()
+    relu = Relu(nO=32)
     relu2 = with_debug(
+        Relu(nO=64), on_init=on_init, on_forward=on_forward, on_backprop=on_backprop
+    )
+    relu3 = with_debug(
         Relu(), on_init=on_init, on_forward=on_forward, on_backprop=on_backprop
     )
-    chained = chain(relu, relu2, relu2)
+    chained = chain(relu, relu2, relu3)
     chained.initialize(X=train_X[:5], Y=train_Y[:5])
     _, backprop = chained(X=train_X[:5], is_train=False)
 

--- a/thinc/tests/mypy/test_mypy.py
+++ b/thinc/tests/mypy/test_mypy.py
@@ -17,6 +17,7 @@ cases = [
 ]
 
 
+@pytest.mark.skip(reason="weirdly slow?")
 @pytest.mark.parametrize("config_filename,python_filename,output_filename", cases)
 def test_mypy_results(
     config_filename, python_filename, output_filename, tmpdir, monkeypatch

--- a/thinc/tests/mypy/test_mypy.py
+++ b/thinc/tests/mypy/test_mypy.py
@@ -17,13 +17,13 @@ cases = [
 ]
 
 
-@pytest.mark.skip(reason="weirdly slow?")
 @pytest.mark.parametrize("config_filename,python_filename,output_filename", cases)
 def test_mypy_results(
     config_filename, python_filename, output_filename, tmpdir, monkeypatch
 ):
     pytest.importorskip("mypy")
     from mypy import api as mypy_api
+
     os.chdir(tmpdir)
     root_dir = Path(__file__).parent
     thinc_root_dir = Path(__file__).parent.parent.parent.parent


### PR DESCRIPTION
The current implementation of `chain`'s initialization does shape inference that guesses too much. For instance, `relu >> relu >> relu`, initialized with `X` and `Y`, would define the whole network and set all `nO`'s to `Y`'s shape, which is not necessarily what the user wants. You could argue that in this case, the network is simply underspecified and should be specified better upon declaration.

Guessing hidden widths also meant we made mistakes. With an ensemble `textcat` with inline `transformer`, two embedding layers are concatenated. But if the embedding width of the transformer isn't known upon initialization, the second embedding layer would just receive its `nO` from `Y`, which is clearly wrong.

This PR restricts transferring `Y` across the network, but introduces a "homomorphic" setting instead that should at least allow us to do better inference for layers where `nI==nO`.

## TODO
- [ ] Think about versioning of `chain` as this change is breaking across `spacy` and `spacy-transformers`, but those libraries don't actually use `chain.v1`, they just import `thinc.api.chain` :|
- [ ] Look at unit test in notebooks: example 01
- [ ] Look more into the issue of inline transformer+textcat, as this might represent a use-case that requires a more complex solution to this problem
- [ ] Find a way to specify relations between dimensions in a network architecture, so that all related dimensions are set when one of them is specified?
- [ ] Test spaCy & spacy-transformers thoroughly against this branch