### PR TITLE
GradScaler: Do not enable when training on CPU

### DIFF
--- a/thinc/tests/shims/test_pytorch_grad_scaler.py
+++ b/thinc/tests/shims/test_pytorch_grad_scaler.py
@@ -89,12 +89,3 @@ def test_grad_scaler():
     assert scaler.scale([torch.tensor([1.0], device=device_id)]) == [
         torch.tensor([2.0**15], device=device_id)
     ]
-
-
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
-@pytest.mark.skipif(
-    has_torch_amp, reason="needs PyTorch without gradient scaling support"
-)
-def test_raises_on_old_pytorch():
-    with pytest.raises(ValueError, match=r"not supported.*1.9.0"):
-        PyTorchGradScaler(enabled=True)


### PR DESCRIPTION
- Disable gradient scaling and emit a warning when but CPU training is
  performed.
- Disable gradient scaling and emit a warning when a PyTorch version
  without gradient scaling is used (rather than raising an exception).

See https://github.com/explosion/spaCy/issues/10527

**Note:** putting this in draft. I'd like to add a similar check and warning to the shim.