### PR TITLE
Mixed-precision training: improve checks

### DIFF
--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -43,11 +43,6 @@ class PyTorchShim(Shim):
         mixed_precision: bool = False,
         grad_scaler: Optional[PyTorchGradScaler] = None,
     ):
-        if mixed_precision and not has_torch_amp:
-            raise ValueError(
-                "Mixed-precision training is not supported, requires capable GPU and torch>=1.9.0"
-            )
-
         super().__init__(model, config, optimizer)
 
         if grad_scaler is None:

--- a/thinc/shims/pytorch_grad_scaler.py
+++ b/thinc/shims/pytorch_grad_scaler.py
@@ -50,11 +50,6 @@ class PyTorchGradScaler:
             When no overflows were found for this number of steps, the scale will
             be multiplied by "growth_factor".
         """
-        if enabled and not has_torch_amp:
-            raise ValueError(
-                "Gradient scaling is not supported, requires capable GPU and torch>=1.9.0"
-            )
-
         self._enabled = enabled
         self._growth_factor = growth_factor
         self._backoff_factor = backoff_factor
@@ -107,6 +102,11 @@ class PyTorchGradScaler:
         scale_per_device: Dict["torch.device", "torch.Tensor"],
         inplace: bool,
     ):
+        if not has_torch_amp:
+            raise ValueError(
+                "Gradient scaling is not supported, requires capable GPU and torch>=1.9.0"
+            )
+
         if not tensor.is_cuda:
             msg = (
                 "Gradient scaling is only supported for CUDA tensors. "

--- a/thinc/shims/pytorch_grad_scaler.py
+++ b/thinc/shims/pytorch_grad_scaler.py
@@ -107,7 +107,13 @@ class PyTorchGradScaler:
         scale_per_device: Dict["torch.device", "torch.Tensor"],
         inplace: bool,
     ):
-        assert tensor.is_cuda, "Gradient scaling is only supported for CUDA tensors"
+        if not tensor.is_cuda:
+            msg = (
+                "Gradient scaling is only supported for CUDA tensors. "
+                "If you are using PyTorch models, you can avoid this "
+                "error by disabling mixed-precision support."
+            )
+            raise ValueError(msg)
 
         device = tensor.device
 

--- a/thinc/tests/layers/test_pytorch_wrapper.py
+++ b/thinc/tests/layers/test_pytorch_wrapper.py
@@ -148,18 +148,3 @@ def test_pytorch_convert_inputs(data, n_args, kwargs_keys):
     convert_inputs = model.attrs["convert_inputs"]
     Y, backprop = convert_inputs(model, data, is_train=True)
     check_input_converters(Y, backprop, data, n_args, kwargs_keys, torch.Tensor)
-
-
-@pytest.mark.skipif(not has_torch_gpu, reason="needs PyTorch with CUDA-capable GPU")
-@pytest.mark.skipif(
-    has_torch_amp, reason="needs PyTorch without mixed-precision support"
-)
-def test_raises_on_old_pytorch():
-    import torch.nn
-
-    pytorch_layer = torch.nn.Linear(5, 5)
-    with pytest.raises(ValueError, match=r"not supported.*1.9.0"):
-        PyTorchWrapper_v2(
-            pytorch_layer.cuda(),
-            mixed_precision=True,
-        )

--- a/thinc/tests/shims/test_pytorch_grad_scaler.py
+++ b/thinc/tests/shims/test_pytorch_grad_scaler.py
@@ -96,8 +96,9 @@ def test_grad_scaler():
     has_torch_amp, reason="needs PyTorch without gradient scaling support"
 )
 def test_raises_on_old_pytorch():
+    scaler = PyTorchGradScaler(enabled=True)
     with pytest.raises(ValueError, match=r"not supported.*1.9.0"):
-        PyTorchGradScaler(enabled=True)
+        scaler.scale([torch.tensor([1.0], device="cpu")])
 
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")

--- a/thinc/tests/shims/test_pytorch_grad_scaler.py
+++ b/thinc/tests/shims/test_pytorch_grad_scaler.py
@@ -96,6 +96,7 @@ def test_grad_scaler():
     has_torch_amp, reason="needs PyTorch without gradient scaling support"
 )
 def test_raises_on_old_pytorch():
+    import torch
     scaler = PyTorchGradScaler(enabled=True)
     with pytest.raises(ValueError, match=r"not supported.*1.9.0"):
         scaler.scale([torch.tensor([1.0], device="cpu")])

--- a/thinc/tests/shims/test_pytorch_grad_scaler.py
+++ b/thinc/tests/shims/test_pytorch_grad_scaler.py
@@ -98,3 +98,17 @@ def test_grad_scaler():
 def test_raises_on_old_pytorch():
     with pytest.raises(ValueError, match=r"not supported.*1.9.0"):
         PyTorchGradScaler(enabled=True)
+
+
+@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(
+    not has_torch_amp, reason="needs PyTorch with gradient scaling support"
+)
+def test_raises_with_cpu_tensor():
+    import torch
+
+    scaler = PyTorchGradScaler(enabled=True)
+    with pytest.raises(
+        ValueError, match=r"Gradient scaling is only supported for CUDA tensors."
+    ):
+        scaler.scale([torch.tensor([1.0], device="cpu")])


### PR DESCRIPTION
1. Before this change, using gradient scaling on a non-CUDA tensor would trigger an assertion. However, it is possible to trigger this error outside Thinc by enabling mixed-precision training on a CPU. So this should be a proper exception rather than an `AssertionError`. Besides raising a `ValueError`, the error message is also extended to describe how the error can be avoided.

2.  We checked that gradient scaling is supported when construction a PyTorchGradScaler. However, this gives issues when someone uses a model that was trained with gradient scaling. In such cases, it's safe to contruct a grad scaler, since it is not used. This change moves the check to the actual scaling.

3. Also remove the check that verifies that mixed-precision scaling is available (when enabled) from the constructor of PyTorchShim. PyTorch will at most give a warning when trying to autocast when there is no support.