### PR TITLE
Removed unnecessary init method return statements

### DIFF
--- a/thinc/layers/add.py
+++ b/thinc/layers/add.py
@@ -51,7 +51,7 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         if model.has_dim("nI") is not False:
             model.set_dim("nI", get_width(X))
@@ -67,4 +67,3 @@ def init(
     for layer in model.layers:
         layer.initialize(X=X, Y=Y)
     model.set_dim("nO", model.layers[0].get_dim("nO"))
-    return model

--- a/thinc/layers/bidirectional.py
+++ b/thinc/layers/bidirectional.py
@@ -38,11 +38,10 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     (Y1, Y2) = _split(model.ops, Y) if Y is not None else (None, None)
     model.layers[0].initialize(X=X, Y=Y1)
     model.layers[1].initialize(X=X, Y=Y2)
-    return model
 
 
 def _reverse(ops: Ops, Xp: Padded) -> Padded:

--- a/thinc/layers/cauchysimilarity.py
+++ b/thinc/layers/cauchysimilarity.py
@@ -46,14 +46,13 @@ def forward(
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X[0]))
     # Initialize weights to 1
     W = model.ops.alloc1f(model.get_dim("nI"))
     W += 1
     model.set_param("W", W)
-    return model
 
 
 def inverse(total: OutT) -> Tuple[OutT, Callable]:

--- a/thinc/layers/chain.py
+++ b/thinc/layers/chain.py
@@ -66,7 +66,7 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     if X is None and Y is None:
         for layer in model.layers:
             layer.initialize()
