### PR TITLE
Speed up maxout by exploiting parallelism better

### DIFF
--- a/thinc/backends/_custom_kernels.cu
+++ b/thinc/backends/_custom_kernels.cu
@@ -88,26 +88,23 @@ void maxout(float* best, int* which,
 {
     int _loop_start = blockIdx.x * blockDim.x + threadIdx.x;
     int _loop_stride = blockDim.x * gridDim.x;
-    for (int b = _loop_start; b < B; b += _loop_stride)
+    for (int bo = _loop_start; bo < B * O; bo += _loop_stride)
     {
-        // Go to the regions we're working on
-        float* best_b = &best[b*O];
-        int* which_b = &which[b*O];
+        // Go to the candidates at the output we're working on
+        const float* cands_bo = &cands[bo * P];
 
-        for (int i=0; i < O; ++i)
+        int best_idx = 0;
+        float best_val = cands_bo[0];
+        for (int p = 1; p < P; ++p)
         {
-            const float* cands_bi = &cands[b*O*P+(i*P)];
-            which_b[i] = 0;
-            best_b[i] = cands_bi[0];
-            for (int p=1; p < P; ++p)
-            {
-                if (cands_bi[p] > best_b[i])
-                {
-                    which_b[i] = p;
-                    best_b[i] = cands_bi[p];
-                }
+            if (cands_bo[p] > best_val) {
+                best_idx = p;
+                best_val = cands_bo[p];
             }
         }
+
+        which[bo] = best_idx;
+        best[bo] = best_val;
     }
 }
 

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -185,8 +185,14 @@ def test_maxout(ops, X):
     ops.xp.testing.assert_allclose(
         expected_best, predicted_best, rtol=0.001, atol=0.001
     )
-    # Can't compare 'which' directly, as sort order might be different
-    # We could check that using the 'which', we get the right results?
+
+    # Can't compare 'which' directly, as sort order might be different.
+    # So, instead we use 'which' to extract elements from X and then
+    # check the result against the expected output.
+    ops.xp.testing.assert_allclose(
+        ops.xp.take_along_axis(X, ops.xp.expand_dims(which, -1), axis=-1),
+        ops.xp.expand_dims(expected_best, -1),
+    )
 
 
 @pytest.mark.parametrize("ops", ALL_OPS)


### PR DESCRIPTION
I was profiling the parser refactor and noticed that the maxout kernel is taking more time than I expected:

<img width="205" alt="Screen Shot 2022-01-25 at 14 45 07" src="https://user-images.githubusercontent.com/49398/150989112-4717f419-a44d-4997-80b6-f43cd2e126be.png">

The maximum amount of parallelism by the kernel is determined by its batch size. However, this leaves the GPU underused. E.g. by default our amount of parallelism is nr_blocks: 128 * nr_threads_per_block: 128 = 16384, which is much larger than the typical batch size.

This PR changes the maxout kernel to parallelize at the output level (each thread computes one output). This makes the maxout kernel about 4.7 times faster with a batch size of 1024 on a RTX 2060 Super:

<img width="354" alt="Screen Shot 2022-01-25 at 14 44 55" src="https://user-images.githubusercontent.com/49398/150989848-70dd6b94-fa68-4224-912b-f36408d497d4.png">

I haven't updated the backprop variant yet, since it barely appears in the profiles.