### PR TITLE
Always serialize Model numpy data with little endian byte order

### DIFF
--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -33,11 +33,11 @@ class CupyOps(Ops):
         self.device_type = device_type
         self.device_id = device_id
 
-    def to_numpy(self, data, *, byteorder=None):
+    def to_numpy(self, data, *, byte_order=None):
         if not isinstance(data, numpy.ndarray):
             data = data.get()
-        if byteorder:
-            dtype = data.dtype.newbyteorder(byteorder)
+        if byte_order:
+            dtype = data.dtype.newbyteorder(byte_order)
             data = numpy.asarray(data, dtype=dtype)
         return data
 

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -33,11 +33,13 @@ class CupyOps(Ops):
         self.device_type = device_type
         self.device_id = device_id
 
-    def to_numpy(self, data):
-        if isinstance(data, numpy.ndarray):
-            return data
-        else:
-            return data.get()
+    def to_numpy(self, data, *, byteorder=None):
+        if not isinstance(data, numpy.ndarray):
+            data = data.get()
+        if byteorder:
+            dtype = data.dtype.newbyteorder(byteorder)
+            data = numpy.asarray(data, dtype=dtype)
+        return data
 
     def gemm(self, x, y, out=None, trans1=False, trans2=False):
         if isinstance(x, numpy.ndarray) or isinstance(y, numpy.ndarray):

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -31,10 +31,10 @@ class Ops:
         self.device_type = device_type
         self.device_id = device_id
 
-    def to_numpy(self, data, *, byteorder=None):  # pragma: no cover
+    def to_numpy(self, data, *, byte_order=None):  # pragma: no cover
         if isinstance(data, numpy.ndarray):
-            if byteorder:
-                dtype = data.dtype.newbyteorder(byteorder)
+            if byte_order:
+                dtype = data.dtype.newbyteorder(byte_order)
                 data = numpy.asarray(data, dtype=dtype)
             return data
         else:

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -31,8 +31,11 @@ class Ops:
         self.device_type = device_type
         self.device_id = device_id
 
-    def to_numpy(self, data):  # pragma: no cover
+    def to_numpy(self, data, *, byteorder=None):  # pragma: no cover
         if isinstance(data, numpy.ndarray):
+            if byteorder:
+                dtype = data.dtype.newbyteorder(byteorder)
+                data = numpy.asarray(data, dtype=dtype)
             return data
         else:
             raise ValueError("Cannot convert non-numpy from base Ops class")

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -512,7 +512,7 @@ class Model(Generic[InT, OutT]):
         result from loading and serializing a model.
         """
         msg = self.to_dict()
-        to_numpy_le = partial(self.ops.to_numpy, byteorder="<")
+        to_numpy_le = partial(self.ops.to_numpy, byte_order="<")
         msg = convert_recursive(is_xp_array, to_numpy_le, msg)
         return srsly.msgpack_dumps(msg)
 

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -512,7 +512,8 @@ class Model(Generic[InT, OutT]):
         result from loading and serializing a model.
         """
         msg = self.to_dict()
-        msg = convert_recursive(is_xp_array, self.ops.to_numpy, msg)
+        to_numpy_le = partial(self.ops.to_numpy, byteorder="<")
+        msg = convert_recursive(is_xp_array, to_numpy_le, msg)
         return srsly.msgpack_dumps(msg)
 
     def to_disk(self, path: Union[Path, str]) -> None:

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -1003,15 +1003,15 @@ def test_clipped_linear(ops, x):
 
 
 @pytest.mark.parametrize("ops", ALL_OPS)
-@pytest.mark.parametrize("byteorder", (">", "<", "=", "|"))
+@pytest.mark.parametrize("byte_order", (">", "<", "=", "|"))
 @settings(max_examples=MAX_EXAMPLES, deadline=None)
 @given(x=strategies.floats(min_value=-10, max_value=10))
-def test_to_numpy_byteorder(ops, byteorder, x):
+def test_to_numpy_byteorder(ops, byte_order, x):
     x = ops.xp.asarray([x])
-    y = ops.to_numpy(x, byteorder=byteorder)
+    y = ops.to_numpy(x, byte_order=byte_order)
     assert numpy.array_equal(ops.to_numpy(x), ops.to_numpy(y))
-    if byteorder in (">", "<"):
+    if byte_order in (">", "<"):
         # hack from: https://stackoverflow.com/a/49740663
-        assert y.dtype.newbyteorder("S").newbyteorder("S").byteorder == byteorder
+        assert y.dtype.newbyteorder("S").newbyteorder("S").byteorder == byte_order
     else:
         assert x.dtype.byteorder == y.dtype.byteorder

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -1000,3 +1000,18 @@ def test_clipped_linear(ops, x):
         ops.backprop_clipped_linear(1.0, x_thinc, slope=0.2, offset=0.5),
         ops.backprop_hard_sigmoid(1.0, x_thinc),
     )
+
+
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("byteorder", (">", "<", "=", "|"))
+@settings(max_examples=MAX_EXAMPLES, deadline=None)
+@given(x=strategies.floats(min_value=-10, max_value=10))
+def test_to_numpy_byteorder(ops, byteorder, x):
+    x = ops.xp.asarray([x])
+    y = ops.to_numpy(x, byteorder=byteorder)
+    assert numpy.array_equal(ops.to_numpy(x), ops.to_numpy(y))
+    if byteorder in (">", "<"):
+        # hack from: https://stackoverflow.com/a/49740663
+        assert y.dtype.newbyteorder("S").newbyteorder("S").byteorder == byteorder
+    else:
+        assert x.dtype.byteorder == y.dtype.byteorder

--- a/website/docs/api-backends.md
+++ b/website/docs/api-backends.md
@@ -377,6 +377,25 @@ the inputs and outputs.
 | `dtype`        | <tt>DTypes</tt>  | The data type (default: `float32`).                             |
 | **RETURNS**    | <tt>ArrayXd</tt> | An array of the correct shape and data type, filled with zeros. |
 
+### Ops.to_numpy {#to_numpy tag="method"}
+
+<inline-list>
+
+- **default:** <i name="yes"></i>
+- **numpy:** default
+- **cupy:** <i name="yes"></i>
+
+</inline-list>
+
+Convert the array to a numpy array.
+
+| Argument       | Type                   | Description                                                                                                                                                      |
+| -------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`         | <tt>ArrayXd</tt>       | The array.                                                                                                                                                       |
+| _keyword-only_ |                        |                                                                                                                                                                  |
+| `byte_order`   | <tt>Optional[str]</tt> | The [new byte order](https://numpy.org/doc/stable/reference/generated/numpy.dtype.newbyteorder.html), `None` preserves the current byte order (default: `None`). |
+| **RETURNS**    | <tt>numpy.ndarray</tt> | A numpy array with the specified byte order.                                                                                                                     |
+
 #### Type-specific methods
 
 <inline-list>
@@ -1037,7 +1056,7 @@ with use_ops("cupy"):
 
 | Argument   | Type         | Description                                           |
 | ---------- | ------------ | ----------------------------------------------------- |
-| `ops`      | <tt>str</tt> | `"numpy"` or `"cupy"`.                       |
+| `ops`      | <tt>str</tt> | `"numpy"` or `"cupy"`.                                |
 | `**kwargs` |              | Optional arguments passed to [`Ops.__init__`](#init). |
 
 ### get_current_ops {#get_current_ops tag="function"}


### PR DESCRIPTION
* Add `byte_order` kwarg to `Ops.to_numpy` and `CupyOps.to_numpy`