### PR TITLE
Add support for sequence lengths to seq2col

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -55,12 +55,30 @@ backprop_reduce_max_kernel = KERNELS["backprop_reduce_max"]
 hash_data_kernel = compile_mmh(MMH_SRC)
 
 
-def seq2col(X, nW, out=None, threads_per_block=128, num_blocks=128):
-    if out is None:
-        out = cupy.zeros((X.shape[0], X.shape[1] * ((nW * 2) + 1)), dtype="f")
+def check_seq2col_lens(lens, B):
+    if lens is None:
+        lens = cupy.array([B], dtype="int32")
+    else:
+        lens = lens.astype("int32")
+        assert cupy.all(lens >= 0), "All sequence lengths must be >= 0"
+        assert cupy.sum(lens) == B, "The lengths must sum up to the batch length"
+
+    return lens
+
+
+def seq2col(X, nW, lens=None, out=None, threads_per_block=128, num_blocks=128):
     B = X.shape[0]
+    nF = nW * 2 + 1
     I = X.shape[1]
-    seq2col_kernel((num_blocks,), (threads_per_block,), (out, X, nW, B, I))
+
+    assert X.dtype == "float32", "CUDA seq2col kernel can only handle float32"
+
+    lens = check_seq2col_lens(lens, B)
+    nL = lens.shape[0]
+
+    if out is None:
+        out = cupy.zeros((B, I * nF), dtype="f")
+    seq2col_kernel((num_blocks,), (threads_per_block,), (out, X, lens, nW, B, I, nL))
     return out
 
 
@@ -120,13 +138,28 @@ def reduce_max(X, lengths, out=None, threads_per_block=128, num_blocks=128):
     return maxes, which
 
 
-def backprop_seq2col(dY, nW, out=None, threads_per_block=128, num_blocks=128):
+def backprop_seq2col(
+    dY, nW, lens=None, out=None, threads_per_block=128, num_blocks=128
+):
     B = dY.shape[0]
     nF = nW * 2 + 1
     I = dY.shape[1] // nF
+
+    assert dY.dtype == "float32", "CUDA backprop_seq2col kernel can only handle float32"
+
+    lens = check_seq2col_lens(lens, B)
+    nL = lens.shape[0]
+
     if out is None:
         out = cupy.zeros((B, I), dtype="f")
