### PR TITLE
Ragged: avoid concatenate when computing sequence spans

### DIFF
--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -1363,7 +1363,7 @@ def test_config_dataclasses():
     config = {"cfg": {"@cats": "catsie.ragged", "arg": ragged}}
     result = my_registry.resolve(config)["cfg"]
     assert isinstance(result, Ragged)
-    assert list(result._get_cumsums()) == [4, 6, 14, 15, 19]
+    assert list(result._get_starts_ends()) == [0, 4, 6, 14, 15, 19]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When profiling the parser refactor, I found that quite a lot of time is spent on initializing the arc eager oracle. Turns out that this (indirectly) does a lot of indexing on `Ragged`.

In `Ragged`, `concatenate` is used for computing the end indices of sequences from their start indices. This creates a new copy of an array that is largely identical to the array of start indices.

This PR changes `Ragged` to compute a single array for start/end indices, avoiding `concatenate` during the array construction.

Before this change:

<img width="998" alt="Screen Shot 2022-02-04 at 11 28 59" src="https://user-images.githubusercontent.com/49398/152515681-45a07d8f-17b3-446f-82f6-07188a5882e5.png">

After this change:

<img width="990" alt="Screen Shot 2022-02-04 at 11 34 37" src="https://user-images.githubusercontent.com/49398/152515719-5631e98a-2a94-4447-ac92-9fb0294e982b.png">

Both the time spent in `init_gold` and `Ragged.__getitem__` is reduced by quite a bit.