### PR TITLE
Make NumpyOps CPU kernels generic

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include thinc *.cu *.pyx *.pxd
+recursive-include thinc *.cu *.pyx *.pxd *.hh
 include LICENSE
 include README.md
 prune tmp/

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ def setup_package():
         version=about["__version__"],
         ext_modules=ext_modules,
         cmdclass={"build_ext": build_ext_subclass},
-        package_data={"": ["*.pyx", "*.pxd", "*.pxi", "*.cu"]},
+        package_data={"": ["*.pyx", "*.pxd", "*.pxi", "*.cu", "*.hh"]},
     )
 
 

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -93,7 +93,7 @@ void cpu_reduce_max(A* maxes__bo, L* which__bo, const A* X__to,
 
         T -= *length;
 
-        memcpy(maxes__bo, X__to, O * sizeof(*maxes__bo));
+        std::memcpy(maxes__bo, X__to, O * sizeof(*maxes__bo));
         X__to += O;
         for (L i = 1; i < *length; ++i) {
             for (L j = 0; j < O; ++j) {

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -1,0 +1,394 @@
+#ifndef CPU_KERNELS_HH
+#define CPU_KERNELS_HH
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+
+// All elementwise functions, such as most activations, work in-place.
+
+template <typename A, typename L>
+L argmax(A* arr, L len)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    L max = 0;
+    for (L i = 1; i < len; ++i) {
+        if (arr[i] > arr[max]) {
+            max = i;
+        }
+    }
+
+    return max;
+}
+
+template <typename A, typename L>
+void vec_add(A* X, const A* Y, A scale, L N)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (L i = 0; i < N; ++i)
+        X[i] += scale * Y[i];
+}
+
+template <typename A, typename L>
+void cpu_maxout(A* best__bo, L* which__bo, const A* cands__bop, L B, L O, L P)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (int i = 0; i < B * O; ++i) {
+        which__bo[i] = argmax(cands__bop + i * P, P);
+        best__bo[i] = cands__bop[i * P + which__bo[i]];
+    }
+}
+
+template <typename A, typename L>
+void cpu_backprop_maxout(A* dX__bop, const A* dX__bo, const L* which__bo,
+    L B, L O, L P)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (L b = 0; b < B; ++b) {
+        for (L o = 0; o < O; ++o) {
+            if (*which__bo >= P) {
+                throw std::out_of_range(std::string("index ") + std::to_string(*which__bo) + " is out of bounds for maxout with size " + std::to_string(P));
+            }
+
+            dX__bop[*which__bo] = *dX__bo;
+            dX__bop += P;
+            dX__bo += 1;
+            which__bo += 1;
+        }
+    }
+}
+
+template <typename A, typename L>
+void cpu_reduce_max(A* maxes__bo, L* which__bo, const A* X__to,
+    const L* lengths__b, L B, L T, L O)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (const L* length = lengths__b; length < lengths__b + B; ++length) {
+        if (*length == 0)
+            continue;
+        else if (*length < 0)
+            throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
+        else if (*length > T) {
+            throw std::out_of_range("lengths must sum up to the number of rows");
+        }
+
+        T -= *length;
+
+        memcpy(maxes__bo, X__to, O * sizeof(*maxes__bo));
+        X__to += O;
+        for (L i = 1; i < *length; ++i) {
+            for (L j = 0; j < O; ++j) {
+                if (X__to[j] > maxes__bo[j]) {
+                    maxes__bo[j] = X__to[j];
+                    which__bo[j] = i;
+                }
+            }
+            X__to += O;
+        }
+
+        maxes__bo += O;
+        which__bo += O;
+    }
+}
+
+template <typename A, typename L>
+void cpu_backprop_reduce_max(A* dX__to, const A* d_maxes__bo, const L* which__bo,
+    const L* lengths__b, L B, L T, L O)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (const L* length = lengths__b; length < lengths__b + B; ++length) {
+        for (L i = 0; i < O; ++i) {
+            L item = which__bo[i];
+            if (item >= *length) {
+                throw std::out_of_range(std::string("index ") + std::to_string(item) + " is out of bounds for maxout with length " + std::to_string(*length));
+            }
+
+            dX__to[item * O + i] = d_maxes__bo[i];
+        }
+
+        dX__to += *length * O;
+        d_maxes__bo += O;
+        which__bo += O;
+    }
+}
+
+template <typename A, typename L>
+void cpu_reduce_mean(A* means__bo, const A* X__to, const L* lengths__b,
+    L B, L T, L O)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (const L* length = lengths__b; length < lengths__b + B; ++length) {
+        if (*length == 0)
+            continue;
+        else if (*length < 0)
+            throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
+        else if (*length > T) {
+            throw std::out_of_range("lengths must sum up to the number of rows");
+        }
+
+        T -= *length;
+
+        A scale = 1. / *length;
+        for (L i = 0; i < *length; ++i) {
+            vec_add(means__bo, X__to, scale, O);
+            X__to += O;
+        }
+
+        means__bo += O;
+    }
+}
+
+template <typename A, typename L>
+void cpu_backprop_reduce_mean(A* dX__to, const A* d_means__bo, const L* lengths__b,
+    L B, L T, L O)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (const L* length = lengths__b; length < lengths__b + B; ++length) {
+        A scale = 1. / *length;
+        for (L i = 0; i < *length; ++i) {
+            vec_add(dX__to, d_means__bo, scale, O);
+            dX__to += O;
+        }
+
+        d_means__bo += O;
+    }
+}
+
+template <typename A, typename L>
+void cpu_mish(A* Y, L N, A threshold)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (L i = 0; i < N; ++i) {
+        if (Y[i] < threshold) {
+            Y[i] *= std::tanh(std::log(1.0 + std::exp(Y[i])));
+        }
+    }
+}
+
+template <typename A, typename L>
+void cpu_backprop_mish(A* dX, const A* X, L N, A threshold)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (L i = 0; i < N; ++i) {
+        A x = X[i];
+
+        if (x < threshold) {
+            A exp_x = std::exp(x);
+            A exp_2x = std::exp(2 * x);
+            A exp_3x = std::exp(3 * x);
+            A omega = (4. * (x + 1)) + (4 * exp_2x) + exp_3x + exp_x * (4. * x + 6);
+            A delta = 2. * exp_x + exp_2x + 2.;
+            dX[i] = dX[i] * ((exp_x * omega) / (delta * delta));
+        }
+    }
+}
+
+template <typename A, typename L>
+void cpu_reduce_sum(A* sums__bo, const A* X__to, const L* lengths__b,
+    L B, L T, L O)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (const L* length = lengths__b; length < lengths__b + B; ++length) {
+        if (*length == 0)
+            continue;
+        else if (*length < 0)
+            throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
+        else if (*length > T) {
+            throw std::out_of_range("lengths must sum up to the number of rows");
+        }
+
+        T -= *length;
+
+        for (L i = 0; i < *length; ++i) {
+            vec_add(sums__bo, X__to, static_cast<A>(1.0), O);
+            X__to += O;
+        }
+
+        sums__bo += O;
+    }
+}
+
+template <typename A, typename L>
+void cpu_backprop_reduce_sum(A* dX__to, const A* d_sums__bo, const L* lengths__b,
+    L B, L T, L O)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (const L* length = lengths__b; length < lengths__b + B; ++length) {
+        for (L i = 0; i < *length; ++i) {
+            vec_add(dX__to, d_sums__bo, static_cast<A>(1.0), O);
+            dX__to += O;
+        }
+
+        d_sums__bo += O;
+    }
+}
+
+template <typename A, typename L>
+void cpu_relu(A* X, L N)
+{
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    for (L i = 0; i < N; ++i) {
+        if (X[i] < 0) {
+            X[i] = 0.0;
+        }
+    }
+}
+
+template <typename A, typename L>
+void seq2col(A* output, const A* X, const L* lengths, L nW, L B, L I, L nL)
+{
+    // Let's say nW is 1 (it usually is). Then we want to take:
+
+    // 1a 1b 1c
+    // 2a 2b 2c
+    // 3a 3b 3c
+
+    // And make
+
+    // __ __ __ 1a 1b 1c 2a 2b 2c
+    // 1a 1b 1c 2a 2b 2c 3a 3b 3c
+    // 2a 2b 2c 3a 3b 3c __ __ __
+
+    // Where __ is padding.
+
+    // Now let's say nW is 2. Then we want to take:
+
+    // 1a 1b 1c
+    // 2a 2b 2c
+    // 3a 3b 3c
+
+    // And make
+
+    // __ __ __ __ __ __ 1a 1b 1c 2a 2b 2c 3a 3b 3c
+    // __ __ __ 1a 1b 1c 2a 2b 2c 3a 3b 3c __ __ __
+    // 1a 1b 1c 2a 2b 2c 3a 3b 3c __ __ __ __ __ __
+
+    // * x_start=-6, x_end=9 : (0-2) * 3, (0+2+1) * 3
+    // * x_start=-3, x_end=13 : (1-2) * 3, (1+2+1) * 3
+    // * x_start=0, x_end=16 : (2-2) * 3, (2+2+1) * 3
+
+    // If lengths > 1, then the sequence lengths dictate
+    // the boundaries/padding rather than the begin/end
+    // of X.
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    L nF = nW * 2 + 1;
+
+    L seq_start = 0;
+    for (L i = 0; i < nL; ++i) {
+        // Calculate the bounds of the next sequence.
+        L seq_end = seq_start + lengths[i];
+
+        for (L j = seq_start; j < seq_end; ++j) {
+            // Find the unconstrained window around b, which
+            // may be out of the sequence bounds.
+            L window_start = j - nW;
+            L window_end = j + nW + 1;
+
+            // Find the sequence-constrained window around b.
+            L x_start = std::max(seq_start, window_start);
+            L x_end = std::min(seq_end, window_end);
+            L n_elems = x_end - x_start;
+
+            L out_offset = x_start - window_start;
+
+            std::memcpy(output + (j * nF * I) + (out_offset * I),
+                X + (x_start * I),
+                n_elems * I * sizeof(*output));
+        }
+
+        seq_start += lengths[i];
+    }
+}
+
+template <typename A, typename L>
+void backprop_seq2col(A* d_seqs, const A* d_cols, const L* lengths, L B, L I, L nW, L nL)
+{
+    // here's what we're doing, if we had 2d indexing.
+    // for i in range(b):
+    //     d_seq[i] += d_cols[i-2, 4]
+    //     d_seq[i] += d_cols[i-1, 3]
+    //     d_seq[i] += d_cols[i, 2]
+    //     d_seq[i] += d_cols[i+1, 1]
+    //     d_seq[i] += d_cols[i+2, 0]
+    static_assert(std::is_floating_point<A>::value,
+        "Array should be floating point");
+    static_assert(std::is_integral<L>::value, "Array length should be integral");
+
+    L nF = nW * 2 + 1;
+
+    L seq_start = 0;
+    for (L i = 0; i < nL; ++i) {
+        // Calculate the bounds of the next sequence.
+        L seq_end = seq_start + lengths[i];
+
+        for (L j = seq_start; j < seq_end; ++j) {
+            // Find the unconstrained window around b, which
+            // may be out of the sequence bounds.
+            L window_begin = j - nW;
+            L window_end = j + nW + 1;
+
+            // Find the sequence-constrained window around b.
+            L d_seqs_begin = std::max(seq_start, window_begin);
+            L d_seqs_end = std::min(seq_end, window_end);
+            L n_elems = d_seqs_end - d_seqs_begin;
+
+            // If the left window is cut short, we want to
+            // start by the same amount in the output.
+            L out_offset = d_seqs_begin - window_begin;
+
+            vec_add(d_seqs + d_seqs_begin * I,
+                d_cols + (j * nF * I) + (out_offset * I),
+                static_cast<A>(1.), n_elems * I);
+        }
+
+        seq_start += lengths[i];
+    }
+}
+
+#endif // CPU_KERNELS_HH

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -271,7 +271,7 @@ void cpu_relu(A* X, L N)
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
     for (L i = 0; i < N; ++i) {
-        if (X[i] < 0) {
+        if (X[i] <= 0.0) {
             X[i] = 0.0;
         }
     }

--- a/thinc/backends/numpy_ops.pxd
+++ b/thinc/backends/numpy_ops.pxd
@@ -1,26 +1,37 @@
-cdef void seq2col(float* output, const float* X, const int* L, int nW, int B, int I, int nL) nogil
+ctypedef double[:, ::1] double2d_t
+ctypedef double[:, :, ::1] double3d_t
+ctypedef float[:, ::1] float2d_t
+ctypedef float[:, :, ::1] float3d_t
 
-cdef void backprop_seq2col(float* d_seqs,
-        const float* d_cols, const int* L, int B, int I, int nW, int nL) nogil
+cdef fused reals2d_ft:
+    float2d_t
+    double2d_t
 
-cdef void cpu_maxout(float* best__bo, int* which__bo,
-        const float* cands__bop, int B, int O, int P) nogil
+cdef fused reals3d_ft:
+    float3d_t
+    double3d_t
 
-cdef int cpu_backprop_maxout(float* dX__bop,
-        const float* dX__bo, const int* which__bo, int B, int O, int P) nogil except -1
 
-cdef int cpu_reduce_mean(float* means__bo,
-        const float* X__to, const int* lengths__b,
-        int B, int T, int O) nogil except -1
+cdef extern from "cpu_kernels.hh":
+    void cpu_maxout[A, L](A* best__bo, L* which__bo, const A* cands_bop,
+        L B, L O, L P)
+    void cpu_backprop_maxout[A, L](A* dX__bop, const A* dX__bo, const L* which__bo,
+        L B, L O, L P) except +
+    void cpu_reduce_max[A, L](A* maxes__bo, L* which_bo, const A* X__to,
+        const L* lengths__b, L B, L T, L O) except +
 
-cdef void cpu_backprop_reduce_mean(float* dX__to,
-        const float* d_means__bo, const int* lengths__b,
-        int B, int T, int O) nogil
-
-cdef int cpu_reduce_max(float* maxes__bo, int* which__bo,
-        const float* X__to, const int* lengths__b,
-        int B, int T, int O) nogil except -1
-
-cdef int cpu_backprop_reduce_max(float* dX__to,
-        const float* d_maxes__bo, const int* which__bo, const int* lengths__b,
-        int B, int T, int O) nogil except -1
+    void cpu_backprop_reduce_max[A, L](A* dX__to, const A* d_maxes__bo, const L* which__bo,
+        const L* lengths__b, L B, L T, L O) except +
+    void cpu_reduce_mean[A, L](A* means__bo, const A* X__to, const L* lengths__b,
+        L B, L T, L O) except +
+    void cpu_backprop_reduce_mean[A, L](A* dX__to, const A* d_means__bo, const L* lengths__b,
+        L B, L T, L O)
+    void cpu_mish[A, L](A* Y, L N, A threshold)
+    void cpu_backprop_mish[A, L](A* dX, const A* X, L N, A threshold)
+    void cpu_reduce_sum[A, L](A* sums__bo, const A* X__to, const L* lengths__b,
+        L B, L T, L O) except +
+    void cpu_backprop_reduce_sum[A, L](A* dX__to, const A* d_sums__bo, const L* lengths__b,
+        L B, L T, L O)
+    void cpu_relu[A, L](A* X, L N)
+    void backprop_seq2col[A, L](A* d_seqs, const A* d_cols, const L* lengths, L B, L I, L nW, L nL)
+    void seq2col[A, L](A* output, const A* X, const L* lengths, L nW, L B, L I, L nL)

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -32,15 +32,6 @@ ALL_OPS = XP_OPS + [VANILLA_OPS]
 FLOAT_TYPES = ["float32", "float64"]
 
 
-def ops_with_dtypes(all_ops, dtypes):
-    ops_dtypes = []
-    for ops in all_ops:
-        for dtype in dtypes:
-            if not (isinstance(ops, NumpyOps) and dtype == "float64"):
-                ops_dtypes.append((ops, dtype))
-    return ops_dtypes
-
-
 def create_pytorch_funcs():
     import torch
     import math
@@ -198,7 +189,8 @@ def test_seq2col_window_one_small(ops):
     assert_allclose(cols[3], [4.0, 5.0, 0.0])
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 @settings(max_examples=MAX_EXAMPLES, deadline=None)
 @given(X=strategies.arrays_BOP())
 def test_maxout(ops, dtype, X):
@@ -219,7 +211,8 @@ def test_maxout(ops, dtype, X):
     )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_backprop_maxout(ops, dtype):
     dX = ops.backprop_maxout(
         ops.asarray2f([[1.0, 2.0], [3.0, 4.0]], dtype=dtype),
@@ -251,7 +244,8 @@ def test_seq2col_window_one(ops, X):
     ops.xp.testing.assert_allclose(target, predicted, atol=0.001, rtol=0.001)
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_seq2col_lengths_all_zero(ops, dtype):
     # Empty batch
     ops.xp.testing.assert_allclose(
@@ -295,7 +289,8 @@ def test_seq2col_lengths_all_zero(ops, dtype):
     )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_seq2col_lengths_zero_first_last(ops, dtype):
     cols_check = ops.asarray2f(
         [
@@ -342,7 +337,8 @@ def test_seq2col_lengths_zero_first_last(ops, dtype):
     )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_seq2col_lengths_zero_between(ops, dtype):
     cols_check = ops.asarray2f(
         [
@@ -409,7 +405,8 @@ def test_seq2col_lengths_zero_between(ops, dtype):
     )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_seq2col_window_one_lengths(ops, dtype):
     X = ops.xp.arange(1.0, 16.0, dtype=dtype).reshape(5, 3)
     lengths = ops.asarray1i([1, 3, 1])
@@ -429,7 +426,8 @@ def test_seq2col_window_one_lengths(ops, dtype):
     )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_seq2col_window_two_lengths(ops, dtype):
     X = ops.xp.arange(1.0, 16.0, dtype=dtype).reshape(5, 3)
     lengths = ops.asarray1i([1, 3, 1])
@@ -449,7 +447,8 @@ def test_seq2col_window_two_lengths(ops, dtype):
     )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_backprop_seq2col_window_one_small(ops, dtype):
     cols = ops.asarray(
         [[0.0, 0.0, 0.0], [-1.0, 0.0, 1.0], [2.0, 0.0, 0.0]], dtype=dtype
@@ -461,7 +460,8 @@ def test_backprop_seq2col_window_one_small(ops, dtype):
     assert_allclose(seq, expected, atol=0.001, rtol=0.001)
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 @settings(max_examples=MAX_EXAMPLES, deadline=None)
 @given(X=strategies.arrays_BI())
 def test_backprop_seq2col_window_one(ops, dtype, X):
@@ -483,7 +483,8 @@ def test_backprop_seq2col_window_one(ops, dtype, X):
     ops.xp.testing.assert_allclose(target, predicted, atol=0.001, rtol=0.001)
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_backprop_seq2col_window_one_lengths(ops, dtype):
     d_y = ops.xp.arange(0.1, 4.6, step=0.1, dtype=dtype).reshape(5, 9)
     lengths = ops.asarray1i([1, 3, 1])
@@ -505,7 +506,8 @@ def test_backprop_seq2col_window_one_lengths(ops, dtype):
     )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_seq2col_window_two(ops, dtype):
     seq = ops.asarray([[1.0], [2.0], [3.0], [4]], dtype=dtype)
     cols = ops.seq2col(seq, 2)
@@ -517,7 +519,8 @@ def test_seq2col_window_two(ops, dtype):
     assert_allclose(cols[3], [2.0, 3.0, 4.0, 0.0, 0.0])
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_backprop_seq2col_window_two_lengths(ops, dtype):
     d_y = ops.xp.arange(0.1, 7.6, step=0.1, dtype=dtype).reshape(5, 15)
     lengths = ops.asarray1i([1, 3, 1])
@@ -538,7 +541,8 @@ def test_backprop_seq2col_window_two_lengths(ops, dtype):
     )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_backprop_seq2col_window_two(ops, dtype):
     cols = ops.asarray(
         [
@@ -613,7 +617,8 @@ def test_large_backprop_seq2col_gpu_against_cpu(nW):
     assert_allclose(d_seqs, d_seqs_gpu.get())
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 @settings(max_examples=MAX_EXAMPLES, deadline=None)
 @given(X=strategies.arrays_BI())
 def test_backprop_reduce_sum(ops, dtype, X):
@@ -725,8 +730,9 @@ def test_flatten_unflatten_roundtrip(cpu_ops, X):
 
 
 @pytest.mark.parametrize("ops", ALL_OPS)
-def test_reduce_sum(ops):
-    m = ops.xp.zeros((19, 5), dtype="f")
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
+def test_reduce_sum(ops, dtype):
+    m = ops.xp.zeros((19, 5), dtype=dtype)
     m += 1
     lengths = ops.xp.array([5, 5, 3, 6], dtype="i")
     output = ops.reduce_sum(m, lengths)
@@ -739,7 +745,8 @@ def test_reduce_sum(ops):
         ops.reduce_sum(m, ops.xp.array([-1, 10, 5, 5], dtype="i"))
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_backprop_fails_with_incorrect_length(ops, dtype):
     with pytest.raises(ValueError, match=r"lengths must be"):
         ops.backprop_reduce_sum(
@@ -748,7 +755,8 @@ def test_backprop_fails_with_incorrect_length(ops, dtype):
         )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_reduce_max_sm(ops, dtype):
     X = ops.xp.zeros((6, 3), dtype=dtype)
     X += ops.xp.random.uniform(-1, 1, X.shape)
@@ -762,7 +770,8 @@ def test_reduce_max_sm(ops, dtype):
         start += length
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_reduce_max(ops, dtype):
     m = ops.xp.zeros((19, 5), dtype=dtype)
     m += ops.xp.random.uniform(-1, 1, m.shape)
@@ -785,7 +794,8 @@ def test_reduce_max(ops, dtype):
         ops.reduce_max(m, ops.xp.array([-1, 10, 5, 5], dtype="i"))
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_backprop_reduce_max(ops, dtype):
     dX = ops.backprop_reduce_max(
         ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),
@@ -819,7 +829,8 @@ def test_backprop_reduce_max(ops, dtype):
         )
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_reduce_mean(ops, dtype):
     X = ops.asarray2f(
         [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2], [3.0, 4.0]], dtype=dtype
@@ -836,7 +847,8 @@ def test_reduce_mean(ops, dtype):
         ops.reduce_mean(X, ops.xp.array([-1, 5], dtype="i"))
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(ALL_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_backprop_reduce_mean(ops, dtype):
     dX = ops.backprop_reduce_mean(
         ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),
@@ -872,7 +884,8 @@ def test_mish(ops, X):
     assert not ops.xp.isnan(Y).any()
 
 
-@pytest.mark.parametrize("ops,dtype", ops_with_dtypes(XP_OPS, FLOAT_TYPES))
+@pytest.mark.parametrize("ops", XP_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES)
 @pytest.mark.parametrize(
     "op",
     [


### PR DESCRIPTION
This PR makes most CPU kernels generic, so that they can take both `float32` and `float64` arrays (and hopefully in the future `float16`). I experimented with kernels in Cython + fused types and kernels as C++ with templates, I found the C++ template route more promising:

- More compact/ergonomic implementations with fewer compile-time conditionals.
- Opens up the possibility to easily use SIMD intrinsics in the future.

To allow genericity in the `NumpyOps` method arguments, we use:

- Fused types when we require a specific dimensionality;
- `np.ndarray` otherwise.

Some of the kernels are not (yet) made generic:

- `cpu_scatter_add`: needs tests to verify that the op still works
  correctly.
- `cpu_position_encode`: the position_encode op doesn't take float
  array(s).
- lstm kernels: I need to look more deeply into them.