### PR TITLE
NumpyOps: add bound checks

### DIFF
--- a/thinc/backends/numpy_ops.pxd
+++ b/thinc/backends/numpy_ops.pxd
@@ -9,17 +9,17 @@ cdef void cpu_maxout(float* best__bo, int* which__bo,
 cdef int cpu_backprop_maxout(float* dX__bop,
         const float* dX__bo, const int* which__bo, int B, int O, int P) nogil except -1
 
-cdef void cpu_reduce_mean(float* means__bo,
+cdef int cpu_reduce_mean(float* means__bo,
         const float* X__to, const int* lengths__b,
-        int B, int T, int O) nogil
+        int B, int T, int O) nogil except -1
 
 cdef void cpu_backprop_reduce_mean(float* dX__to,
         const float* d_means__bo, const int* lengths__b,
         int B, int T, int O) nogil
 
-cdef void cpu_reduce_max(float* maxes__bo, int* which__bo,
+cdef int cpu_reduce_max(float* maxes__bo, int* which__bo,
         const float* X__to, const int* lengths__b,
-        int B, int T, int O) nogil
+        int B, int T, int O) nogil except -1
 
 cdef int cpu_backprop_reduce_max(float* dX__to,
         const float* d_maxes__bo, const int* which__bo, const int* lengths__b,

--- a/thinc/backends/numpy_ops.pxd
+++ b/thinc/backends/numpy_ops.pxd
@@ -6,8 +6,8 @@ cdef void backprop_seq2col(float* d_seqs,
 cdef void cpu_maxout(float* best__bo, int* which__bo,
         const float* cands__bop, int B, int O, int P) nogil
 
-cdef void cpu_backprop_maxout(float* dX__bop,
-        const float* dX__bo, const int* which__bo, int B, int O, int P) nogil
+cdef int cpu_backprop_maxout(float* dX__bop,
+        const float* dX__bo, const int* which__bo, int B, int O, int P) nogil except -1
 
 cdef void cpu_reduce_mean(float* means__bo,
         const float* X__to, const int* lengths__b,
@@ -21,7 +21,6 @@ cdef void cpu_reduce_max(float* maxes__bo, int* which__bo,
         const float* X__to, const int* lengths__b,
         int B, int T, int O) nogil
 
-
-cdef void cpu_backprop_reduce_max(float* dX__to,
+cdef int cpu_backprop_reduce_max(float* dX__to,
         const float* d_maxes__bo, const int* which__bo, const int* lengths__b,
-        int B, int T, int O) nogil
+        int B, int T, int O) nogil except -1

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -284,6 +284,8 @@ class NumpyOps(Ops):
         cdef int O = d_means.shape[1]
         cdef int T = 0
         for length in lengths[:B]:
+            if length < 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
             T += length
         cdef Pool mem = Pool()
         assert T != 0
@@ -300,6 +302,8 @@ class NumpyOps(Ops):
         cdef int O = d_sums.shape[1]
         cdef int T = 0
         for length in lengths[:B]:
+            if length < 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
             T += length
         cdef Pool mem = Pool()
         assert T != 0
@@ -334,6 +338,8 @@ class NumpyOps(Ops):
         cdef int O = d_maxes.shape[1]
         cdef int T = 0
         for length in lengths[:B]:
+            if length < 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
             T += length
         cdef Pool mem = Pool()
         assert T != 0

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -603,7 +603,7 @@ class Ops:
             Y += 1.0
             return Y
         else:
-            return 1 - Y ** 2
+            return 1 - Y**2
 
     def softmax(
         self,
@@ -913,6 +913,10 @@ class Ops:
         threshold: float = 20.0,
         inplace: bool = False,
     ) -> FloatsType:
+        if dY.shape != X.shape:
+            msg = f"arrays have incompatible shapes: {dY.shape} and {X.shape}"
+            raise ValueError(msg)
+
         xp = get_array_module(X)
         indices = X < threshold
         Xsub = X[indices]
@@ -924,7 +928,7 @@ class Ops:
         delta = xp.exp(Xsub) + 1.0
         delta *= delta
         delta += 1.0
-        dXsub = dYsub * ((xp.exp(Xsub) * omega) / (delta ** 2))
+        dXsub = dYsub * ((xp.exp(Xsub) * omega) / (delta**2))
         # Gradient when above threshold will ignore softplus.
         if inplace:
             out = dY

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1014,6 +1014,8 @@ class Ops:
         dX = self.alloc2f(lengths.sum(), d_sums.shape[1], dtype=d_sums.dtype)
         start = 0
         for i, length in enumerate(lengths):
+            if length < 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
             dX[start : start + length] = d_sums[i]
             start += length
         return dX
@@ -1022,6 +1024,8 @@ class Ops:
         dX = self.alloc2f(lengths.sum(), d_means.shape[1], dtype=d_means.dtype)
         start = 0
         for i, length in enumerate(lengths):
+            if length < 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
             dX[start : start + length] = d_means[i] / length
             start += length
         return dX

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -986,15 +986,24 @@ class Ops:
         Y = self.alloc2f(lengths.shape[0], X.shape[1])
         start = 0
         for i, length in enumerate(lengths):
-            Y[i] = X[start : start + length].sum(axis=0)
-            start += length
+            if length < 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
+            elif start + length > X.shape[0]:
+                raise IndexError("lengths must sum up to the number of rows")
+            elif length:
+                Y[i] = X[start : start + length].sum(axis=0)
+                start += length
         return Y
 
     def reduce_mean(self, X: Floats2d, lengths: Ints1d) -> Floats2d:
         Y = self.alloc2f(lengths.shape[0], X.shape[1])
         start = 0
         for i, length in enumerate(lengths):
-            if length:
+            if length < 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
+            elif start + length > X.shape[0]:
+                raise IndexError("lengths must sum up to the number of rows")
+            elif length:
                 Y[i] = X[start : start + length].mean(axis=0)
             start += length
         return Y
@@ -1004,7 +1013,11 @@ class Ops:
         which = self.alloc2i(lengths.shape[0], X.shape[1])
         start = 0
         for i, length in enumerate(lengths):
-            if length:
+            if length < 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
+            elif start + length > X.shape[0]:
+                raise IndexError("lengths must sum up to the number of rows")
+            elif length:
                 which[i] = X[start : start + length].argmax(axis=0)
                 Y[i] = X[start : start + length].max(axis=0)
             start += length

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -734,6 +734,32 @@ def test_reduce_sum(ops):
 
 
 @pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+def test_backprop_reduce_sum(ops, dtype):
+    dX = ops.backprop_reduce_sum(
+        ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),
+        ops.xp.array([4, 2], dtype="int32"),
+    )
+    assert dX.dtype == dtype
+    ops.xp.testing.assert_allclose(
+        dX,
+        [
+            [1.0, 2.0, 3.0],
+            [1.0, 2, 3.0],
+            [1.0, 2, 3.0],
+            [1.0, 2, 3.0],
+            [4.0, 5, 6.0],
+            [4.0, 5, 6.0],
+        ],
+    )
+
+    with pytest.raises(ValueError, match=r"lengths must be"):
+        ops.backprop_reduce_sum(
+            ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),
+            ops.xp.array([-1, 2], dtype="int32"),
+        )
+
+
+@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
 def test_reduce_max_sm(ops, dtype):
     X = ops.xp.zeros((6, 3), dtype=dtype)
     X += ops.xp.random.uniform(-1, 1, X.shape)
@@ -827,6 +853,12 @@ def test_backprop_reduce_mean(ops, dtype):
             [2.0, 2.5, 3.0],
         ],
     )
