### PR TITLE
Fix Ops.backprop_reduce_max

### DIFF
--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1028,7 +1028,9 @@ class Ops:
         dX = self.alloc2f(lengths.sum(), d_maxes.shape[1])
         start = 0
         for i, length in enumerate(lengths):
-            dX[start : start + length, which[i]] = d_maxes[i]
+            self.xp.put_along_axis(
+                dX[start : start + length], which[i].reshape((1, -1)), d_maxes[i], 0
+            )
             start += length
         return dX
 

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -712,6 +712,25 @@ def test_reduce_max(ops):
 
 
 @pytest.mark.parametrize("ops", ALL_OPS)
+def test_backprop_reduce_max(ops):
+    dX = ops.backprop_reduce_max(
+        ops.xp.arange(1, 7, dtype="f").reshape(2, 3),
+        ops.xp.array([[2, 1, 0], [1, 0, 1]]).astype("int32"),
+        ops.xp.array([3, 2], dtype="int32"),
+    )
+    ops.xp.testing.assert_allclose(
+        dX,
+        [
+            [0.0, 0.0, 3.0],
+            [0.0, 2.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 5.0, 0.0],
+            [4.0, 0.0, 6.0],
+        ],
+    )
+
+
+@pytest.mark.parametrize("ops", ALL_OPS)
 @settings(max_examples=MAX_EXAMPLES, deadline=None)
 @given(X=strategies.arrays_BI())
 def test_mish(ops, X):


### PR DESCRIPTION
Suppose that we have a sequence of length 2 and dimensionality 3:

```
1: a b c
2: d e f
```

The `which` array specifies for each dimension which sequence contained
the maximum value. For example, if `which = [0, 1, 0]`, the maximum values
were:

```
a e c
```

However, the `Ops` implementation of this function was using which to
select columns. So,

```
a b a
d e d
```

would be selected. This change rectifies this, to select per column the
row indicated in `which`.