### PR TITLE
Update pydantic version and unpin mypy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wasabi>=0.8.1,<1.1.0
 catalogue>=2.0.4,<2.1.0
 ml_datasets>=0.2.0,<0.3.0
 # Third-party dependencies
-pydantic>=1.7.4,!=1.8,!=1.8.1,<1.9.0
+pydantic>=1.9.0,<1.10.0
 numpy>=1.15.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"
@@ -23,7 +23,7 @@ coverage>=5.0.0,<6.0.0
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
 # restricting mypy until faster 3.10 wheels are available
-mypy>=0.901,<0.920; python_version < "3.10"
+mypy>=0.901; python_version < "3.10"
 types-mock>=0.1.1
 types-contextvars>=0.1.2; python_version < "3.7"
 types-dataclasses>=0.1.3; python_version < "3.7"


### PR DESCRIPTION
#569 pinned the `mypy` version because `pydantic` was not yet compatible with `mypy` versions > 0.910.

pydantic v1.9.0 was released and includes the following release note:
> Extend pydantic's mypy plugin to support mypy versions 0.910, 0.920, 0.921 & 0.930

This updates `requirements.txt` to unpin the `mypy` version and update the `pydantic` version to allow for version 1.9.0.