+
+    with pytest.raises(ValueError, match=r"lengths must be"):
+        ops.backprop_reduce_mean(
+            ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),
+            ops.xp.array([-1, 2], dtype="int32"),
+        )
 
 
 @pytest.mark.parametrize("ops", ALL_OPS)

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -228,6 +228,11 @@ def test_backprop_maxout(ops, dtype):
         [[[0.0, 1.0, 0.0], [2.0, 0.0, 0.0]], [[0.0, 0.0, 3.0], [0.0, 4.0, 0.0]]],
     )
 
+    with pytest.raises(IndexError):
+        ops.backprop_maxout(
+            ops.asarray2f([[1.0, 2.0], [3.0, 4.0]]), ops.asarray2i([[1, 0], [3, 1]]), 3
+        )
+
 
 @pytest.mark.parametrize("ops", ALL_OPS)
 @settings(max_examples=MAX_EXAMPLES, deadline=None)
@@ -773,6 +778,13 @@ def test_backprop_reduce_max(ops, dtype):
             [4.0, 0.0, 6.0],
         ],
     )
+
+    with pytest.raises(IndexError):
+        ops.backprop_reduce_max(
+            ops.xp.arange(1, 7, dtype="f").reshape(2, 3),
+            ops.xp.array([[2, 3, 0], [1, 0, 1]]).astype("int32"),
+            ops.xp.array([3, 2], dtype="int32"),
+        )
 
 
 @pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -732,6 +732,12 @@ def test_reduce_sum(ops):
     output = ops.reduce_sum(m, lengths)
     assert output.sum() == m.sum(), (output.sum(), m.sum())
 
