### PR TITLE
Improve mish activation, test against PyTorch

### DIFF
--- a/thinc/backends/_custom_kernels.cu
+++ b/thinc/backends/_custom_kernels.cu
@@ -112,7 +112,7 @@ void maxout(float* best, int* which,
 }
 
 extern "C" __global__
-void mish(float* Y, const float* X, float threshold, int N)
+void mish(float* Y, const float* X, double threshold, int N)
 {
     int _loop_start = blockIdx.x * blockDim.x + threadIdx.x;
     int _loop_stride = blockDim.x * gridDim.x;
@@ -283,11 +283,10 @@ void backprop_maxout(float* dX,
 
 extern "C" __global__
 void backprop_mish(float* dX,
-    const float* dY, const float* X, float threshold, int N)
+    const float* dY, const float* X, double threshold, int N)
 {
     int _loop_start = blockIdx.x * blockDim.x + threadIdx.x;
     int _loop_stride = blockDim.x * gridDim.x;
-    float two = 2.;
     for (int i = _loop_start; i < N; i += _loop_stride)
     {
         float x = X[i];
@@ -302,7 +301,7 @@ void backprop_mish(float* dX,
 
             float omega = (4. * (x+1)) + (4 * exp_2x) + exp_3x + exp_x * (4.*x+6);
             float delta = 2 * exp_x + exp_2x + 2;
-            dX[i] = dY[i] * ((exp_x * omega) / pow(delta, two));
+            dX[i] = dY[i] * ((exp_x * omega) / (delta * delta));
         }
     }
 }

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -182,12 +182,10 @@ def backprop_maxout(dY, which, P, out=None, threads_per_block=128, num_blocks=12
 
 
 def backprop_mish(dY, X, out=None, threshold=5, threads_per_block=128, num_blocks=128):
-    B = dY.shape[0]
-    I = dY.shape[1]
     if out is None:
-        out = cupy.zeros((B, I), dtype="f")
+        out = cupy.empty_like(X)
     backprop_mish_kernel(
-        (num_blocks,), (threads_per_block,), (out, dY, X, threshold, B * I)
+        (num_blocks,), (threads_per_block,), (out, dY, X, threshold, dY.size)
     )
     return out
 

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -90,11 +90,17 @@ class CupyOps(Ops):
         dY *= Y > 0
         return dY
 
-    def mish(self, X, threshold=20.0):
-        return _custom_kernels.mish(X, threshold=threshold, out=None)
+    def mish(self, X, threshold=20.0, inplace=False):
+        if X.dtype == "float32" and not inplace:
+            return _custom_kernels.mish(X, threshold=threshold, out=None)
+        else:
+            return super().mish(X, threshold, inplace)
 
-    def backprop_mish(self, dY, X, threshold=20.0, out=None):
-        return _custom_kernels.backprop_mish(dY, X, threshold=threshold, out=out)
+    def backprop_mish(self, dY, X, threshold=20.0, inplace=False):
+        if dY.dtype == "float32" and X.dtype == "float32" and not inplace:
+            return _custom_kernels.backprop_mish(dY, X, threshold=threshold)
+        else:
+            return super().backprop_mish(dY, X, threshold, inplace)
 
     def clip_gradient(self, gradient, threshold):
         # We do not use CuPy's linalg.norm, since it uses scalar reductions

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -904,9 +904,9 @@ class Ops:
         omega += 4.0 * xp.exp(2.0 * Xsub)
         omega += xp.exp(3.0 * Xsub)
         omega += xp.exp(Xsub) * ((4.0 * Xsub) + 6.0)
-        delta = 2.0 * xp.exp(Xsub)
-        delta += xp.exp(2.0 * Xsub)
-        delta += 2.0
+        delta = xp.exp(Xsub) + 1.0
+        delta *= delta
+        delta += 1.0
         dXsub = dYsub * ((xp.exp(Xsub) * omega) / (delta ** 2))
         # Gradient when above threshold will ignore softplus.
         if inplace:

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -879,8 +879,8 @@ class Ops:
         return dY * dX
 
     def mish(
-        self, X: FloatsXd, threshold: float = 20.0, inplace: bool = False
-    ) -> Floats2d:
+        self, X: FloatsType, threshold: float = 20.0, inplace: bool = False
+    ) -> FloatsType:
         tmp = X * self.xp.tanh(self.xp.log(1.0 + self.xp.exp(X)))
         Y = self.xp.where(X >= threshold, X, tmp)
         if inplace:
@@ -890,8 +890,12 @@ class Ops:
             return Y
 
     def backprop_mish(
-        self, dY: Floats2d, X: Floats2d, threshold: float = 20.0, inplace: bool = False
-    ) -> Floats2d:
+        self,
+        dY: FloatsType,
+        X: Floats2d,
+        threshold: float = 20.0,
+        inplace: bool = False,
+    ) -> FloatsType:
         xp = get_array_module(X)
         indices = X < threshold
         Xsub = X[indices]
