### PR TITLE
_custom_kernels: make all arguments kwarg-only

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -125,6 +125,7 @@ backprop_swish_kernel_float = _get_kernel("backprop_swish<float>")
 
 
 def clipped_linear(
+    *,
     X,
     inplace=False,
     slope=1.0,
@@ -154,7 +155,7 @@ def clipped_linear(
     return out
 
 
-def gelu(X, inplace=False, threshold=6.0, threads_per_block=128, num_blocks=128):
+def gelu(*, X, inplace=False, threshold=6.0, threads_per_block=128, num_blocks=128):
     _is_float_array(X)
 
     out = X
@@ -179,32 +180,32 @@ def check_seq2col_lengths(lengths, B):
     return lengths
 
 
-def seq2col(X, nW, *, lengths=None, threads_per_block=128, num_blocks=128):
-    _is_float_array(X)
+def seq2col(*, seq, nW, lengths=None, threads_per_block=128, num_blocks=128):
+    _is_float_array(seq)
 
-    B = X.shape[0]
+    B = seq.shape[0]
     nF = nW * 2 + 1
-    I = X.shape[1]
+    I = seq.shape[1]
 
     lengths = check_seq2col_lengths(lengths, B)
     nL = lengths.shape[0]
 
-    out = cupy.zeros((B, I * nF), dtype=X.dtype)
+    out = cupy.zeros((B, I * nF), dtype=seq.dtype)
 
-    if X.size != 0 and lengths.size != 0:
-        if X.dtype == "float32":
+    if seq.size != 0 and lengths.size != 0:
+        if seq.dtype == "float32":
             seq2col_kernel_float(
-                (num_blocks,), (threads_per_block,), (out, X, lengths, nW, B, I, nL)
+                (num_blocks,), (threads_per_block,), (out, seq, lengths, nW, B, I, nL)
             )
         else:
             seq2col_kernel_double(
-                (num_blocks,), (threads_per_block,), (out, X, lengths, nW, B, I, nL)
+                (num_blocks,), (threads_per_block,), (out, seq, lengths, nW, B, I, nL)
             )
 
     return out
 
 
-def maxout(X, threads_per_block=128, num_blocks=128):
+def maxout(*, X, threads_per_block=128, num_blocks=128):
     _is_float_array(X)
 
     B, I, P = X.shape
@@ -225,7 +226,7 @@ def maxout(X, threads_per_block=128, num_blocks=128):
     return best, which
 
 
-def mish(X, inplace=False, threshold=5, threads_per_block=128, num_blocks=128):
+def mish(*, X, inplace=False, threshold=5, threads_per_block=128, num_blocks=128):
     _is_float_array(X)
 
     out = X
@@ -244,7 +245,7 @@ def mish(X, inplace=False, threshold=5, threads_per_block=128, num_blocks=128):
     return out
 
 
-def reduce_sum(X, lengths, threads_per_block=128, num_blocks=128):
+def reduce_sum(*, X, lengths, threads_per_block=128, num_blocks=128):
     _is_float_array(X)
 
     B = len(lengths)
@@ -267,7 +268,7 @@ def reduce_sum(X, lengths, threads_per_block=128, num_blocks=128):
     return out
 
 
-def reduce_mean(X, lengths, threads_per_block=128, num_blocks=128):
+def reduce_mean(*, X, lengths, threads_per_block=128, num_blocks=128):
     _is_float_array(X)
 
     B = len(lengths)
@@ -292,7 +293,7 @@ def reduce_mean(X, lengths, threads_per_block=128, num_blocks=128):
     return out
 
 
-def reduce_max(X, lengths, threads_per_block=128, num_blocks=128):
+def reduce_max(*, X, lengths, threads_per_block=128, num_blocks=128):
     _is_float_array(X)
 
     B = len(lengths)
@@ -317,7 +318,7 @@ def reduce_max(X, lengths, threads_per_block=128, num_blocks=128):
     return maxes, which
 
 
-def swish(X, inplace=False, threshold=17.0, threads_per_block=128, num_blocks=128):
+def swish(*, X, inplace=False, threshold=17.0, threads_per_block=128, num_blocks=128):
     _is_float_array(X)
 
     out = X
@@ -334,7 +335,7 @@ def swish(X, inplace=False, threshold=17.0, threads_per_block=128, num_blocks=12
     return out
 
 
-def backprop_seq2col(dY, nW, *, lengths=None, threads_per_block=128, num_blocks=128):
+def backprop_seq2col(*, dY, nW, lengths=None, threads_per_block=128, num_blocks=128):
     _is_float_array(dY)
 
     B = dY.shape[0]
@@ -360,6 +361,7 @@ def backprop_seq2col(dY, nW, *, lengths=None, threads_per_block=128, num_blocks=
 
 
 def backprop_clipped_linear(
+    *,
     dY,
     X,
     slope: float = 1.0,
@@ -394,7 +396,7 @@ def backprop_clipped_linear(
 
 
 def backprop_hard_swish(
-    dY, X, inplace: bool = False, threads_per_block=128, num_blocks=128
+    *, dY, X, inplace: bool = False, threads_per_block=128, num_blocks=128
 ):
     _is_float_array(dY)
     _is_float_array(X, shape=dY.shape)
@@ -416,7 +418,7 @@ def backprop_hard_swish(
 
 
 def backprop_hard_swish_mobilenet(
-    dY, X, inplace: bool = False, threads_per_block=128, num_blocks=128
+    *, dY, X, inplace: bool = False, threads_per_block=128, num_blocks=128
 ):
     _is_float_array(dY)
     _is_float_array(X, shape=dY.shape)
@@ -438,7 +440,13 @@ def backprop_hard_swish_mobilenet(
 
 
 def backprop_gelu(
-    dY, X, inplace: bool = False, threshold=6.0, threads_per_block=128, num_blocks=128
+    *,
+    dY,
+    X,
+    inplace: bool = False,
+    threshold=6.0,
+    threads_per_block=128,
+    num_blocks=128,
 ):
     _is_float_array(dY)
     _is_float_array(X, shape=dY.shape)
@@ -459,7 +467,7 @@ def backprop_gelu(
     return out
 
 
-def backprop_maxout(dY, which, P, threads_per_block=128, num_blocks=128):
+def backprop_maxout(*, dY, which, P, threads_per_block=128, num_blocks=128):
     _is_float_array(dY)
 
     B = dY.shape[0]
@@ -482,7 +490,7 @@ def backprop_maxout(dY, which, P, threads_per_block=128, num_blocks=128):
 
 
 def backprop_mish(
-    dY, X, inplace: bool = False, threshold=5, threads_per_block=128, num_blocks=128
+    *, dY, X, inplace: bool = False, threshold=5, threads_per_block=128, num_blocks=128
 ):
     _is_float_array(dY)
     _is_float_array(X, shape=dY.shape)
@@ -503,51 +511,53 @@ def backprop_mish(
     return out
 
 
-def backprop_reduce_sum(d_sum, lengths, threads_per_block=128, num_blocks=128):
-    _is_float_array(d_sum)
+def backprop_reduce_sum(*, d_sums, lengths, threads_per_block=128, num_blocks=128):
+    _is_float_array(d_sums)
 
     B = len(lengths)
     T = int(lengths.sum())
-    O = d_sum.shape[1]
+    O = d_sums.shape[1]
     _check_lengths(lengths, T)
 
-    out = cupy.zeros((T, O), dtype=d_sum.dtype)
+    out = cupy.zeros((T, O), dtype=d_sums.dtype)
 
-    if d_sum.dtype == "float32":
+    if d_sums.dtype == "float32":
         backprop_reduce_sum_kernel_float(
-            (num_blocks,), (threads_per_block,), (out, d_sum, lengths, B, T, O)
+            (num_blocks,), (threads_per_block,), (out, d_sums, lengths, B, T, O)
         )
     else:
         backprop_reduce_sum_kernel_double(
-            (num_blocks,), (threads_per_block,), (out, d_sum, lengths, B, T, O)
+            (num_blocks,), (threads_per_block,), (out, d_sums, lengths, B, T, O)
         )
 
     return out
 
 
-def backprop_reduce_mean(d_mean, lengths, threads_per_block=128, num_blocks=128):
-    _is_float_array(d_mean)
+def backprop_reduce_mean(*, d_means, lengths, threads_per_block=128, num_blocks=128):
+    _is_float_array(d_means)
 
     B = len(lengths)
     T = int(lengths.sum())
-    O = d_mean.shape[1]
+    O = d_means.shape[1]
     _check_lengths(lengths, T)
 
-    out = cupy.zeros((T, O), dtype=d_mean.dtype)
+    out = cupy.zeros((T, O), dtype=d_means.dtype)
 
-    if d_mean.dtype == "float32":
+    if d_means.dtype == "float32":
         backprop_reduce_mean_kernel_float(
-            (num_blocks,), (threads_per_block,), (out, d_mean, lengths, B, T, O)
+            (num_blocks,), (threads_per_block,), (out, d_means, lengths, B, T, O)
         )
     else:
         backprop_reduce_mean_kernel_double(
-            (num_blocks,), (threads_per_block,), (out, d_mean, lengths, B, T, O)
+            (num_blocks,), (threads_per_block,), (out, d_means, lengths, B, T, O)
         )
 
     return out
 
 
-def backprop_reduce_max(d_maxes, which, lengths, threads_per_block=128, num_blocks=128):
+def backprop_reduce_max(
+    *, d_maxes, which, lengths, threads_per_block=128, num_blocks=128
+):
     _is_float_array(d_maxes)
 
     B = len(lengths)
@@ -572,7 +582,7 @@ def backprop_reduce_max(d_maxes, which, lengths, threads_per_block=128, num_bloc
 
 
 def backprop_swish(
-    dY, X, Y, inplace=False, threshold=17.0, threads_per_block=128, num_blocks=128
+    *, dY, X, Y, inplace=False, threshold=17.0, threads_per_block=128, num_blocks=128
 ):
     _is_float_array(dY)
     _is_float_array(X, shape=dY.shape)
@@ -594,7 +604,7 @@ def backprop_swish(
     return out
 
 
-def hash(ids, seed, threads_per_block=128, num_blocks=128):
+def hash(*, ids, seed, threads_per_block=128, num_blocks=128):
     out = cupy.zeros((ids.shape[0], 4), dtype="uint32")
 
     # sizeof(uint32_t) * 4

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -43,13 +43,15 @@ class CupyOps(Ops):
 
     def gelu(self, X, inplace=False):
         if X.dtype in ("float32", "float64"):
-            return _custom_kernels.gelu(X, inplace=inplace, threshold=6.0)
+            return _custom_kernels.gelu(X=X, inplace=inplace, threshold=6.0)
         else:
             return super().gelu(X, inplace=inplace)
 
     def backprop_gelu(self, dY, X, inplace=False):
         if X.dtype == dY.dtype and X.dtype in ("float32", "float64"):
-            return _custom_kernels.backprop_gelu(dY, X, inplace=inplace, threshold=6.0)
+            return _custom_kernels.backprop_gelu(
+                dY=dY, X=X, inplace=inplace, threshold=6.0
+            )
         else:
             return super().backprop_gelu(dY, X, inplace=inplace)
 
@@ -87,13 +89,13 @@ class CupyOps(Ops):
 
     def maxout(self, X):
         if X.dtype in ("float32", "float64"):
-            return _custom_kernels.maxout(X)
+            return _custom_kernels.maxout(X=X)
         else:
             return super().maxout(X)
 
     def backprop_maxout(self, dY, which, P):
         if dY.dtype in ("float32", "float64") and which.dtype == "int32":
-            return _custom_kernels.backprop_maxout(dY, which, P)
+            return _custom_kernels.backprop_maxout(dY=dY, which=which, P=P)
         else:
             return super().backprop_maxout(dY, which, P)
 
@@ -121,7 +123,7 @@ class CupyOps(Ops):
     ):
         if X.dtype in ("float32", "float64"):
             return _custom_kernels.clipped_linear(
-                X,
+                X=X,
                 inplace=inplace,
                 slope=slope,
                 offset=offset,
@@ -171,40 +173,42 @@ class CupyOps(Ops):
 
     def backprop_hard_swish(self, dY, X, inplace: bool = False):
         if X.dtype == dY.dtype and X.dtype in ("float32", "float64"):
-            return _custom_kernels.backprop_hard_swish(dY, X, inplace=inplace)
+            return _custom_kernels.backprop_hard_swish(dY=dY, X=X, inplace=inplace)
         else:
             return super().backprop_hard_swish(dY, X, inplace=inplace)
 
     def backprop_hard_swish_mobilenet(self, dY, X, inplace: bool = False):
         if X.dtype == dY.dtype and X.dtype in ("float32", "float64"):
-            return _custom_kernels.backprop_hard_swish_mobilenet(dY, X, inplace=inplace)
+            return _custom_kernels.backprop_hard_swish_mobilenet(
+                dY=dY, X=X, inplace=inplace
+            )
         else:
             return super().backprop_hard_swish_mobilenet(dY, X, inplace=inplace)
 
     def mish(self, X, threshold=20.0, inplace=False):
         if X.dtype in ("float32", "float64"):
-            return _custom_kernels.mish(X, inplace=inplace, threshold=threshold)
+            return _custom_kernels.mish(X=X, inplace=inplace, threshold=threshold)
         else:
             return super().mish(X, threshold, inplace)
 
     def backprop_mish(self, dY, X, threshold=20.0, inplace=False):
         if X.dtype == dY.dtype and X.dtype in ("float32", "float64"):
             return _custom_kernels.backprop_mish(
-                dY, X, inplace=inplace, threshold=threshold
+                dY=dY, X=X, inplace=inplace, threshold=threshold
             )
         else:
             return super().backprop_mish(dY, X, threshold, inplace)
 
     def swish(self, X, inplace=False):
         if X.dtype in ("float32", "float64"):
-            return _custom_kernels.swish(X, inplace=inplace, threshold=17.0)
+            return _custom_kernels.swish(X=X, inplace=inplace, threshold=17.0)
         else:
             return super().swish(X, inplace=inplace)
 
     def backprop_swish(self, dY, X, Y, inplace=False):
         if X.dtype == dY.dtype == Y.dtype and X.dtype in ("float32", "float64"):
             return _custom_kernels.backprop_swish(
-                dY, X, Y, inplace=inplace, threshold=17.0
+                dY=dY, X=X, Y=Y, inplace=inplace, threshold=17.0
             )
         else:
             return super().backprop_swish(dY, X, Y, inplace=inplace)
@@ -229,7 +233,7 @@ class CupyOps(Ops):
         if seq.dtype in ("float32", "float64") and (
             lengths is None or lengths.dtype == "int32"
         ):
-            return _custom_kernels.seq2col(seq, nW, lengths=lengths)
+            return _custom_kernels.seq2col(seq=seq, nW=nW, lengths=lengths)
         else:
             return super().seq2col(seq, nW, lengths=lengths)
 
@@ -237,25 +241,27 @@ class CupyOps(Ops):
         if dY.dtype in ("float32", "float64") and (
             lengths is None or lengths.dtype == "int32"
         ):
-            return _custom_kernels.backprop_seq2col(dY, nW, lengths=lengths)
+            return _custom_kernels.backprop_seq2col(dY=dY, nW=nW, lengths=lengths)
         else:
             return super().backprop_seq2col(dY, nW, lengths=lengths)
 
     def reduce_mean(self, X, lengths):
         if X.dtype in ("float32", "float64") and lengths.dtype == "int32":
-            return _custom_kernels.reduce_mean(X, lengths)
+            return _custom_kernels.reduce_mean(X=X, lengths=lengths)
         else:
             super().reduce_mean(X, lengths)
 
     def backprop_reduce_mean(self, d_means, lengths):
         if d_means.dtype in ("float32", "float64") and lengths.dtype == "int32":
-            return _custom_kernels.backprop_reduce_mean(d_means, lengths)
+            return _custom_kernels.backprop_reduce_mean(
+                d_means=d_means, lengths=lengths
+            )
         else:
             super().backprop_reduce_mean(d_means, lengths)
 
     def reduce_max(self, X, lengths):
         if X.dtype in ("float32", "float64") and lengths.dtype == "int32":
-            return _custom_kernels.reduce_max(X, lengths)
+            return _custom_kernels.reduce_max(X=X, lengths=lengths)
         else:
             super().reduce_max(X, lengths)
 
@@ -265,24 +271,26 @@ class CupyOps(Ops):
             and which.dtype == "int32"
             and lengths.dtype == "int32"
         ):
-            return _custom_kernels.backprop_reduce_max(d_maxes, which, lengths)
+            return _custom_kernels.backprop_reduce_max(
+                d_maxes=d_maxes, which=which, lengths=lengths
+            )
         else:
             super().backprop_reduce_max(d_maxes, which, lengths)
 
     def reduce_sum(self, X, lengths):
         if X.dtype in ("float32", "float64") and lengths.dtype == "int32":
-            return _custom_kernels.reduce_sum(X, lengths)
+            return _custom_kernels.reduce_sum(X=X, lengths=lengths)
         else:
             return super().reduce_sum(X, lengths)
 
     def backprop_reduce_sum(self, d_sums, lengths):
         if d_sums.dtype in ("float32", "float64") and lengths.dtype == "int32":
-            return _custom_kernels.backprop_reduce_sum(d_sums, lengths)
+            return _custom_kernels.backprop_reduce_sum(d_sums=d_sums, lengths=lengths)
         else:
             return super().backprop_reduce_sum(d_sums, lengths)
 
     def hash(self, ids, seed):
-        return _custom_kernels.hash(ids, seed)
+        return _custom_kernels.hash(ids=ids, seed=seed)
 
     def scatter_add(self, table, indices, values):
         self._xp2.scatter_add(table, indices, values)


### PR DESCRIPTION
Some kernels take multiple arguments, which are all arrays with the same shape. It's easy to accidentally mix up the order and introduce bugs in that way. This change makes all arguments kwarg-only, so that we always specify what we intend to pass at the call site.

Since `_custom_kernels` is an internal module, this does not result in any public API changes.