+    with pytest.raises(IndexError):
+        ops.reduce_sum(m, ops.xp.array([5, 5, 5, 5], dtype="i"))
+
+    with pytest.raises(ValueError):
+        ops.reduce_sum(m, ops.xp.array([-1, 10, 5, 5], dtype="i"))
+
 
 @pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
 def test_backprop_fails_with_incorrect_length(ops, dtype):
@@ -771,6 +777,12 @@ def test_reduce_max(ops, dtype):
         truth = m[start : start + length].max(axis=0)
         ops.xp.testing.assert_allclose(maxes[i], truth)
         start += length
+
+    with pytest.raises(IndexError):
+        ops.reduce_max(m, ops.xp.array([5, 5, 5, 5], dtype="i"))
+
+    with pytest.raises(ValueError):
+        ops.reduce_max(m, ops.xp.array([-1, 10, 5, 5], dtype="i"))
 
 
 @pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
@@ -816,6 +828,12 @@ def test_reduce_mean(ops, dtype):
     ops.xp.testing.assert_allclose(
         ops.reduce_mean(X, lengths), [[3.0, 4.0], [2.0, 3.0]]
     )
+
+    with pytest.raises(IndexError):
+        ops.reduce_mean(X, ops.xp.array([3, 3], dtype="i"))
+
+    with pytest.raises(ValueError):
+        ops.reduce_mean(X, ops.xp.array([-1, 5], dtype="i"))
 
 
 @pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -734,24 +734,7 @@ def test_reduce_sum(ops):
 
 
 @pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
-def test_backprop_reduce_sum(ops, dtype):
-    dX = ops.backprop_reduce_sum(
-        ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),
-        ops.xp.array([4, 2], dtype="int32"),
-    )
-    assert dX.dtype == dtype
-    ops.xp.testing.assert_allclose(
-        dX,
-        [
-            [1.0, 2.0, 3.0],
-            [1.0, 2, 3.0],
-            [1.0, 2, 3.0],
-            [1.0, 2, 3.0],
-            [4.0, 5, 6.0],
-            [4.0, 5, 6.0],
-        ],
-    )
-
+def test_backprop_fails_with_incorrect_length(ops, dtype):
     with pytest.raises(ValueError, match=r"lengths must be"):
         ops.backprop_reduce_sum(
             ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),


### PR DESCRIPTION
This PR adds various bounds checks to `NumpyOps` to prevent out-of-bound reads and writes:

- Check that `which` indices are in bounds for `backprop_{maxout, reduce_max}`.
- Check that `dY` and `X` shapes match in backprop for elementwise functions.
- Hook up ReLU to the PyTorch comparison tests.
- Check that lengths are valid in `backprop_reduce_{mean, max, sum}`.