@@ -74,7 +74,6 @@ def init(
             model.set_dim("nI", model.layers[0].get_dim("nI"))
         if model.layers[-1].has_dim("nO"):
             model.set_dim("nO", model.layers[-1].get_dim("nO"))
-        return model
 
     # Try to set nO on each layer, where available.
     # Shape inference is tricky, especially for the output. The policy is:
@@ -100,4 +99,3 @@ def init(
             else:
                 nO = None  # type: ignore
         model.set_dim("nO", nO)
-    return model

--- a/thinc/layers/clipped_linear.py
+++ b/thinc/layers/clipped_linear.py
@@ -76,14 +76,13 @@ def init(
     model: Model[Floats2d, Floats2d],
     X: Optional[Floats2d] = None,
     Y: Optional[Floats2d] = None,
-) -> Model[Floats2d, Floats2d]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model
 
 
 @registry.layers("HardSigmoid.v1")

--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -124,7 +124,7 @@ def _list_forward(model: Model[InT, List[Array2d]], X, Ys, callbacks, is_train: 
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         if model.has_dim("nI") is not False:
             model.set_dim("nI", get_width(X))
@@ -135,4 +135,3 @@ def init(
         layer.initialize(X=X, Y=Y)
     if all([layer.has_dim("nO") for layer in model.layers]):
         model.set_dim("nO", sum(layer.get_dim("nO") for layer in model.layers))
-    return model

--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -75,9 +75,8 @@ def init(
     model: Model[InT, OutT],
     X: Optional[Ints1d] = None,
     Y: Optional[OutT] = None,
-) -> Model[InT, OutT]:
+) -> None:
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     shape = (model.get_dim("nV"), model.get_dim("nO"))
     model.set_param("E", initializer(model.ops, shape))
-    return model

--- a/thinc/layers/gelu.py
+++ b/thinc/layers/gelu.py
@@ -56,11 +56,10 @@ def init(
     model: Model[Floats2d, Floats2d],
     X: Optional[Floats2d] = None,
     Y: Optional[Floats2d] = None,
-) -> Model[Floats2d, Floats2d]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model

--- a/thinc/layers/hard_swish.py
+++ b/thinc/layers/hard_swish.py
@@ -56,11 +56,10 @@ def init(
     model: Model[Floats2d, Floats2d],
     X: Optional[Floats2d] = None,
     Y: Optional[Floats2d] = None,
-) -> Model[Floats2d, Floats2d]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model

--- a/thinc/layers/hard_swish_mobilenet.py
+++ b/thinc/layers/hard_swish_mobilenet.py
@@ -58,11 +58,10 @@ def init(
     model: Model[Floats2d, Floats2d],
     X: Optional[Floats2d] = None,
     Y: Optional[Floats2d] = None,
-) -> Model[Floats2d, Floats2d]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -95,7 +95,6 @@ def init(
     model: Model[InT, OutT],
     X: Optional[Ints1d] = None,
     Y: Optional[OutT] = None,
-) -> Model[InT, OutT]:
+) -> None:
     E = initializer(model.ops, (model.get_dim("nV"), model.get_dim("nO")))
     model.set_param("E", E)
-    return model

--- a/thinc/layers/layernorm.py
+++ b/thinc/layers/layernorm.py
@@ -39,7 +39,7 @@ def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callab
 
 def init(
     model: Model[InT, InT], X: Optional[InT] = None, Y: Optional[InT] = None
-) -> Model[InT, InT]:
+) -> None:
     if X is not None:
         X_width = get_width(X)
         model.set_dim("nI", X_width)
@@ -54,7 +54,6 @@ def init(
     model.set_param("G", model.ops.alloc1f(nI) + 1)
     model.set_param("b", model.ops.alloc1f(nI))
     assert model.get_dim("nO") is not None
-    return model
 
 
 def _begin_update_scale_shift(model: Model[InT, InT], X: InT) -> Tuple[InT, Callable]:

--- a/thinc/layers/linear.py
+++ b/thinc/layers/linear.py
@@ -49,11 +49,10 @@ def init(
     model: Model[InT, OutT],
     X: Optional[InT] = None,
     Y: Optional[OutT] = None,
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model

--- a/thinc/layers/map_list.py
+++ b/thinc/layers/map_list.py
@@ -32,5 +32,5 @@ def init(
     model: Model[List[InT], List[OutT]],
     X: Optional[List[InT]] = None,
     Y: Optional[List[OutT]] = None,
-):
+) -> None:
     model.layers[0].initialize(X=X[0] if X else None, Y=Y[0] if Y else None)

--- a/thinc/layers/maxout.py
+++ b/thinc/layers/maxout.py
@@ -69,7 +69,7 @@ def init(
     model: Model[InT, OutT],
     X: Optional[InT] = None,
     Y: Optional[OutT] = None,
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
@@ -77,4 +77,3 @@ def init(
     W_shape = (model.get_dim("nO"), model.get_dim("nP"), model.get_dim("nI"))
     model.set_param("W", init_W(model.ops, W_shape))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"), model.get_dim("nP"))))
-    return model

--- a/thinc/layers/mish.py
+++ b/thinc/layers/mish.py
@@ -64,11 +64,10 @@ def init(
     model: Model[InT, OutT],
     X: Optional[InT] = None,
     Y: Optional[OutT] = None,
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model

--- a/thinc/layers/multisoftmax.py
+++ b/thinc/layers/multisoftmax.py
@@ -48,11 +48,10 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     nO = model.get_dim("nO")
     nI = model.get_dim("nI")
     model.set_param("W", model.ops.alloc2f(nO, nI))
     model.set_param("b", model.ops.alloc1f(nO))
-    return model

--- a/thinc/layers/parametricattention.py
+++ b/thinc/layers/parametricattention.py
@@ -33,14 +33,13 @@ def forward(model: Model[InT, OutT], Xr: InT, is_train: bool) -> Tuple[OutT, Cal
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-):
+) -> None:
     if X is not None:
         model.set_dim("nO", get_width(X))
     # Randomly initialize the parameter, as though it were an embedding.
     Q = model.ops.alloc1f(model.get_dim("nO"))
     Q += model.ops.xp.random.uniform(-0.1, 0.1, Q.shape)
     model.set_param("Q", Q)
-    return model
 
 
 def _get_attention(ops, Q, X, lengths):

--- a/thinc/layers/relu.py
+++ b/thinc/layers/relu.py
@@ -59,11 +59,10 @@ def init(
     model: Model[InT, OutT],
     X: Optional[InT] = None,
     Y: Optional[OutT] = None,
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model

--- a/thinc/layers/residual.py
+++ b/thinc/layers/residual.py
@@ -51,7 +51,7 @@ def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callab
 
 def init(
     model: Model[InT, InT], X: Optional[InT] = None, Y: Optional[InT] = None
-) -> Model[InT, InT]:
+) -> None:
     first_layer = model.layers[0]
     if first_layer.has_dim("nO") is None:
         first_layer.initialize(X=X, Y=Y)
@@ -61,4 +61,3 @@ def init(
         model.set_dim("nO", first_layer.get_dim("nO"))
     if first_layer.has_dim("nI"):
         model.set_dim("nI", first_layer.get_dim("nI"))
-    return model

--- a/thinc/layers/resizable.py
+++ b/thinc/layers/resizable.py
@@ -34,10 +34,9 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool):
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     layer = model.layers[0]
     layer.initialize(X, Y)
-    return model
 
 
 def resize_model(model: Model[InT, OutT], new_nO):

--- a/thinc/layers/siamese.py
+++ b/thinc/layers/siamese.py
@@ -44,7 +44,7 @@ def forward(
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None:
         model.layers[0].set_dim("nI", get_width(X[1]))
         model.layers[0].initialize(X=X[0])
@@ -52,4 +52,3 @@ def init(
     model.layers[1].initialize(X=X, Y=Y)
     model.set_dim("nI", model.layers[0].get_dim("nI"))
     model.set_dim("nO", model.layers[1].get_dim("nO"))
-    return model

--- a/thinc/layers/sigmoid.py
+++ b/thinc/layers/sigmoid.py
@@ -53,11 +53,10 @@ def init(
     model: Model[InT, OutT],
     X: Optional[InT] = None,
     Y: Optional[OutT] = None,
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None and model.has_dim("nI") is None:
         model.set_dim("nI", get_width(X))
     if Y is not None and model.has_dim("nO") is None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model

--- a/thinc/layers/softmax.py
+++ b/thinc/layers/softmax.py
@@ -93,14 +93,13 @@ def init(
     model: Model[InT, OutT],
     X: Optional[InT] = None,
     Y: Optional[OutT] = None,
-) -> Model[InT, OutT]:
+) -> None:
     if X is not None and model.has_dim("nI") is None:
         model.set_dim("nI", get_width(X))
     if Y is not None and model.has_dim("nO") is None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model
 
 
 def validate_temperature(temperature):

--- a/thinc/layers/swish.py
+++ b/thinc/layers/swish.py
@@ -56,11 +56,10 @@ def init(
     model: Model[Floats2d, Floats2d],
     X: Optional[Floats2d] = None,
     Y: Optional[Floats2d] = None,
-) -> Model[Floats2d, Floats2d]:
+) -> None:
     if X is not None:
         model.set_dim("nI", get_width(X))
     if Y is not None:
         model.set_dim("nO", get_width(Y))
     model.set_param("W", init_W(model.ops, (model.get_dim("nO"), model.get_dim("nI"))))
     model.set_param("b", init_b(model.ops, (model.get_dim("nO"),)))
-    return model

--- a/thinc/layers/tuplify.py
+++ b/thinc/layers/tuplify.py
@@ -48,13 +48,12 @@ def tuplify_forward(model, X, is_train):
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     if X is None and Y is None:
         for layer in model.layers:
             layer.initialize()
         if model.layers[0].has_dim("nI"):
             model.set_dim("nI", model.layers[0].get_dim("nI"))
-        return model
 
     # Try to set nO on each layer, where available.
     # All layers have the same input, and the output should map directly from the
@@ -68,4 +67,3 @@ def init(
     if model.layers[0].has_dim("nI"):
         model.set_dim("nI", model.layers[0].get_dim("nI"))
     # this model can have an input dimension, but can't have an output dimension
-    return model

--- a/thinc/layers/uniqued.py
+++ b/thinc/layers/uniqued.py
@@ -56,11 +56,10 @@ def forward(model: Model[InT, OutT], X: InT, is_train: bool) -> Tuple[OutT, Call
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     layer = model.layers[0]
     layer.initialize(X=X, Y=Y)
     if layer.has_dim("nI"):
         model.set_dim("nI", layer.get_dim("nI"))  # pragma: no cover
     if layer.has_dim("nO"):
         model.set_dim("nO", layer.get_dim("nO"))
-    return model

--- a/thinc/layers/with_array.py
+++ b/thinc/layers/with_array.py
@@ -42,7 +42,7 @@ def forward(model: Model[SeqT, SeqT], Xseq: SeqT, is_train: bool):
 
 def init(
     model: Model[SeqT, SeqT], X: Optional[SeqT] = None, Y: Optional[SeqT] = None
-) -> Model[SeqT, SeqT]:
+) -> None:
     layer: Model[ArrayXd, ArrayXd] = model.layers[0]
     layer.initialize(
         X=_get_array(model, X) if X is not None else X,
@@ -52,7 +52,6 @@ def init(
         value = layer.maybe_get_dim(dim_name)
         if value is not None:
             model.set_dim(dim_name, value)
-    return model
 
 
 def _get_array(model, X: SeqT) -> ArrayXd:

--- a/thinc/layers/with_array2d.py
+++ b/thinc/layers/with_array2d.py
@@ -43,7 +43,7 @@ def forward(model: Model[SeqT, SeqT], Xseq: SeqT, is_train: bool):
 
 def init(
     model: Model[SeqT, SeqT], X: Optional[SeqT] = None, Y: Optional[SeqT] = None
-) -> Model[SeqT, SeqT]:
+) -> None:
     layer: Model[Array2d, Array2d] = model.layers[0]
     layer.initialize(
         X=_get_array(model, X) if X is not None else X,
@@ -53,7 +53,6 @@ def init(
         value = layer.maybe_get_dim(dim_name)
         if value is not None:
             model.set_dim(dim_name, value)
-    return model
 
 
 def _get_array(model, X: SeqT) -> Array2d:

--- a/thinc/layers/with_cpu.py
+++ b/thinc/layers/with_cpu.py
@@ -31,8 +31,8 @@ def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
     return gpu_outputs, with_cpu_backprop
 
 
-def init(model: Model, X: Any, Y: Any) -> Model:
-    return model.layers[0].initialize(X, Y)
+def init(model: Model, X: Any, Y: Any) -> None:
+    model.layers[0].initialize(X, Y)
 
 
 def _to_cpu(X):

--- a/thinc/layers/with_debug.py
+++ b/thinc/layers/with_debug.py
@@ -34,12 +34,10 @@ def with_debug(
 
         return layer_Y, backprop
 
-    def init(model: Model, X: Any, Y: Any) -> Model:
+    def init(model: Model, X: Any, Y: Any) -> None:
         on_init(model, X, Y)
         if orig_init is not None:
-            return orig_init(layer, X, Y)
-        else:
-            return layer
+            orig_init(layer, X, Y)
 
     layer.replace_callbacks(forward, init=init)
 

--- a/thinc/layers/with_flatten.py
+++ b/thinc/layers/with_flatten.py
@@ -43,7 +43,7 @@ def _flatten(nested: InT) -> List[ItemT]:
     return flat
 
 
-def init(model, X=None, Y=None):
+def init(model, X=None, Y=None) -> None:
     model.layers[0].initialize(
         _flatten(X) if X is not None else None,
         model.layers[0].ops.xp.hstack(Y) if Y is not None else None,

--- a/thinc/layers/with_getitem.py
+++ b/thinc/layers/with_getitem.py
@@ -37,9 +37,8 @@ def forward(
 
 def init(
     model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
-) -> Model[InT, OutT]:
+) -> None:
     idx = model.attrs["idx"]
     X_i = X[idx] if X is not None else X
     Y_i = Y[idx] if Y is not None else Y
     model.layers[0].initialize(X=X_i, Y=Y_i)
-    return model

--- a/thinc/layers/with_list.py
+++ b/thinc/layers/with_list.py
@@ -35,12 +35,11 @@ def forward(
 
 def init(
     model: Model[SeqT, SeqT], X: Optional[SeqT] = None, Y: Optional[SeqT] = None
-) -> Model[SeqT, SeqT]:
+) -> None:
     model.layers[0].initialize(
         X=_get_list(model, X) if X is not None else None,
         Y=_get_list(model, Y) if Y is not None else None,
     )
-    return model
 
 
 def _get_list(model, seq):

--- a/thinc/layers/with_padded.py
+++ b/thinc/layers/with_padded.py
@@ -41,12 +41,11 @@ def forward(
 
 def init(
     model: Model[SeqT, SeqT], X: Optional[SeqT] = None, Y: Optional[SeqT] = None
-) -> Model[SeqT, SeqT]:
+) -> None:
     model.layers[0].initialize(
         X=_get_padded(model, X) if X is not None else None,
         Y=_get_padded(model, Y) if Y is not None else None,
     )
-    return model
 
 
 def _is_padded_data(seq):

--- a/thinc/layers/with_ragged.py
+++ b/thinc/layers/with_ragged.py
@@ -32,12 +32,12 @@ def forward(
 
 def init(
     model: Model[SeqT, SeqT], X: Optional[SeqT] = None, Y: Optional[SeqT] = None
-) -> Model[SeqT, SeqT]:
+) -> None:
     model.layers[0].initialize(
         X=_get_ragged(model, X) if X is not None else None,
         Y=_get_ragged(model, Y) if Y is not None else None,
     )
-    return model
+
 
 
 def _is_ragged_data(seq):

--- a/thinc/layers/with_reshape.py
+++ b/thinc/layers/with_reshape.py
@@ -40,11 +40,10 @@ def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callab
 
 def init(
     model: Model[InT, InT], X: Optional[Array3d] = None, Y: Optional[Array3d] = None
-) -> Model[InT, InT]:
+) -> None:
     layer = model.layers[0]
     if X is None and Y is None:
         layer.initialize()
-        return model
     X2d: Optional[Array2d] = None
     Y2d: Optional[Array2d] = None
     if X is not None:
@@ -56,4 +55,3 @@ def init(
         model.set_dim("nI", layer.get_dim("nI"))
     if layer.has_dim("nO"):
         model.set_dim("nO", layer.get_dim("nO"))
-    return model


### PR DESCRIPTION
Many layers return the initialized model from their `init()` methods, although the [documentation of the superclass method](https://thinc.ai/docs/api-model#init) does not include a return type and the returned model is not used anywhere when `initialize()` is called. Returning the models hence entails unnecessary code that in a couple of layers is also more involved than simply a `return model` at the end of the method, and is liable to lead to confusion about how model initialization works.

I've removed the return statements consistently across all layers.