### PR TITLE
Improve bound and type checks in CUDA kernels

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -489,7 +489,11 @@ def _check_lengths(lengths, n_elems: int):
 
 
 def _check_which(which, B: int, I: int, P: int, check_values: bool = False):
-    assert which.dtype == "int32", "which should be encoded as 32-bit integers"
-    assert which.shape == (B, I), "which has incorrect shape"
+    assert (
+        which.dtype == "int32"
+    ), "maximum index (which) should be encoded as 32-bit integers"
+    assert which.shape == (B, I), "maximum index (which) has incorrect shape"
     if check_values:
-        assert cupy.all((which >= 0) & (which < which_len)), "which value out of bounds"
+        assert cupy.all(
+            (which >= 0) & (which < which_len)
+        ), "maximum index (which) value out of bounds"

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -495,5 +495,5 @@ def _check_which(which, B: int, I: int, P: int, check_values: bool = False):
     assert which.shape == (B, I), "maximum index (which) has incorrect shape"
     if check_values:
         assert cupy.all(
-            (which >= 0) & (which < which_len)
+            (which >= 0) & (which < P)
         ), "maximum index (which) value out of bounds"

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -271,9 +271,7 @@ def backprop_clipped_linear(
     assert (
         dY.dtype == "float32"
     ), "CUDA backprop_clipped_linear kernel can only handle float32"
-    assert (
-        X.dtype == "float32"
-    ), "CUDA backprop_clipped_linear kernel can only handle float32"
+    _check_array(X, dY.shape)
 
     out = dY
     if not inplace:
@@ -292,9 +290,7 @@ def backprop_hard_swish(
     assert (
         dY.dtype == "float32"
     ), "CUDA backprop_hard_swish kernel can only handle float32"
-    assert (
-        X.dtype == "float32"
-    ), "CUDA backprop_hard_swish kernel can only handle float32"
+    _check_array(X, dY.shape)
 
     out = dY
     if not inplace:
@@ -311,9 +307,7 @@ def backprop_hard_swish_mobilenet(
     assert (
         dY.dtype == "float32"
     ), "CUDA backprop_hard_swish_mobilenet kernel can only handle float32"
-    assert (
-        X.dtype == "float32"
-    ), "CUDA backprop_hard_swish_mobilenet kernel can only handle float32"
+    _check_array(X, dY.shape)
 
     out = dY
     if not inplace:
@@ -328,7 +322,7 @@ def backprop_gelu(
     dY, X, inplace: bool = False, threshold=6.0, threads_per_block=128, num_blocks=128
 ):
     assert dY.dtype == "float32", "CUDA backprop_gelu kernel can only handle float32"
-    assert X.dtype == "float32", "CUDA backprop_gelu kernel can only handle float32"
+    _check_array(X, dY.shape)
 
     out = dY
     if not inplace:
@@ -363,7 +357,7 @@ def backprop_mish(
     dY, X, inplace: bool = False, threshold=5, threads_per_block=128, num_blocks=128
 ):
     assert dY.dtype == "float32", "CUDA backprop_mish kernel can only handle float32"
-    assert X.dtype == "float32", "CUDA backprop_mish kernel can only handle float32"
+    _check_array(X, dY.shape)
 
     out = dY
     if not inplace:
@@ -452,8 +446,8 @@ def backprop_swish(
     dY, X, Y, inplace=False, threshold=17.0, threads_per_block=128, num_blocks=128
 ):
     assert dY.dtype == "float32", "CUDA backprop_swish kernel can only handle float32"
-    assert X.dtype == "float32", "CUDA backprop_swish kernel can only handle float32"
-    assert Y.dtype == "float32", "CUDA backprop_swish kernel can only handle float32"
+    _check_array(X, dY.shape)
+    _check_array(Y, dY.shape)
 
     out = dY
     if not inplace:

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -176,14 +176,16 @@ class CupyOps(Ops):
             return super().backprop_hard_swish_mobilenet(dY, X, inplace=inplace)
 
     def mish(self, X, threshold=20.0, inplace=False):
-        if X.dtype == "float32" and not inplace:
-            return _custom_kernels.mish(X, threshold=threshold, out=None)
+        if X.dtype == "float32":
+            return _custom_kernels.mish(X, inplace=inplace, threshold=threshold)
         else:
             return super().mish(X, threshold, inplace)
 
     def backprop_mish(self, dY, X, threshold=20.0, inplace=False):
-        if dY.dtype == "float32" and X.dtype == "float32" and not inplace:
-            return _custom_kernels.backprop_mish(dY, X, threshold=threshold)
+        if dY.dtype == "float32" and X.dtype == "float32":
+            return _custom_kernels.backprop_mish(
+                dY, X, inplace=inplace, threshold=threshold
+            )
         else:
             return super().backprop_mish(dY, X, threshold, inplace)
 


### PR DESCRIPTION
This PR combines some improvements that should remove most accidental out of bounds reads/writes:

* Check that floating point kernel inputs have dtype `float32`.
* Check that integer kernel inputs have dtype `int32`.
* Check in elementwise backprop kernels that the shapes of `X` and `Y` match that of `dY` (where applicable).
* Check that output arrays have the correct shape when they are provided.
* Check that lengths are `>= 0` and that lengths sum up to the number of instances.
* Check that `which` used in `backprop_maxout` and `backprop_reduce_max` are in bounds.

The `out` option of `mish` is replaced by `inpace`, to give `mish` the same interface as other elementwise kernels. This should not break the API, since `_custom_kernels` is a private module.