@@ -904,12 +908,11 @@ class Ops:
         delta += xp.exp(2.0 * Xsub)
         delta += 2.0
         dXsub = dYsub * ((xp.exp(Xsub) * omega) / (delta ** 2))
+        # Gradient when above threshold will ignore softplus.
         if inplace:
             out = dY
         else:
-            out = xp.empty_like(dY)
-        # Gradient when above threshold will ignore softplus.
-        out[:] = dY
+            out = xp.copy(dY)
         out[indices] = dXsub
         return out
 

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -941,7 +941,7 @@ def test_ngrams():
 @pytest.mark.parametrize("dtype", ["float32", "float64"])
 @pytest.mark.parametrize("torch_func", TORCH_FUNCS)
 @settings(max_examples=MAX_EXAMPLES, deadline=None)
-@given(x=strategies.floats(min_value=-5, max_value=5))
+@given(x=strategies.floats(min_value=-30, max_value=30))
 def test_compare_activations_to_torch(ops, dtype, x, torch_func):
     import torch
 

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -39,6 +39,9 @@ def create_pytorch_funcs():
     def torch_hard_tanh(x):
         return torch.nn.functional.hardtanh(x)
 
+    def torch_mish(x):
+        return torch.nn.functional.mish(x)
+
     def torch_swish(x):
         return torch.nn.functional.silu(x)
 
@@ -68,6 +71,7 @@ def create_pytorch_funcs():
         ("relu_k", torch_relu_k),
         ("hard_sigmoid", torch_hard_sigmoid),
         ("hard_tanh", torch_hard_tanh),
+        ("mish", torch_mish),
         ("swish", torch_swish),
         ("hard_swish", torch_hard_swish),
         ("hard_swish_mobilenet", torch_hard_swish_mobilenet),
@@ -959,7 +963,7 @@ def test_compare_activations_to_torch(ops, dtype, x, torch_func):
     y_thinc = forward(x_thinc)
     y.backward()
     assert x_thinc.dtype == y_thinc.dtype
-    assert ops.xp.isclose(y_thinc, forward(x_thinc, inplace=True))
+    assert ops.xp.isclose(y_thinc, forward(x_thinc, inplace=True), atol=1e-06)
     assert ops.xp.isclose(y_thinc, y.detach().numpy(), atol=1e-06)
     x_thinc = ops.asarray([x], dtype=dtype)
     dY_thinc = ops.asarray([1.0], dtype=dtype)


### PR DESCRIPTION
Improve mish and backprop_mish
    
* Fix incorrect casting of threshold in CUDA kernels.
* Fix incorrect numerator of backprop_mish in Ops.
* Make mish and mish_backprop invariant to the shape dimensionality.
* Use `inplace` rather than `out` in Ops to work towards a more
  uniform API and make it possible to test the Mish activations
  against PyTorch.
  
Also add `mish`/`backprop_mish` to the PyTorch comparison test.