-    backprop_seq2col_kernel((num_blocks,), (threads_per_block,), (out, dY, nW, B, I))
+    else:
+        assert (
+            out.dtype == "float32"
+        ), "CUDA backprop_seq2col kernel can only handle float32"
+
+    backprop_seq2col_kernel(
+        (num_blocks,), (threads_per_block,), (out, dY, lens, nW, B, I, nL)
+    )
     return out
 
 

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -78,7 +78,12 @@ def seq2col(X, nW, *, lengths=None, out=None, threads_per_block=128, num_blocks=
 
     if out is None:
         out = cupy.zeros((B, I * nF), dtype="f")
-    seq2col_kernel((num_blocks,), (threads_per_block,), (out, X, lengths, nW, B, I, nL))
+
+    if X.size != 0 and lengths.size != 0:
+        seq2col_kernel(
+            (num_blocks,), (threads_per_block,), (out, X, lengths, nW, B, I, nL)
+        )
+
     return out
 
 
@@ -157,9 +162,11 @@ def backprop_seq2col(
             out.dtype == "float32"
         ), "CUDA backprop_seq2col kernel can only handle float32"
 
-    backprop_seq2col_kernel(
-        (num_blocks,), (threads_per_block,), (out, dY, lengths, nW, B, I, nL)
-    )
+    if dY.size != 0 and lengths.size != 0:
+        backprop_seq2col_kernel(
+            (num_blocks,), (threads_per_block,), (out, dY, lengths, nW, B, I, nL)
+        )
+
     return out
 
 

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -55,30 +55,30 @@ backprop_reduce_max_kernel = KERNELS["backprop_reduce_max"]
 hash_data_kernel = compile_mmh(MMH_SRC)
 
 
-def check_seq2col_lens(lens, B):
-    if lens is None:
-        lens = cupy.array([B], dtype="int32")
+def check_seq2col_lengths(lengths, B):
+    if lengths is None:
+        lengths = cupy.array([B], dtype="int32")
     else:
-        lens = lens.astype("int32")
-        assert cupy.all(lens >= 0), "All sequence lengths must be >= 0"
-        assert cupy.sum(lens) == B, "The lengths must sum up to the batch length"
+        lengths = lengths.astype("int32")
+        assert cupy.all(lengths >= 0), "All sequence lengths must be >= 0"
+        assert cupy.sum(lengths) == B, "The lengths must sum up to the batch length"
 
-    return lens
+    return lengths
 
 
-def seq2col(X, nW, lens=None, out=None, threads_per_block=128, num_blocks=128):
+def seq2col(X, nW, *, lengths=None, out=None, threads_per_block=128, num_blocks=128):
     B = X.shape[0]
     nF = nW * 2 + 1
     I = X.shape[1]
 
     assert X.dtype == "float32", "CUDA seq2col kernel can only handle float32"
 
-    lens = check_seq2col_lens(lens, B)
-    nL = lens.shape[0]
+    lengths = check_seq2col_lengths(lengths, B)
+    nL = lengths.shape[0]
 
     if out is None:
         out = cupy.zeros((B, I * nF), dtype="f")
-    seq2col_kernel((num_blocks,), (threads_per_block,), (out, X, lens, nW, B, I, nL))
+    seq2col_kernel((num_blocks,), (threads_per_block,), (out, X, lengths, nW, B, I, nL))
     return out
 
 
@@ -139,7 +139,7 @@ def reduce_max(X, lengths, out=None, threads_per_block=128, num_blocks=128):
 
 
 def backprop_seq2col(
-    dY, nW, lens=None, out=None, threads_per_block=128, num_blocks=128
+    dY, nW, *, lengths=None, out=None, threads_per_block=128, num_blocks=128
 ):
     B = dY.shape[0]
     nF = nW * 2 + 1
@@ -147,8 +147,8 @@ def backprop_seq2col(
 
     assert dY.dtype == "float32", "CUDA backprop_seq2col kernel can only handle float32"
 
-    lens = check_seq2col_lens(lens, B)
-    nL = lens.shape[0]
+    lengths = check_seq2col_lengths(lengths, B)
+    nL = lengths.shape[0]
 
     if out is None:
         out = cupy.zeros((B, I), dtype="f")
@@ -158,7 +158,7 @@ def backprop_seq2col(
         ), "CUDA backprop_seq2col kernel can only handle float32"
 
     backprop_seq2col_kernel(
-        (num_blocks,), (threads_per_block,), (out, dY, lens, nW, B, I, nL)
+        (num_blocks,), (threads_per_block,), (out, dY, lengths, nW, B, I, nL)
     )
     return out
 

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -108,15 +108,15 @@ class CupyOps(Ops):
         gradient *= cupy.minimum(threshold, grad_norm) / grad_norm
         return gradient
 
-    def seq2col(self, seq, nW, lens=None):
+    def seq2col(self, seq, nW, *, lengths=None):
         """Given an (M, N) sequence of vectors, return an (M, N*(nW*2+1)) sequence.
         The new sequence is constructed by concatenating nW preceding and succeeding
         vectors onto each column in the sequence, to extract a window of features.
         """
-        return _custom_kernels.seq2col(seq, nW, lens=lens)
+        return _custom_kernels.seq2col(seq, nW, lengths=lengths)
 
-    def backprop_seq2col(self, dY, nW, lens=None):
-        return _custom_kernels.backprop_seq2col(dY, nW, lens=lens)
+    def backprop_seq2col(self, dY, nW, *, lengths=None):
+        return _custom_kernels.backprop_seq2col(dY, nW, lengths=lengths)
 
     def reduce_mean(self, X, lengths):
         return _custom_kernels.reduce_mean(X, lengths)

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -108,15 +108,15 @@ class CupyOps(Ops):
         gradient *= cupy.minimum(threshold, grad_norm) / grad_norm
         return gradient
 
-    def seq2col(self, seq, nW):
+    def seq2col(self, seq, nW, lens=None):
         """Given an (M, N) sequence of vectors, return an (M, N*(nW*2+1)) sequence.
         The new sequence is constructed by concatenating nW preceding and succeeding
         vectors onto each column in the sequence, to extract a window of features.
         """
-        return _custom_kernels.seq2col(seq, nW)
+        return _custom_kernels.seq2col(seq, nW, lens=lens)
 
-    def backprop_seq2col(self, dY, nW):
-        return _custom_kernels.backprop_seq2col(dY, nW)
+    def backprop_seq2col(self, dY, nW, lens=None):
+        return _custom_kernels.backprop_seq2col(dY, nW, lens=lens)
 
     def reduce_mean(self, X, lengths):
         return _custom_kernels.reduce_mean(X, lengths)

--- a/thinc/backends/numpy_ops.pxd
+++ b/thinc/backends/numpy_ops.pxd
@@ -1,7 +1,7 @@
-cdef void seq2col(float* output, const float* X, int B, int I, int nW) nogil
+cdef void seq2col(float* output, const float* X, const int* L, int nW, int B, int I, int nL) nogil
 
 cdef void backprop_seq2col(float* d_seqs,
-        const float* d_cols, int B, int I, int nW) nogil
+        const float* d_cols, const int* L, int B, int I, int nW, int nL) nogil
 
 cdef void cpu_maxout(float* best__bo, int* which__bo,
         const float* cands__bop, int B, int O, int P) nogil

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -195,7 +195,10 @@ class NumpyOps(Ops):
         cdef int nL = lengths.shape[0]
 
         cdef np.ndarray cols = self.alloc((B, (2*nW + 1) * I), dtype="float32")
-        seq2col(<float*>cols.data, &seq[0,0], &lengths[0], nW, B, I, nL)
+
+        if seq.size != 0 and lengths.size != 0:
+            seq2col(<float*>cols.data, &seq[0,0], &lengths[0], nW, B, I, nL)
+
         return cols
 
     def backprop_seq2col(self, const float[:, ::1] dY, int nW, *, const int[::1] lengths=None):
@@ -207,7 +210,8 @@ class NumpyOps(Ops):
         cdef int nL = lengths.shape[0]
 
         cdef np.ndarray dX = self.alloc((B, I), dtype='float32')
-        backprop_seq2col(<float*>dX.data, &dY[0,0], &lengths[0], B, I, nW, nL)
+        if dY.size != 0 and lengths.size != 0:
+            backprop_seq2col(<float*>dX.data, &dY[0,0], &lengths[0], B, I, nW, nL)
         return dX
 
     @cython.boundscheck(False)

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -182,7 +182,7 @@ class NumpyOps(Ops):
         else:
             return dX
 
-    def seq2col(self, const float[:, ::1] seq, int nW):
+    def seq2col(self, const float[:, ::1] seq, int nW, const int[:] lens=None):
         """Given an (M, N) sequence of vectors, return an (M, N*(nW*2+1))
         sequence. The new sequence is constructed by concatenating nW preceding
         and succeeding vectors onto each column in the sequence, to extract a
@@ -190,16 +190,24 @@ class NumpyOps(Ops):
         """
         cdef int B = seq.shape[0]
         cdef int I = seq.shape[1]
+
+        lens = check_seq2col_lens(self, lens, B)
+        cdef int nL = lens.shape[0]
+
         cdef np.ndarray cols = self.alloc((B, (2*nW + 1) * I), dtype="float32")
-        seq2col(<float*>cols.data, &seq[0,0], nW, B, I)
+        seq2col(<float*>cols.data, &seq[0,0], &lens[0], nW, B, I, nL)
         return cols
 
-    def backprop_seq2col(self, const float[:, ::1] dY, int nW):
+    def backprop_seq2col(self, const float[:, ::1] dY, int nW, const int[:] lens=None):
         cdef int B = dY.shape[0]
         cdef int nF = nW*2+1
         cdef int I = dY.shape[1] / nF
+
+        lens = check_seq2col_lens(self, lens, B)
+        cdef int nL = lens.shape[0]
+
         cdef np.ndarray dX = self.alloc((B, I), dtype='float32')
-        backprop_seq2col(<float*>dX.data, &dY[0,0], B, I, nW)
+        backprop_seq2col(<float*>dX.data, &dY[0,0], &lens[0], B, I, nW, nL)
         return dX
 
     @cython.boundscheck(False)
@@ -361,7 +369,17 @@ class NumpyOps(Ops):
         return out_
 
 
-cdef void seq2col(float* output, const float* X, int nW, int B, int I) nogil:
+def check_seq2col_lens(ops, lens, B):
+    if lens is None:
+        lens = ops.asarray1i([B])
+    else:
+        assert ops.xp.all(ops.xp.array(lens) >= 0), "All sequence lengths must be >= 0"
+        assert ops.xp.sum(lens) == B, "The lengths must sum up to the batch length"
+
+    return lens
+
+
+cdef void seq2col(float* output, const float* X, const int* L, int nW, int B, int I, int nL) nogil:
     '''
     Let's say nW is 1 (it usually is). Then we want to take:
 
@@ -393,23 +411,41 @@ cdef void seq2col(float* output, const float* X, int nW, int B, int I) nogil:
     * x_start=-3, x_end=13 : (1-2) * 3, (1+2+1) * 3
     * x_start=0, x_end=16 : (2-2) * 3, (2+2+1) * 3
 
+    If lens > 1, then the sequence lengths dictate
+    the boundaries/padding rather than the begin/end
+    of X.
     '''
+
     nF = nW * 2 + 1
-    for i in range(B):
-        o_start = i * I * nF
-        x_start = (i-nW) * I
-        x_end = (i+nW+1) * I
-        if x_start < 0:
-            o_start += -x_start
-            x_start = 0
-        if x_end >= B * I:
-            x_end = B * I
-        memcpy(&output[o_start],
-            &X[x_start], (x_end-x_start) * sizeof(output[0]))
+
+    seq_start = 0
+    for i in range(nL):
+        # Calculate the bounds of the next sequence.
+        seq_end = seq_start + L[i]
+
+        # Four-argument range loop only works with constant step.
+        for j in range(seq_start, seq_end):
+            # Find the unconstrained window around b, which
+            # may be out of the sequence bounds.
+            window_start = j - nW
+            window_end = j + nW + 1
+
+            # Find the sequence-constrained window around b.
+            x_start = max(seq_start, window_start)
+            x_end = min(seq_end, window_end)
+            n_elems = x_end - x_start
+
+            out_offset = x_start - window_start
+
+            memcpy(output + (j * nF * I) + (out_offset * I),
+                   X + (x_start * I),
+                   n_elems * I * sizeof(output[0]))
+
+        seq_start += L[i]
 
 
 cdef void backprop_seq2col(float* d_seqs,
-        const float* d_cols, int B, int I, int nW) nogil:
+        const float* d_cols, const int* L, int B, int I, int nW, int nL) nogil:
     # Here's what we're doing, if we had 2d indexing.
     #for i in range(B):
     #    d_seq[i] += d_cols[i-2, 4]
