### PR TITLE
Couple of experimental optimizer features

### DIFF
--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -970,6 +970,30 @@ class Ops:
         weights -= learn_rate * (mom1 / (mod_rate * self.xp.sqrt(mom2) + eps))
         return weights, gradient, mom1, mom2
 
+    def adabelief(
+        self,
+        weights: Floats1d,
+        gradient: Floats1d,
+        mom: Floats1d,
+        belief: Floats1d,
+        beta1: float,
+        beta2: float,
+        eps: float,
+        learn_rate: float,
+        time_step: int
+    ) -> Tuple[Floats1d, Floats1d, Floats1d, Floats1d]:
+        mom *= beta1
+        belief *= beta2
+        mom += gradient * (1 - beta1)
+        grad_residual = gradient - mom
+        belief += grad_residual * grad_residual * (1 - beta2)
+        belief += eps
+        # bias correction not optimized
+        mom_ = mom / (1 - beta1**time_step)
+        belief_ = belief / (1 - beta2**time_step)
+        weights -= learn_rate * (mom_ / (self.xp.sqrt(belief_) + eps))
+        return weights, gradient, mom, belief
+
     def clip_gradient(self, gradient: FloatsT, threshold: float) -> FloatsT:
         # Internals for optimizer
         xp = get_array_module(gradient)

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -603,7 +603,7 @@ class Ops:
             Y += 1.0
             return Y
         else:
-            return 1 - Y ** 2
+            return 1 - Y**2
 
     def softmax(
         self,
@@ -924,7 +924,7 @@ class Ops:
         delta = xp.exp(Xsub) + 1.0
         delta *= delta
         delta += 1.0
-        dXsub = dYsub * ((xp.exp(Xsub) * omega) / (delta ** 2))
+        dXsub = dYsub * ((xp.exp(Xsub) * omega) / (delta**2))
         # Gradient when above threshold will ignore softplus.
         if inplace:
             out = dY
@@ -933,10 +933,16 @@ class Ops:
         out[indices] = dXsub
         return out
 
+    # Vanilla moving average of weights
+    def update_averages_swa(self, ma: FloatsT, weights: FloatsT, t: int) -> None:
+        ma *= t
+        ma += weights
+        ma /= t + 1
+
+    # Exponential moving average of weights
     def update_averages(
         self, ema: FloatsT, weights: FloatsT, t: int, max_decay: float = 0.9999
     ) -> None:
-        # Internals for optimizer
         decay = (1.0 + t) / (10.0 + t)
         if decay > max_decay:
             decay = max_decay
@@ -1368,7 +1374,7 @@ def dsigmoid(Y: ArrayT) -> ArrayT:
 
 
 def dtanh(Y: ArrayT) -> ArrayT:
-    return 1 - Y ** 2
+    return 1 - Y**2
 
 
 def gaussian_cdf(ops: Ops, X: FloatsType) -> FloatsType:


### PR DESCRIPTION
This PR contains a few recent optimizer features and is about exploring whether some of the new improvements could be helpful optimizing problems usually faced in `spaCy`. I'm taking inspiration from [`Ranger`](https://github.com/lessw2020/Ranger21). My main moving target goal would probably something like replacing averaging with `lookahead` for convenience, weight-decay `AdamW` style, use `adaptive-clipping` maybe [`weight-norm`](https://arxiv.org/pdf/2103.06583v1.pdf).  

Currently it has a sketch of the following features: 

- [`AdaBelief`](https://arxiv.org/abs/2010.07468): A slight variation on `Adam` with the same API.
- [`Lookahead`](https://arxiv.org/abs/1907.08610): Rather than normal training and weight averaging after, during training keep a slow exponential moving average of the weights with `k` lookahead steps. 
- [`Gradient Centering`](https://arxiv.org/abs/2004.01461v2): Subtracts the mean from the gradients to center. 

So far I only ran a couple of sanity check experiments on `MNIST`, `Fashion-MNIST` and `Kuzushiji-MNIST` using https://github.com/explosion/ml-datasets and running the `MNIST` example https://github.com/explosion/thinc/blob/master/examples/mnist.py.

The `AdaBelief` implementation diverges when `lr = 0.001`. Its kind of fine on `lr = 0.0001`, but not as good as `Adam`. I feel like I might abandon `AdaBelief` and focus on other `Adam` tweaks like `AdamW` and 

The `gradient centering` doesn't cause any issues, but I didn't observe benefits over vanilla `clipping` on these data sets. The `lookahead` seems somewhat promising in that it did seem to slightly improve over no `lookahead` with `k=3` and `alpha=0.8`, but didn't compare it yet to averaging.

The good thing about the `lookahead` is that if it's as good as `weight-averaging` then serialization is the same as normal unlike with `weight-averaging` where one needs to store the moving average for in case of `resume`. 