### PR TITLE
Remove deadline of test_scale_random_inputs

### DIFF
--- a/thinc/tests/shims/test_pytorch_grad_scaler.py
+++ b/thinc/tests/shims/test_pytorch_grad_scaler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import lists, one_of, tuples
 from thinc.util import has_torch, has_torch_gpu, is_torch_array
 from thinc.api import PyTorchGradScaler
@@ -23,6 +23,7 @@ def tensors():
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")
 @pytest.mark.skipif(not has_torch_gpu, reason="needs a GPU")
 @given(X=one_of(tensors(), lists(tensors()), tuples(tensors())))
+@settings(deadline=None)
 def test_scale_random_inputs(X):
     import torch
 


### PR DESCRIPTION
By default the hypothesis deadline is 200ms. The test_scale_random_inputs test would frequently fail because on the first run the deadline was exceeded because GPU initialization takes some time.