@@ -417,19 +453,34 @@ cdef void backprop_seq2col(float* d_seqs,
     #    d_seq[i] += d_cols[i, 2]
     #    d_seq[i] += d_cols[i+1, 1]
     #    d_seq[i] += d_cols[i+2, 0]
-    cdef int col_feat
+
     nF = nW * 2 + 1
-    for i in range(B):
-        seq_row = i * I
-        col_feat = nF * I
-        for f in range(-nW, nW+1):
-            col_row = (i+f) * (I * nF)
-            col_feat -= I
-            if col_row >= 0 and (col_row < (B*I*nF)):
-                j = col_row + col_feat
-                if j >= 0 and (j+I) < (B*I*nF):
-                    VecVec.add_i(&d_seqs[seq_row],
-                        &d_cols[j], 1., I)
+
+    seq_start = 0
+    for i in range(nL):
+        # Calculate the bounds of the next sequence.
+        seq_end = seq_start + L[i]
+
+        for j in range(seq_start, seq_end):
+            # Find the unconstrained window around b, which
+            # may be out of the sequence bounds.
+            window_begin = j - nW
+            window_end = j + nW + 1
+
+            # Find the sequence-constrained window around b.
+            d_seqs_begin = max(seq_start, window_begin)
+            d_seqs_end = min(seq_end, window_end)
+            n_elems = d_seqs_end - d_seqs_begin
+
+            # If the left window is cut short, we want to
+            # start by the same amount in the output.
+            out_offset = d_seqs_begin - window_begin
+
+            VecVec.add_i(&d_seqs[d_seqs_begin * I],
+                         &d_cols[(j * nF * I) + (out_offset * I)],
+                         1., n_elems * I)
+
+        seq_start += L[i]
 
 
 cdef void cpu_maxout(float* best__bo, int* which__bo,

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -149,7 +149,9 @@ class Ops:
             i += output[-1]
         return output
 
-    def seq2col(self, seq: Floats2d, nW: int, *, lengths: Ints1d = None) -> Floats2d:
+    def seq2col(
+        self, seq: Floats2d, nW: int, *, lengths: Optional[Ints1d] = None
+    ) -> Floats2d:
         """Given an (M, N) sequence of vectors, return an (M, N*(nW*2+1))
         sequence. The new sequence is constructed by concatenating nW preceding
         and succeeding vectors onto each column in the sequence, to extract a
@@ -167,7 +169,9 @@ class Ops:
         cols[:-nW, nW + 1 :] = self.reshape3f(seq[nW:], -1, nW, I)
         return self.reshape2f(cols, B, I * (2 * nW + 1))
 
-    def backprop_seq2col(self, dY: Floats2d, nW: int, *, lengths=None) -> Floats2d:
+    def backprop_seq2col(
+        self, dY: Floats2d, nW: int, *, lengths: Optional[Ints1d] = None
+    ) -> Floats2d:
         """The reverse/backward operation of the `seq2col` function: calculate
         the gradient of the original `(M, N)` sequence, as a function of the
         gradient of the output `(M, N*(nW*2+1))` sequence.

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -149,14 +149,15 @@ class Ops:
             i += output[-1]
         return output
 
-    def seq2col(self, seq: Floats2d, nW: int) -> Floats2d:
+    def seq2col(self, seq: Floats2d, nW: int, lens: Ints1d = None) -> Floats2d:
         """Given an (M, N) sequence of vectors, return an (M, N*(nW*2+1))
         sequence. The new sequence is constructed by concatenating nW preceding
         and succeeding vectors onto each column in the sequence, to extract a
         window of features.
         """
-        # This is a test implementation that only supports nW=1
+        # This is a test implementation that only supports nW=1 and lens=None
         assert nW == 1
+        assert lens == None
         B = seq.shape[0]
         I = seq.shape[1]
         cols = self.alloc3f(B, (nW * 2 + 1), I)
@@ -166,13 +167,14 @@ class Ops:
         cols[:-nW, nW + 1 :] = self.reshape3f(seq[nW:], -1, nW, I)
         return self.reshape2f(cols, B, I * (2 * nW + 1))
 
-    def backprop_seq2col(self, dY: Floats2d, nW: int) -> Floats2d:
+    def backprop_seq2col(self, dY: Floats2d, nW: int, lens=None) -> Floats2d:
         """The reverse/backward operation of the `seq2col` function: calculate
         the gradient of the original `(M, N)` sequence, as a function of the
         gradient of the output `(M, N*(nW*2+1))` sequence.
         """
-        # This is a test implementation that only supports nW=1
+        # This is a test implementation that only supports nW=1 and lens=None
         assert nW == 1
+        assert lens == None
         nF = nW * 2 + 1
         B = dY.shape[0]
         I = dY.shape[1] // nF

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -149,15 +149,15 @@ class Ops:
             i += output[-1]
         return output
 
-    def seq2col(self, seq: Floats2d, nW: int, lens: Ints1d = None) -> Floats2d:
+    def seq2col(self, seq: Floats2d, nW: int, *, lengths: Ints1d = None) -> Floats2d:
         """Given an (M, N) sequence of vectors, return an (M, N*(nW*2+1))
         sequence. The new sequence is constructed by concatenating nW preceding
         and succeeding vectors onto each column in the sequence, to extract a
         window of features.
         """
-        # This is a test implementation that only supports nW=1 and lens=None
+        # This is a test implementation that only supports nW=1 and lengths=None
         assert nW == 1
-        assert lens == None
+        assert lengths == None
         B = seq.shape[0]
         I = seq.shape[1]
         cols = self.alloc3f(B, (nW * 2 + 1), I)
@@ -167,14 +167,14 @@ class Ops:
         cols[:-nW, nW + 1 :] = self.reshape3f(seq[nW:], -1, nW, I)
         return self.reshape2f(cols, B, I * (2 * nW + 1))
 
-    def backprop_seq2col(self, dY: Floats2d, nW: int, lens=None) -> Floats2d:
+    def backprop_seq2col(self, dY: Floats2d, nW: int, *, lengths=None) -> Floats2d:
         """The reverse/backward operation of the `seq2col` function: calculate
         the gradient of the original `(M, N)` sequence, as a function of the
         gradient of the output `(M, N*(nW*2+1))` sequence.
         """
-        # This is a test implementation that only supports nW=1 and lens=None
+        # This is a test implementation that only supports nW=1 and lengths=None
         assert nW == 1
-        assert lens == None
+        assert lengths == None
         nF = nW * 2 + 1
         B = dY.shape[0]
         I = dY.shape[1] // nF

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -204,10 +204,10 @@ def test_seq2col_window_one(ops, X):
 
 
 @pytest.mark.parametrize("ops", XP_OPS)
-def test_seq2col_window_one_lens(ops):
+def test_seq2col_window_one_lengths(ops):
     X = ops.xp.arange(1.0, 16.0, dtype="float32").reshape(5, 3)
-    lens = ops.asarray1i([1, 3, 1])
-    cols = ops.seq2col(X, 1, lens)
+    lengths = ops.asarray1i([1, 3, 1])
+    cols = ops.seq2col(X, 1, lengths=lengths)
     ops.xp.testing.assert_allclose(
         ops.asarray2f(
             [
@@ -223,10 +223,10 @@ def test_seq2col_window_one_lens(ops):
 
 
 @pytest.mark.parametrize("ops", XP_OPS)
-def test_seq2col_window_two_lens(ops):
+def test_seq2col_window_two_lengths(ops):
     X = ops.xp.arange(1.0, 16.0, dtype="float32").reshape(5, 3)
-    lens = ops.asarray1i([1, 3, 1])
-    cols = ops.seq2col(X, 2, lens)
+    lengths = ops.asarray1i([1, 3, 1])
+    cols = ops.seq2col(X, 2, lengths=lengths)
     ops.xp.testing.assert_allclose(
         ops.asarray2f(
             [
@@ -276,10 +276,10 @@ def test_backprop_seq2col_window_one(ops, X):
 
 
 @pytest.mark.parametrize("ops", XP_OPS)
-def test_backprop_seq2col_window_one_lens(ops):
+def test_backprop_seq2col_window_one_lengths(ops):
     d_y = ops.xp.arange(0.1, 4.6, step=0.1, dtype="float32").reshape(5, 9)
-    lens = ops.asarray1i([1, 3, 1])
-    d_seqs = ops.backprop_seq2col(d_y, 1, lens)
+    lengths = ops.asarray1i([1, 3, 1])
+    d_seqs = ops.backprop_seq2col(d_y, 1, lengths=lengths)
 
     ops.xp.testing.assert_allclose(
         ops.asarray2f(
@@ -309,10 +309,10 @@ def test_seq2col_window_two(ops):
 
 
 @pytest.mark.parametrize("ops", XP_OPS)
-def test_backprop_seq2col_window_two_lens(ops):
+def test_backprop_seq2col_window_two_lengths(ops):
     d_y = ops.xp.arange(0.1, 7.6, step=0.1, dtype="float32").reshape(5, 15)
-    lens = ops.asarray1i([1, 3, 1])
-    d_seqs = ops.backprop_seq2col(d_y, 2, lens)
+    lengths = ops.asarray1i([1, 3, 1])
+    d_seqs = ops.backprop_seq2col(d_y, 2, lengths=lengths)
 
     ops.xp.testing.assert_allclose(
         ops.asarray2f(
@@ -369,11 +369,11 @@ def test_large_seq2col_gpu_against_cpu(nW):
     X_gpu = cupy_ops.asarray2f(X)
 
     # Use somewhat interesting sequence lengths.
-    lens = numpy_ops.asarray1i([1, 4, 2, 1] * (batch_size // 8))
-    lens_gpu = cupy_ops.asarray1i(lens)
+    lengths = numpy_ops.asarray1i([1, 4, 2, 1] * (batch_size // 8))
+    lengths_gpu = cupy_ops.asarray1i(lengths)
 
-    cols = numpy_ops.seq2col(X, nW=nW, lens=lens)
-    cols_gpu = cupy_ops.seq2col(X_gpu, nW=nW, lens=lens_gpu)
+    cols = numpy_ops.seq2col(X, nW=nW, lengths=lengths)
+    cols_gpu = cupy_ops.seq2col(X_gpu, nW=nW, lengths=lengths_gpu)
 
     assert_allclose(cols, cols_gpu.get())
 
@@ -394,11 +394,11 @@ def test_large_backprop_seq2col_gpu_against_cpu(nW):
     d_cols_gpu = cupy_ops.asarray2f(d_cols)
 
     # Use somewhat interesting sequence lengths.
-    lens = numpy_ops.asarray1i([1, 4, 2, 1] * (batch_size // 8))
-    lens_gpu = cupy_ops.asarray1i(lens)
+    lengths = numpy_ops.asarray1i([1, 4, 2, 1] * (batch_size // 8))
+    lengths_gpu = cupy_ops.asarray1i(lengths)
 
-    d_seqs = numpy_ops.backprop_seq2col(d_cols, nW=nW, lens=lens)
-    d_seqs_gpu = cupy_ops.backprop_seq2col(d_cols_gpu, nW=nW, lens=lens_gpu)
+    d_seqs = numpy_ops.backprop_seq2col(d_cols, nW=nW, lengths=lengths)
+    d_seqs_gpu = cupy_ops.backprop_seq2col(d_cols_gpu, nW=nW, lengths=lengths_gpu)
 
     assert_allclose(d_seqs, d_seqs_gpu.get())
 


### PR DESCRIPTION
This change adds a `lens` option to `seq2col` and `seq2col_backprop`. When this option is set, the data is divided in sequences with the given lengths. Padding is added for parts of the window that are outside a sequence.

Checks

- The accuracies for existing models does not change:
  * [x] CPU
  * [x] GPU 
- The accuracy for a newly-trained model does not change:
  * [x] CPU
  * [x] GPU
- There are no performance regressions for predictions with `lengths=None`:
  * [x] CPU
  * [x] GPU 
- There are no performance regressions for training with `lengths=None`:
  * [x] CPU
  * [x] GPU