### PR TITLE
Add the `normalize` option to the Softmax layer

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -28,7 +28,7 @@ from .layers import ClippedLinear, ReluK, HardTanh, HardSigmoid
 from .layers import HardSwish, HardSwishMobilenet, Swish, Gelu
 from .layers import PyTorchWrapper, PyTorchRNNWrapper, PyTorchLSTM
 from .layers import TensorFlowWrapper, keras_subclass, MXNetWrapper
-from .layers import PyTorchWrapper_v2
+from .layers import PyTorchWrapper_v2, Softmax_v2
 
 from .layers import add, bidirectional, chain, clone, concatenate, noop
 from .layers import residual, uniqued, siamese, list2ragged, ragged2list

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -24,7 +24,7 @@ from .resizable import resizable
 from .sigmoid_activation import sigmoid_activation
 from .sigmoid import Sigmoid
 from .softmax_activation import softmax_activation
-from .softmax import Softmax
+from .softmax import Softmax, Softmax_v2
 from .sparselinear import SparseLinear
 from .tensorflowwrapper import TensorFlowWrapper, keras_subclass
 from .mxnetwrapper import MXNetWrapper
@@ -94,6 +94,7 @@ __all__ = [
     "sigmoid_activation",
     "Sigmoid" "softmax_activation",
     "Softmax",
+    "Softmax_v2",
     "SparseLinear",
     "TensorFlowWrapper",
     "add",

--- a/thinc/layers/softmax.py
+++ b/thinc/layers/softmax.py
@@ -43,10 +43,14 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
         model.inc_grad("W", model.ops.gemm(dY, X, trans1=True))
         return model.ops.gemm(dY, W)
 
+    def backprop_unnormalized(dY: InT):
+        msg = "backprop is not supported for an unnormalized Softmax layer"
+        raise ValueError(msg)
+
     if normalized:
         return Y, backprop
     else:
-        return Y, lambda dY: []
+        return Y, backprop_unnormalized
 
 
 def init(

--- a/thinc/layers/softmax.py
+++ b/thinc/layers/softmax.py
@@ -26,12 +26,12 @@ def Softmax(
         init=partial(init, init_W, init_b),
         dims={"nO": nO, "nI": nI},
         params={"W": None, "b": None},
-        attrs={"normalize": normalize},
+        attrs={"normalize_softmax": normalize},
     )
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    normalized = model.attrs["normalize"] or is_train
+    normalized = model.attrs["normalize_softmax"] or is_train
     W = cast(Floats2d, model.get_param("W"))
     b = cast(Floats1d, model.get_param("b"))
     Y = model.ops.affine(X, W, b)

--- a/thinc/layers/softmax.py
+++ b/thinc/layers/softmax.py
@@ -18,7 +18,7 @@ def Softmax(
     *,
     init_W: Callable = zero_init,
     init_b: Callable = zero_init,
-    normalize: bool = True,
+    normalize_outputs: bool = True,
 ) -> Model[InT, OutT]:
     return Model(
         "softmax",
@@ -26,7 +26,7 @@ def Softmax(
         init=partial(init, init_W, init_b),
         dims={"nO": nO, "nI": nI},
         params={"W": None, "b": None},
-        attrs={"normalize_softmax": normalize},
+        attrs={"normalize_softmax": normalize_outputs},
     )
 
 

--- a/thinc/layers/softmax.py
+++ b/thinc/layers/softmax.py
@@ -18,6 +18,24 @@ def Softmax(
     *,
     init_W: Callable = zero_init,
     init_b: Callable = zero_init,
+) -> Model[InT, OutT]:
+    return Model(
+        "softmax",
+        forward,
+        init=partial(init, init_W, init_b),
+        dims={"nO": nO, "nI": nI},
+        params={"W": None, "b": None},
+        attrs={"normalize_softmax": True},
+    )
+
+
+@registry.layers("Softmax.v2")
+def Softmax_v2(
+    nO: Optional[int] = None,
+    nI: Optional[int] = None,
+    *,
+    init_W: Callable = zero_init,
+    init_b: Callable = zero_init,
     normalize_outputs: bool = True,
 ) -> Model[InT, OutT]:
     return Model(

--- a/thinc/layers/softmax.py
+++ b/thinc/layers/softmax.py
@@ -31,11 +31,11 @@ def Softmax(
 
 
 def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    normalized = model.attrs["normalize_softmax"] or is_train
+    normalize = model.attrs["normalize_softmax"] or is_train
     W = cast(Floats2d, model.get_param("W"))
     b = cast(Floats1d, model.get_param("b"))
     Y = model.ops.affine(X, W, b)
-    if normalized:
+    if normalize:
         Y = model.ops.softmax(Y)
 
     def backprop(dY: InT) -> OutT:
@@ -47,7 +47,7 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
         msg = "backprop is not supported for an unnormalized Softmax layer"
         raise ValueError(msg)
 
-    if normalized:
+    if normalize:
         return Y, backprop
     else:
         return Y, backprop_unnormalized

--- a/thinc/tests/layers/test_layers_api.py
+++ b/thinc/tests/layers/test_layers_api.py
@@ -91,6 +91,8 @@ TEST_CASES_SUMMABLE = [
     ("softmax_activation.v1", {}, array2d, array2d),
     ("Softmax.v1", {}, array2d, array2d),
     ("Softmax.v1", {"nO": 4, "nI": 4}, array2d, array2d),
+    ("Softmax.v2", {}, array2d, array2d),
+    ("Softmax.v2", {"nO": 4, "nI": 4}, array2d, array2d),
     # fmt: off
     # List to list
     ("LSTM.v1", {"bi": False}, [array2d, array2d], [array2d, array2d]),

--- a/thinc/tests/layers/test_softmax.py
+++ b/thinc/tests/layers/test_softmax.py
@@ -1,6 +1,6 @@
 import numpy
 import pytest
-from thinc.api import NumpyOps, Softmax
+from thinc.api import NumpyOps, Softmax_v2
 
 OPS = NumpyOps()
 
@@ -16,7 +16,7 @@ outputs = OPS.xp.asarray(
 
 
 def test_unnormalized_softmax_backprop():
-    model = Softmax(normalize_outputs=False)
+    model = Softmax_v2(normalize_outputs=False)
     model.initialize(inputs, outputs)
     _, backprop = model(inputs, is_train=False)
     with pytest.raises(ValueError, match="backprop is not supported"):

--- a/thinc/tests/layers/test_softmax.py
+++ b/thinc/tests/layers/test_softmax.py
@@ -21,3 +21,8 @@ def test_unnormalized_softmax_backprop():
     _, backprop = model(inputs, is_train=False)
     with pytest.raises(ValueError, match="backprop is not supported"):
         backprop(OPS.xp.zeros_like(outputs))
+
+    # Backprop should not fail when training.
+    _, backprop = model(inputs, is_train=True)
+    dX = backprop(OPS.xp.zeros_like(outputs))
+    assert OPS.xp.all(dX == 0.0)

--- a/thinc/tests/layers/test_softmax.py
+++ b/thinc/tests/layers/test_softmax.py
@@ -1,0 +1,23 @@
+import numpy
+import pytest
+from thinc.api import NumpyOps, Softmax
+
+OPS = NumpyOps()
+
+inputs = OPS.xp.asarray([[4, 2, 3, 4], [1, 5, 3, 1], [9, 8, 5, 7]], dtype="f")
+outputs = OPS.xp.asarray(
+    [
+        [0.39948627, 0.05406459, 0.14696279, 0.39948627],
+        [0.01562812, 0.8532666, 0.11547707, 0.01562812],
+        [0.657233, 0.24178252, 0.01203764, 0.08894681],
+    ],
+    dtype="f",
+)
+
+
+def test_unnormalized_softmax_backprop():
+    model = Softmax(normalize=False)
+    model.initialize(inputs, outputs)
+    _, backprop = model(inputs, is_train=False)
+    with pytest.raises(ValueError, match="backprop is not supported"):
+        backprop(OPS.xp.zeros_like(outputs))

--- a/thinc/tests/layers/test_softmax.py
+++ b/thinc/tests/layers/test_softmax.py
@@ -16,7 +16,7 @@ outputs = OPS.xp.asarray(
 
 
 def test_unnormalized_softmax_backprop():
-    model = Softmax(normalize=False)
+    model = Softmax(normalize_outputs=False)
     model.initialize(inputs, outputs)
     _, backprop = model(inputs, is_train=False)
     with pytest.raises(ValueError, match="backprop is not supported"):

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -468,8 +468,13 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/softmax.py
 A dense layer with a softmax activation. This is usually used as a prediction
 layer. Vectors produced by the softmax function sum to 1, and have values
 between 0 and 1, so each vector can be interpreted as a probability
-distribution. In contrast to the `Softmax` function, `Softmax_v2` also supports
-outputting unnormalized probabilities during inference.
+distribution.
+
+In contrast to the `Softmax` function, `Softmax_v2` also supports outputting
+unnormalized probabilities during inference by using `normalize_outputs=False`
+as an argument. This is useful when we are only interested in finding the top-k
+classes, but not their probabilities. Computing unnormalized probabilities is
+faster, because it skips the expensive normalization step.
 
 | Argument            | Type                               | Description                                                                                              |
 | ------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -442,12 +442,13 @@ between 0 and 1, so each vector can be interpreted as a probability
 distribution.
 
 | Argument       | Type                               | Description                                                                                              |
-| -------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+|----------------|------------------------------------|----------------------------------------------------------------------------------------------------------|
 | `nO`           | <tt>Optional[int]</tt>             | The size of the output vectors.                                                                          |
 | `nI`           | <tt>Optional[int]</tt>             | The size of the input vectors.                                                                           |
 | _keyword-only_ |                                    |                                                                                                          |
 | `init_W`       | <tt>Callable</tt>                  | A function to initialize the weights matrix. Defaults to [`zero_init`](/docs/api-initializers#zero_init) |
 | `init_b`       | <tt>Callable</tt>                  | A function to initialize the bias vector. Defaults to [`zero_init`](/docs/api-initializers#zero_init).   |
+| `normalize`    | <tt>bool</tt>                      | Return normalized probabilities during inference. Defaults to `True`.                                    |
 | **RETURNS**    | <tt>Model[Floats2d, Floats2d]</tt> | The created softmax layer.                                                                               |
 
 ```python

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -222,13 +222,13 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/linear.py
 A linear (aka dense) layer, followed by a sigmoid activation. This is usually
 used as an output layer for multi-label classification (in contrast to the
 `Softmax` layer, which is used for problems where exactly one class is correct
-per example. 
+per example.
 
 | Argument    | Type                               | Description                      |
 | ----------- | ---------------------------------- | -------------------------------- |
 | `nOs`       | <tt>Tuple[int, ...]</tt>           | The sizes of the output vectors. |
 | `nI`        | <tt>Optional[int]</tt>             | The size of the input vectors.   |
-| **RETURNS** | <tt>Model[Floats2d, Floats2d]</tt> | The created sigmoid layer. |
+| **RETURNS** | <tt>Model[Floats2d, Floats2d]</tt> | The created sigmoid layer.       |
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/sigmoid.py
@@ -243,12 +243,12 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/sigmoid.py
 
 </inline-list>
 
-Apply the sigmoid logistic function as an activation to the inputs. This is often
-used as an output activation for multi-label classification, because each element
-of the output vectors will be between `0` and `1`.
+Apply the sigmoid logistic function as an activation to the inputs. This is
+often used as an output activation for multi-label classification, because each
+element of the output vectors will be between `0` and `1`.
 
-| Argument    | Type                               | Description                   |
-| ----------- | ---------------------------------- | ----------------------------- |
+| Argument    | Type                               | Description                             |
+| ----------- | ---------------------------------- | --------------------------------------- |
 | **RETURNS** | <tt>Model[Floats2d, Floats2d]</tt> | The created `sigmoid_activation` layer. |
 
 ```python
@@ -442,14 +442,44 @@ between 0 and 1, so each vector can be interpreted as a probability
 distribution.
 
 | Argument       | Type                               | Description                                                                                              |
-|----------------|------------------------------------|----------------------------------------------------------------------------------------------------------|
+| -------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | `nO`           | <tt>Optional[int]</tt>             | The size of the output vectors.                                                                          |
 | `nI`           | <tt>Optional[int]</tt>             | The size of the input vectors.                                                                           |
 | _keyword-only_ |                                    |                                                                                                          |
 | `init_W`       | <tt>Callable</tt>                  | A function to initialize the weights matrix. Defaults to [`zero_init`](/docs/api-initializers#zero_init) |
 | `init_b`       | <tt>Callable</tt>                  | A function to initialize the bias vector. Defaults to [`zero_init`](/docs/api-initializers#zero_init).   |
-| `normalize`    | <tt>bool</tt>                      | Return normalized probabilities during inference. Defaults to `True`.                                    |
 | **RETURNS**    | <tt>Model[Floats2d, Floats2d]</tt> | The created softmax layer.                                                                               |
+
+```python
+https://github.com/explosion/thinc/blob/master/thinc/layers/softmax.py
+```
+
+### Softmax_v2 {#softmax_v2 tag="function"}
+
+<inline-list>
+
+- **Input:** <ndarray shape="batch_size, nI">Floats2d</ndarray>
+- **Output:** <ndarray shape="batch_size, nO">Floats2d</ndarray>
+- **Parameters:** <ndarray shape="nO, nI">W</ndarray>,
+  <ndarray shape="nO,">b</ndarray>
+
+</inline-list>
+
+A dense layer with a softmax activation. This is usually used as a prediction
+layer. Vectors produced by the softmax function sum to 1, and have values
+between 0 and 1, so each vector can be interpreted as a probability
+distribution. In contrast to the `Softmax` function, `Softmax_v2` also supports
+outputting unnormalized probabilities during inference.
+
+| Argument            | Type                               | Description                                                                                              |
+| ------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `nO`                | <tt>Optional[int]</tt>             | The size of the output vectors.                                                                          |
+| `nI`                | <tt>Optional[int]</tt>             | The size of the input vectors.                                                                           |
+| _keyword-only_      |                                    |                                                                                                          |
+| `init_W`            | <tt>Callable</tt>                  | A function to initialize the weights matrix. Defaults to [`zero_init`](/docs/api-initializers#zero_init) |
+| `init_b`            | <tt>Callable</tt>                  | A function to initialize the bias vector. Defaults to [`zero_init`](/docs/api-initializers#zero_init).   |
+| `normalize_outputs` | <tt>bool</tt>                      | Return normalized probabilities during inference. Defaults to `True`.                                    |
+| **RETURNS**         | <tt>Model[Floats2d, Floats2d]</tt> | The created softmax layer.                                                                               |
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/softmax.py
@@ -537,8 +567,8 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_first.py
 
 ### reduce_last {#reduce_last tag="function"}
 
-Pooling layer that reduces the dimensions of the data by selecting the last
-item of each sequence. This is typically used after multi-head attention or recurrent
+Pooling layer that reduces the dimensions of the data by selecting the last item
+of each sequence. This is typically used after multi-head attention or recurrent
 neural network layers such as LSTMs, which can learn to assign a good feature
 representation for the sequence to its final element.
 
@@ -556,8 +586,6 @@ representation for the sequence to its final element.
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_last.py
 ```
-
-
 
 ### reduce_max {#reduce_max tag="function"}
 
@@ -707,7 +735,7 @@ Map a child layer across list inputs.
 
 | Argument    | Type                                  | Description             |
 | ----------- | ------------------------------------- | ----------------------- |
-| `layer`   | <tt>Model[InT, OutT]</tt>               | The child layer to map. |
+| `layer`     | <tt>Model[InT, OutT]</tt>             | The child layer to map. |
 | **RETURNS** | <tt>Model[List[InT], List[OutT]]</tt> | The composed model.     |
 
 ```python
@@ -1007,9 +1035,9 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/strings2arrays.py
 
 </inline-list>
 
-Transform sequence data into a contiguous array on the way into and out of a model.
-Handles a variety of sequence types: lists, padded and ragged. If the input is
-an array, it is passed through unchanged.
+Transform sequence data into a contiguous array on the way into and out of a
+model. Handles a variety of sequence types: lists, padded and ragged. If the
+input is an array, it is passed through unchanged.
 
 | Argument       | Type                             | Description                   |
 | -------------- | -------------------------------- | ----------------------------- |
@@ -1032,10 +1060,10 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/with_array2d.py
 
 Transform sequence data into a contiguous two-dimensional array on the way into
 and out of a model. In comparison to the `with_array` layer, the behavior of
-this layer mostly differs on `Padded` inputs, as this layer merges the batch
-and length axes to form a two-dimensional array.
-Handles a variety of sequence types: lists, padded and ragged.
-If the input is a two-dimensional array, it is passed through unchanged.
+this layer mostly differs on `Padded` inputs, as this layer merges the batch and
+length axes to form a two-dimensional array. Handles a variety of sequence
+types: lists, padded and ragged. If the input is a two-dimensional array, it is
+passed through unchanged.
 
 | Argument       | Type                             | Description                   |
 | -------------- | -------------------------------- | ----------------------------- |
@@ -1232,8 +1260,8 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/with_debug.py
 
 </inline-list>
 
-Layer that wraps any layer and marks the forward and backprop passes as an
-NVTX range. This can be helpful when profiling GPU performance of a layer.
+Layer that wraps any layer and marks the forward and backprop passes as an NVTX
+range. This can be helpful when profiling GPU performance of a layer.
 
 ```python
 ### Example
@@ -1243,19 +1271,18 @@ model = with_nvtx_range(Linear(2, 5))
 model.initialize()
 ```
 
-| Argument         | Type                   | Description                                                                                               |
-| ---------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------|
-| `layer`          | <tt>Model</tt>         | The layer to wrap.                                                                                        |
+| Argument         | Type                   | Description                                                                     |
+| ---------------- | ---------------------- | ------------------------------------------------------------------------------- |
+| `layer`          | <tt>Model</tt>         | The layer to wrap.                                                              |
 | `name`           | <tt>Optional[str]</tt> | Optional name for the wrapped layer. Defaults to the name of the wrapped layer. |
-| _keyword-only_   |                        |                                                                                                           |
-| `forward_color`  | <tt>int</tt>           | Identifier of the color to use for the forward pass                                                       |
-| `backprop_color` | <tt>int</tt>           | Identifier of the color to use for the backward pass                                                      |
-| **RETURNS**      | <tt>Model</tt>         | The wrapped layer.                                                                                        |
+| _keyword-only_   |                        |                                                                                 |
+| `forward_color`  | <tt>int</tt>           | Identifier of the color to use for the forward pass                             |
+| `backprop_color` | <tt>int</tt>           | Identifier of the color to use for the backward pass                            |
+| **RETURNS**      | <tt>Model</tt>         | The wrapped layer.                                                              |
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/with_nvtx_range.py
 ```
-
 
 ---
 


### PR DESCRIPTION
When this option is disabled, unnormalized probabilities (logits) are
returned during inference.

I was not too sure if adding a keyword argument requires making a
new version of the layer. The default behavior is unchanged.

Using unnormalized probabilities during inference can give nice
speedups. E.g. on my M1 Pro, a German tagging/parsing pipeline is
~27% faster with unnormalized probabilities due to not having to
use the expensive `expf` function.
