### PR TITLE
Config: do not sort positional arguments

### DIFF
--- a/thinc/config.py
+++ b/thinc/config.py
@@ -465,7 +465,7 @@ def mask_positional_args(name: str) -> List[Optional[str]]:
 
     stable_name = cast(List[Optional[str]], name.split("."))
 
-    # Remove names of sections that are a positional arugment.
+    # Remove names of sections that are a positional argument.
     for i in range(1, len(stable_name)):
         if stable_name[i - 1] == "*":
             stable_name[i] = None

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -342,7 +342,7 @@ class Config(dict):
         sort_map = {section: i for i, section in enumerate(self.section_order)}
         sort_key = lambda x: (
             sort_map.get(x[0].split(".")[0], len(sort_map)),
-            mask_positional_args(x[0]),
+            _mask_positional_args(x[0]),
         )
         return dict(sorted(data.items(), key=sort_key))
 
@@ -459,7 +459,7 @@ class Config(dict):
         return self.from_str(text, interpolate=interpolate, overrides=overrides)
 
 
-def mask_positional_args(name: str) -> List[Optional[str]]:
+def _mask_positional_args(name: str) -> List[Optional[str]]:
     """Create a section name representation that masks names
     of positional arguments to retain their order in sorts."""
 

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -1,5 +1,5 @@
 from typing import Union, Dict, Any, Optional, List, Tuple, Callable, Type
-from typing import Iterable, Sequence
+from typing import Iterable, Sequence, cast
 from types import GeneratorType
 from dataclasses import dataclass
 from configparser import ConfigParser, ExtendedInterpolation, MAX_INTERPOLATION_DEPTH
@@ -459,11 +459,11 @@ class Config(dict):
         return self.from_str(text, interpolate=interpolate, overrides=overrides)
 
 
-def mask_positional_args(name: str) -> List[str]:
+def mask_positional_args(name: str) -> List[Optional[str]]:
     """Create a section name representation that masks names
     of positional arguments to retain their order in sorts."""
 
-    stable_name = name.split(".")
+    stable_name = cast(List[Optional[str]], name.split("."))
 
     # Remove names of sections that are a positional arugment.
     for i in range(1, len(stable_name)):

--- a/thinc/config.py
+++ b/thinc/config.py
@@ -340,7 +340,10 @@ class Config(dict):
         account for subsections, which should always follow their parent.
         """
         sort_map = {section: i for i, section in enumerate(self.section_order)}
-        sort_key = lambda x: (sort_map.get(x[0].split(".")[0], len(sort_map)), x[0])
+        sort_key = lambda x: (
+            sort_map.get(x[0].split(".")[0], len(sort_map)),
+            mask_positional_args(x[0]),
+        )
         return dict(sorted(data.items(), key=sort_key))
 
     def _set_overrides(self, config: "ConfigParser", overrides: Dict[str, Any]) -> None:
@@ -454,6 +457,20 @@ class Config(dict):
         with path.open("r", encoding="utf8") as file_:
             text = file_.read()
         return self.from_str(text, interpolate=interpolate, overrides=overrides)
+
+
+def mask_positional_args(name: str) -> List[str]:
+    """Create a section name representation that masks names
+    of positional arguments to retain their order in sorts."""
+
+    stable_name = name.split(".")
+
+    # Remove names of sections that are a positional arugment.
+    for i in range(1, len(stable_name)):
+        if stable_name[i - 1] == "*":
+            stable_name[i] = None
+
+    return stable_name
 
 
 def try_load_json(value: str) -> Any:


### PR DESCRIPTION
In a configuration such as the following:

```
[model]

[model.chain]
@layers = "chain.v1"

[model.chain.*.hashembed]
@layers = "HashEmbed.v1"
nO = 8
nV = 8

[model.chain.*.expand_window]
@layers = "expand_window.v1"
window_size = 1
```

The positional arguments in the chain were sorted, changing the chain order. This change masks the names of positional arguments. Since `sorted` is a stable sort, the order of positional arguments is retained.