### PR TITLE
test end-of-life Python 3.6 on windows-2019 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   strategy:
     matrix:
       Python36Windows:
-        imageName: 'windows-latest'
+        imageName: 'windows-2019'
         python.version: '3.6'
       Python37Mac:
         imageName: 'macos-10.15'


### PR DESCRIPTION
`windows-latest` recently [switched](https://github.com/actions/virtual-environments/issues/4856) to `windows-2022`, which doesn't support (end-of-life) Python 3.6 anymore. It doesn't hurt to keep testing this Python version on the CI when we still can, though, so editing this Azure step to use `windows-2019` explicitely.