### PR TITLE
Reduce unnecessary zero-init'd allocations

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -533,7 +533,7 @@ def backprop_reduce_sum(d_sums, lengths, *, threads_per_block=128, num_blocks=12
     O = d_sums.shape[1]
     _check_lengths(lengths, T)
 
-    out = _alloc((T, O), dtype=d_sums.dtype, zeros=True)
+    out = _alloc((T, O), dtype=d_sums.dtype, zeros=False)
 
     if d_sums.dtype == "float32":
         backprop_reduce_sum_kernel_float(
@@ -555,7 +555,7 @@ def backprop_reduce_mean(d_means, lengths, *, threads_per_block=128, num_blocks=
     O = d_means.shape[1]
     _check_lengths(lengths, T)
 
-    out = _alloc((T, O), dtype=d_means.dtype, zeros=True)
+    out = _alloc((T, O), dtype=d_means.dtype, zeros=False)
 
     if d_means.dtype == "float32":
         backprop_reduce_mean_kernel_float(

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -204,7 +204,7 @@ def seq2col(seq, nW, *, lengths=None, threads_per_block=128, num_blocks=128):
     lengths = check_seq2col_lengths(lengths, B)
     nL = lengths.shape[0]
 
-    out = _alloc((B, I * nF), dtype=seq.dtype)
+    out = _alloc((B, I * nF), dtype=seq.dtype, zeros=True)
 
     if seq.size != 0 and lengths.size != 0:
         if seq.dtype == "float32":
@@ -268,7 +268,7 @@ def reduce_sum(X, lengths, *, threads_per_block=128, num_blocks=128):
 
     _check_lengths(lengths, T)
 
-    out = _alloc((B, O), dtype=X.dtype)
+    out = _alloc((B, O), dtype=X.dtype, zeros=True)
 
     if X.dtype == "float32":
         reduce_sum_kernel_float(
@@ -291,7 +291,7 @@ def reduce_mean(X, lengths, *, threads_per_block=128, num_blocks=128):
 
     _check_lengths(lengths, T)
 
-    out = _alloc((B, O), dtype=X.dtype)
+    out = _alloc((B, O), dtype=X.dtype, zeros=True)
 
     if X.dtype == "float32":
         reduce_sum_kernel_float(
@@ -359,7 +359,7 @@ def backprop_seq2col(dY, nW, *, lengths=None, threads_per_block=128, num_blocks=
     lengths = check_seq2col_lengths(lengths, B)
     nL = lengths.shape[0]
 
-    out = _alloc((B, I), dtype=dY.dtype)
+    out = _alloc((B, I), dtype=dY.dtype, zeros=True)
 
     if dY.size != 0 and lengths.size != 0:
         if dY.dtype == "float32":
@@ -487,7 +487,7 @@ def backprop_maxout(dY, which, P, *, threads_per_block=128, num_blocks=128):
     B = dY.shape[0]
     I = dY.shape[1]
 
-    out = _alloc((B, I, P), dtype=dY.dtype)
+    out = _alloc((B, I, P), dtype=dY.dtype, zeros=True)
 
     _check_which_maxout(which, B, I, P)
 
@@ -533,7 +533,7 @@ def backprop_reduce_sum(d_sums, lengths, *, threads_per_block=128, num_blocks=12
     O = d_sums.shape[1]
     _check_lengths(lengths, T)
 
-    out = _alloc((T, O), dtype=d_sums.dtype)
+    out = _alloc((T, O), dtype=d_sums.dtype, zeros=True)
 
     if d_sums.dtype == "float32":
         backprop_reduce_sum_kernel_float(
@@ -555,7 +555,7 @@ def backprop_reduce_mean(d_means, lengths, *, threads_per_block=128, num_blocks=
     O = d_means.shape[1]
     _check_lengths(lengths, T)
 
-    out = _alloc((T, O), dtype=d_means.dtype)
+    out = _alloc((T, O), dtype=d_means.dtype, zeros=True)
 
     if d_means.dtype == "float32":
         backprop_reduce_mean_kernel_float(
@@ -579,7 +579,7 @@ def backprop_reduce_max(
     O = d_maxes.shape[1]
     _check_lengths(lengths, T)
 
-    out = _alloc((T, O), dtype=d_maxes.dtype)
+    out = _alloc((T, O), dtype=d_maxes.dtype, zeros=True)
 
     _check_which_reduce_max(which, (B, O), lengths)
 
@@ -619,7 +619,7 @@ def backprop_swish(
 
 
 def hash(ids, seed, *, threads_per_block=128, num_blocks=128):
-    out = _alloc((ids.shape[0], 4), dtype="uint32")
+    out = _alloc((ids.shape[0], 4), dtype="uint32", zeros=True)
 
     # sizeof(uint32_t) * 4
     out_size = 4 * 4

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -139,7 +139,7 @@ def clipped_linear(
 
     out = X
     if not inplace:
-        out = cupy.zeros_like(X)
+        out = cupy.empty_like(X)
     if X.dtype == "float32":
         clipped_linear_kernel_float(
             (num_blocks,),
@@ -160,7 +160,7 @@ def gelu(X, *, inplace=False, threshold=6.0, threads_per_block=128, num_blocks=1
 
     out = X
     if not inplace:
-        out = cupy.zeros_like(X)
+        out = cupy.empty_like(X)
     if X.dtype == "float32":
         gelu_kernel_float(
             (num_blocks,), (threads_per_block,), (out, X, threshold, X.size)
@@ -211,8 +211,8 @@ def maxout(X, *, threads_per_block=128, num_blocks=128):
     B, I, P = X.shape
 
     out_shape = (B, I)
-    best = cupy.zeros(out_shape, dtype=X.dtype)
-    which = cupy.zeros(out_shape, dtype="i")
+    best = cupy.empty(out_shape, dtype=X.dtype)
+    which = cupy.empty(out_shape, dtype="i")
 
     if X.dtype == "float32":
         maxout_kernel_float(
@@ -231,7 +231,7 @@ def mish(X, *, inplace=False, threshold=5, threads_per_block=128, num_blocks=128
 
     out = X
     if not inplace:
-        out = cupy.zeros_like(X)
+        out = cupy.empty_like(X)
 
     if X.dtype == "float32":
         mish_kernel_float(
@@ -303,8 +303,8 @@ def reduce_max(X, lengths, *, threads_per_block=128, num_blocks=128):
     _check_lengths(lengths, T)
 
     out_shape = (B, O)
-    maxes = cupy.zeros(out_shape, dtype=X.dtype)
-    which = cupy.zeros(out_shape, dtype="i")
+    maxes = cupy.empty(out_shape, dtype=X.dtype)
+    which = cupy.empty(out_shape, dtype="i")
 
     if X.dtype == "float32":
         reduce_max_kernel_float(
@@ -323,7 +323,7 @@ def swish(X, *, inplace=False, threshold=17.0, threads_per_block=128, num_blocks
 
     out = X
     if not inplace:
-        out = cupy.zeros_like(X)
+        out = cupy.empty_like(X)
     if X.dtype == "float32":
         swish_kernel_float(
             (num_blocks,), (threads_per_block,), (out, X, threshold, X.size)
@@ -377,7 +377,7 @@ def backprop_clipped_linear(
 
     out = dY
     if not inplace:
-        out = cupy.zeros_like(dY)
+        out = cupy.empty_like(dY)
 
     if dY.dtype == "float32":
         backprop_clipped_linear_kernel_float(
@@ -403,7 +403,7 @@ def backprop_hard_swish(
 
     out = dY
     if not inplace:
-        out = cupy.zeros_like(dY)
+        out = cupy.empty_like(dY)
 
     if dY.dtype == "float32":
         backprop_hard_swish_kernel_float(
@@ -425,7 +425,7 @@ def backprop_hard_swish_mobilenet(
 
     out = dY
     if not inplace:
-        out = cupy.zeros_like(dY)
+        out = cupy.empty_like(dY)
 
     if dY.dtype == "float32":
         backprop_hard_swish_mobilenet_kernel_float(
@@ -453,7 +453,7 @@ def backprop_gelu(
 
     out = dY
     if not inplace:
-        out = cupy.zeros_like(dY)
+        out = cupy.empty_like(dY)
 
     if dY.dtype == "float32":
         backprop_gelu_kernel_float(
@@ -497,7 +497,7 @@ def backprop_mish(
 
     out = dY
     if not inplace:
-        out = cupy.zeros_like(dY)
+        out = cupy.empty_like(dY)
 
     if dY.dtype == "float32":
         backprop_mish_kernel_float(
@@ -590,7 +590,7 @@ def backprop_swish(
 
     out = dY
     if not inplace:
-        out = cupy.zeros_like(dY)
+        out = cupy.empty_like(dY)
 
     if dY.dtype == "float32":
         backprop_swish_kernel_float(

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -162,14 +162,14 @@ class NumpyOps(Ops):
         cdef int P = X.shape[2]
 
         cdef np.ndarray best
-        cdef np.ndarray which = numpy.empty(shape=(B, O), dtype='int32', order='C')
+        cdef np.ndarray which = self.alloc(shape=(B, O), dtype='int32', uninitialized=True)
         if reals3d_ft is float3d_t:
-            best = numpy.empty(shape=(B, O), dtype="float32", order='C')
+            best = self.alloc(shape=(B, O), dtype="float32", uninitialized=True)
             if len(X) > 0:
                 cpu_maxout(<float*>best.data, <int*>which.data,
                     &X[0, 0, 0], B, O, P)
         else:
-            best = numpy.empty(shape=(B, O), dtype="float64", order='C')
+            best = self.alloc(shape=(B, O), dtype="float64", uninitialized=True)
             if len(X) > 0:
                 cpu_maxout(<double*>best.data, <int*>which.data,
                     &X[0, 0, 0], B, O, P)
@@ -396,12 +396,12 @@ class NumpyOps(Ops):
         assert O != 0
 
         cdef np.ndarray maxes
-        cdef np.ndarray which = numpy.zeros(shape=(B, O), dtype="i")
+        cdef np.ndarray which = self.alloc(shape=(B, O), dtype="i", uninitialized=True)
         if reals2d_ft is float2d_t:
-            maxes = numpy.zeros(shape=(B, O), dtype="float32")
+            maxes = self.alloc(shape=(B, O), dtype="float32", uninitialized=True)
             cpu_reduce_max(<float*>maxes.data, <int*>which.data, &X[0, 0], &lengths[0], B, T, O)
         else:
-            maxes = numpy.zeros(shape=(B, O), dtype="float64")
+            maxes = self.alloc(shape=(B, O), dtype="float64", uninitialized=True)
             cpu_reduce_max(<double*>maxes.data, <int*>which.data, &X[0, 0], &lengths[0], B, T, O)
 
         return maxes, which

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -911,10 +911,10 @@ class Ops:
         if inplace:
             X *= tmp
             return X
-        Y = self.xp.zeros_like(X)
-        Y += tmp
-        Y *= X
-        return cast(FloatsType, Y)
+        else:
+            Y = self.xp.array(X)
+            Y *= tmp
+            return cast(FloatsType, Y)
 
     def backprop_gelu_approx(
         self, dY: FloatsType, X: FloatsType, inplace: bool = False

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -382,18 +382,35 @@ class Ops:
         mask = (coinflips >= drop) / (1.0 - drop)
         return cast(FloatsXd, self.asarray(mask, dtype="float32"))
 
-    def alloc1f(self, d0: int, *, dtype: Optional[DTypesFloat] = "float32") -> Floats1d:
-        return self.alloc((d0,), dtype=dtype)
+    def alloc1f(
+        self,
+        d0: int,
+        *,
+        dtype: Optional[DTypesFloat] = "float32",
+        uninitialized: bool = False,
+    ) -> Floats1d:
+        return self.alloc((d0,), dtype=dtype, uninitialized=uninitialized)
 
     def alloc2f(
-        self, d0: int, d1: int, *, dtype: Optional[DTypesFloat] = "float32"
+        self,
+        d0: int,
+        d1: int,
+        *,
+        dtype: Optional[DTypesFloat] = "float32",
+        uninitialized: bool = False,
     ) -> Floats2d:
-        return self.alloc((d0, d1), dtype=dtype)
+        return self.alloc((d0, d1), dtype=dtype, uninitialized=uninitialized)
 
     def alloc3f(
-        self, d0: int, d1: int, d2: int, *, dtype: Optional[DTypesFloat] = "float32"
+        self,
+        d0: int,
+        d1: int,
+        d2: int,
+        *,
+        dtype: Optional[DTypesFloat] = "float32",
+        uninitialized: bool = False,
     ) -> Floats3d:
-        return self.alloc((d0, d1, d2), dtype=dtype)
+        return self.alloc((d0, d1, d2), dtype=dtype, uninitialized=uninitialized)
 
     def alloc4f(
         self,
@@ -403,26 +420,48 @@ class Ops:
         d3: int,
         *,
         dtype: Optional[DTypesFloat] = "float32",
+        uninitialized: bool = False,
     ) -> Floats4d:
-        return self.alloc((d0, d1, d2, d3), dtype=dtype)
+        return self.alloc((d0, d1, d2, d3), dtype=dtype, uninitialized=uninitialized)
 
     def alloc_f(
-        self, shape: Shape, *, dtype: Optional[DTypesFloat] = "float32"
+        self,
+        shape: Shape,
+        *,
+        dtype: Optional[DTypesFloat] = "float32",
+        uninitialized: bool = False,
     ) -> FloatsXd:
-        return self.alloc(shape, dtype=dtype)
+        return self.alloc(shape, dtype=dtype, uninitialized=uninitialized)
 
-    def alloc1i(self, d0: int, *, dtype: Optional[DTypesInt] = "int32") -> Ints1d:
-        return self.alloc((d0,), dtype=dtype)
+    def alloc1i(
+        self,
+        d0: int,
+        *,
+        dtype: Optional[DTypesInt] = "int32",
+        uninitialized: bool = False,
+    ) -> Ints1d:
+        return self.alloc((d0,), dtype=dtype, uninitialized=uninitialized)
 
     def alloc2i(
-        self, d0: int, d1: int, *, dtype: Optional[DTypesInt] = "int32"
+        self,
+        d0: int,
+        d1: int,
+        *,
+        dtype: Optional[DTypesInt] = "int32",
+        uninitialized: bool = False,
     ) -> Ints2d:
-        return self.alloc((d0, d1), dtype=dtype)
+        return self.alloc((d0, d1), dtype=dtype, uninitialized=uninitialized)
 
     def alloc3i(
-        self, d0: int, d1: int, d2: int, *, dtype: Optional[DTypesInt] = "int32"
+        self,
+        d0: int,
+        d1: int,
+        d2: int,
+        *,
+        dtype: Optional[DTypesInt] = "int32",
+        uninitialized: bool = False,
     ) -> Ints3d:
-        return self.alloc((d0, d1, d2), dtype=dtype)
+        return self.alloc((d0, d1, d2), dtype=dtype, uninitialized=uninitialized)
 
     def alloc4i(
         self,
@@ -432,17 +471,34 @@ class Ops:
         d3: int,
         *,
         dtype: Optional[DTypesInt] = "int32",
+        uninitialized: bool = False,
     ) -> Ints4d:
-        return self.alloc((d0, d1, d2, d3), dtype=dtype)
+        return self.alloc((d0, d1, d2, d3), dtype=dtype, uninitialized=uninitialized)
 
-    def alloc_i(self, shape: Shape, *, dtype: Optional[DTypesInt] = "int32") -> IntsXd:
-        return self.alloc(shape, dtype=dtype)
+    def alloc_i(
+        self,
+        shape: Shape,
+        *,
+        dtype: Optional[DTypesInt] = "int32",
+        uninitialized: bool = False,
+    ) -> IntsXd:
+        return self.alloc(shape, dtype=dtype, uninitialized=uninitialized)
 
-    def alloc(self, shape: Shape, *, dtype: Optional[DTypes] = "float32") -> ArrayT:
+    def alloc(
+        self,
+        shape: Shape,
+        *,
+        dtype: Optional[DTypes] = "float32",
+        uninitialized: bool = False,
+    ) -> ArrayT:
         """Allocate an array of a certain shape."""
         if isinstance(shape, int):
             shape = (shape,)
-        return self.xp.zeros(shape, dtype=dtype)
+
+        if uninitialized:
+            return self.xp.empty(shape, dtype=dtype)
+        else:
+            return self.xp.zeros(shape, dtype=dtype)
 
     def reshape1f(self, array: FloatsXd, d0: int) -> Floats1d:
         return cast(Floats1d, self.reshape(array, (d0,)))
@@ -982,7 +1038,7 @@ class Ops:
         return -loss
 
     def reduce_sum(self, X: Floats2d, lengths: Ints1d) -> Floats2d:
-        Y = self.alloc2f(lengths.shape[0], X.shape[1])
+        Y = self.alloc2f(lengths.shape[0], X.shape[1], uninitialized=True)
         start = 0
         for i, length in enumerate(lengths):
             if length < 0:
@@ -995,7 +1051,7 @@ class Ops:
         return Y
 
     def reduce_mean(self, X: Floats2d, lengths: Ints1d) -> Floats2d:
-        Y = self.alloc2f(lengths.shape[0], X.shape[1])
+        Y = self.alloc2f(lengths.shape[0], X.shape[1], uninitialized=True)
         start = 0
         for i, length in enumerate(lengths):
             if length < 0:
@@ -1008,8 +1064,10 @@ class Ops:
         return Y
 
     def reduce_max(self, X: Floats2d, lengths: Ints1d) -> Tuple[Floats2d, Ints2d]:
-        Y = self.alloc2f(lengths.shape[0], X.shape[1], dtype=X.dtype)
-        which = self.alloc2i(lengths.shape[0], X.shape[1])
+        Y = self.alloc2f(
+            lengths.shape[0], X.shape[1], dtype=X.dtype, uninitialized=True
+        )
+        which = self.alloc2i(lengths.shape[0], X.shape[1], uninitialized=True)
         start = 0
         for i, length in enumerate(lengths):
             if length < 0:
@@ -1023,7 +1081,9 @@ class Ops:
         return Y, which
 
     def backprop_reduce_sum(self, d_sums: Floats2d, lengths: Ints1d) -> Floats2d:
-        dX = self.alloc2f(lengths.sum(), d_sums.shape[1], dtype=d_sums.dtype)
+        dX = self.alloc2f(
+            lengths.sum(), d_sums.shape[1], dtype=d_sums.dtype, uninitialized=True
+        )
         start = 0
         for i, length in enumerate(lengths):
             if length < 0:
@@ -1033,7 +1093,9 @@ class Ops:
         return dX
 
     def backprop_reduce_mean(self, d_means: Floats2d, lengths: Ints1d) -> Floats2d:
-        dX = self.alloc2f(lengths.sum(), d_means.shape[1], dtype=d_means.dtype)
+        dX = self.alloc2f(
+            lengths.sum(), d_means.shape[1], dtype=d_means.dtype, uninitialized=True
+        )
         start = 0
         for i, length in enumerate(lengths):
             if length < 0:

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -387,9 +387,9 @@ class Ops:
         d0: int,
         *,
         dtype: Optional[DTypesFloat] = "float32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> Floats1d:
-        return self.alloc((d0,), dtype=dtype, uninitialized=uninitialized)
+        return self.alloc((d0,), dtype=dtype, zeros=zeros)
 
     def alloc2f(
         self,
@@ -397,9 +397,9 @@ class Ops:
         d1: int,
         *,
         dtype: Optional[DTypesFloat] = "float32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> Floats2d:
-        return self.alloc((d0, d1), dtype=dtype, uninitialized=uninitialized)
+        return self.alloc((d0, d1), dtype=dtype, zeros=zeros)
 
     def alloc3f(
         self,
@@ -408,9 +408,9 @@ class Ops:
         d2: int,
         *,
         dtype: Optional[DTypesFloat] = "float32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> Floats3d:
-        return self.alloc((d0, d1, d2), dtype=dtype, uninitialized=uninitialized)
+        return self.alloc((d0, d1, d2), dtype=dtype, zeros=zeros)
 
     def alloc4f(
         self,
@@ -420,27 +420,27 @@ class Ops:
         d3: int,
         *,
         dtype: Optional[DTypesFloat] = "float32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> Floats4d:
-        return self.alloc((d0, d1, d2, d3), dtype=dtype, uninitialized=uninitialized)
+        return self.alloc((d0, d1, d2, d3), dtype=dtype, zeros=zeros)
 
     def alloc_f(
         self,
         shape: Shape,
         *,
         dtype: Optional[DTypesFloat] = "float32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> FloatsXd:
-        return self.alloc(shape, dtype=dtype, uninitialized=uninitialized)
+        return self.alloc(shape, dtype=dtype, zeros=zeros)
 
     def alloc1i(
         self,
         d0: int,
         *,
         dtype: Optional[DTypesInt] = "int32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> Ints1d:
-        return self.alloc((d0,), dtype=dtype, uninitialized=uninitialized)
+        return self.alloc((d0,), dtype=dtype, zeros=zeros)
 
     def alloc2i(
         self,
@@ -448,9 +448,9 @@ class Ops:
         d1: int,
         *,
         dtype: Optional[DTypesInt] = "int32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> Ints2d:
-        return self.alloc((d0, d1), dtype=dtype, uninitialized=uninitialized)
+        return self.alloc((d0, d1), dtype=dtype, zeros=zeros)
 
     def alloc3i(
         self,
@@ -459,9 +459,9 @@ class Ops:
         d2: int,
         *,
         dtype: Optional[DTypesInt] = "int32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> Ints3d:
-        return self.alloc((d0, d1, d2), dtype=dtype, uninitialized=uninitialized)
+        return self.alloc((d0, d1, d2), dtype=dtype, zeros=zeros)
 
     def alloc4i(
         self,
@@ -471,34 +471,34 @@ class Ops:
         d3: int,
         *,
         dtype: Optional[DTypesInt] = "int32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> Ints4d:
-        return self.alloc((d0, d1, d2, d3), dtype=dtype, uninitialized=uninitialized)
+        return self.alloc((d0, d1, d2, d3), dtype=dtype, zeros=zeros)
 
     def alloc_i(
         self,
         shape: Shape,
         *,
         dtype: Optional[DTypesInt] = "int32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> IntsXd:
-        return self.alloc(shape, dtype=dtype, uninitialized=uninitialized)
+        return self.alloc(shape, dtype=dtype, zeros=zeros)
 
     def alloc(
         self,
         shape: Shape,
         *,
         dtype: Optional[DTypes] = "float32",
-        uninitialized: bool = False,
+        zeros: bool = True,
     ) -> ArrayT:
         """Allocate an array of a certain shape."""
         if isinstance(shape, int):
             shape = (shape,)
 
-        if uninitialized:
-            return self.xp.empty(shape, dtype=dtype)
-        else:
+        if zeros:
             return self.xp.zeros(shape, dtype=dtype)
+        else:
+            return self.xp.empty(shape, dtype=dtype)
 
     def reshape1f(self, array: FloatsXd, d0: int) -> Floats1d:
         return cast(Floats1d, self.reshape(array, (d0,)))
@@ -1038,7 +1038,7 @@ class Ops:
         return -loss
 
     def reduce_sum(self, X: Floats2d, lengths: Ints1d) -> Floats2d:
-        Y = self.alloc2f(lengths.shape[0], X.shape[1], uninitialized=True)
+        Y = self.alloc2f(lengths.shape[0], X.shape[1], zeros=False)
         start = 0
         for i, length in enumerate(lengths):
             if length < 0:
@@ -1051,7 +1051,7 @@ class Ops:
         return Y
 
     def reduce_mean(self, X: Floats2d, lengths: Ints1d) -> Floats2d:
-        Y = self.alloc2f(lengths.shape[0], X.shape[1], uninitialized=True)
+        Y = self.alloc2f(lengths.shape[0], X.shape[1], zeros=False)
         start = 0
         for i, length in enumerate(lengths):
             if length < 0:
@@ -1064,10 +1064,8 @@ class Ops:
         return Y
 
     def reduce_max(self, X: Floats2d, lengths: Ints1d) -> Tuple[Floats2d, Ints2d]:
-        Y = self.alloc2f(
-            lengths.shape[0], X.shape[1], dtype=X.dtype, uninitialized=True
-        )
-        which = self.alloc2i(lengths.shape[0], X.shape[1], uninitialized=True)
+        Y = self.alloc2f(lengths.shape[0], X.shape[1], dtype=X.dtype, zeros=False)
+        which = self.alloc2i(lengths.shape[0], X.shape[1], zeros=False)
         start = 0
         for i, length in enumerate(lengths):
             if length < 0:
@@ -1082,7 +1080,7 @@ class Ops:
 
     def backprop_reduce_sum(self, d_sums: Floats2d, lengths: Ints1d) -> Floats2d:
         dX = self.alloc2f(
-            lengths.sum(), d_sums.shape[1], dtype=d_sums.dtype, uninitialized=True
+            lengths.sum(), d_sums.shape[1], dtype=d_sums.dtype, zeros=False
         )
         start = 0
         for i, length in enumerate(lengths):
@@ -1094,7 +1092,7 @@ class Ops:
 
     def backprop_reduce_mean(self, d_means: Floats2d, lengths: Ints1d) -> Floats2d:
         dX = self.alloc2f(
-            lengths.sum(), d_means.shape[1], dtype=d_means.dtype, uninitialized=True
+            lengths.sum(), d_means.shape[1], dtype=d_means.dtype, zeros=False
         )
         start = 0
         for i, length in enumerate(lengths):

--- a/website/docs/api-backends.md
+++ b/website/docs/api-backends.md
@@ -379,7 +379,8 @@ the inputs and outputs.
 | `shape`        | <tt>Shape</tt>   | The shape.                                                      |
 | _keyword-only_ |                  |                                                                 |
 | `dtype`        | <tt>DTypes</tt>  | The data type (default: `float32`).                             |
-| **RETURNS**    | <tt>ArrayXd</tt> | An array of the correct shape and data type, filled with zeros. |
+| `zeros`        | <tt>bool</tt>    | Fill the array with zeros (default: `True`).                    |
+| **RETURNS**    | <tt>ArrayXd</tt> | An array of the correct shape and data type.                    |
 
 ### Ops.to_numpy {#to_numpy tag="method"}
 
@@ -426,7 +427,8 @@ Y = model.ops.alloc1i(4)  # Ints1d
 | `*shape`       | <tt>int</tt>                              | The shape, one positional argument per dimension.                          |
 | _keyword-only_ |                                           |                                                                            |
 | `dtype`        | <tt>DTypesInt</tt> / <tt>DTypesFloat</tt> | The data type (float type for float methods and int type for int methods). |
-| **RETURNS**    | <tt>ArrayXd</tt>                          | An array of the correct shape and data type, filled with zeros.            |
+| `zeros`        | <tt>bool</tt>                             | Fill the array with zeros (default: `True`).                               |
+| **RETURNS**    | <tt>ArrayXd</tt>                          | An array of the correct shape and data type.                               |
 
 ### Ops.reshape {#reshape tag="method"}
 

--- a/website/docs/api-backends.md
+++ b/website/docs/api-backends.md
@@ -374,13 +374,13 @@ Allocate an array of a certain shape. If possible, you should always use the
 allow more sophisticated static [type checking](/docs/usage-type-checking) of
 the inputs and outputs.
 
-| Argument       | Type             | Description                                                     |
-| -------------- | ---------------- | --------------------------------------------------------------- |
-| `shape`        | <tt>Shape</tt>   | The shape.                                                      |
-| _keyword-only_ |                  |                                                                 |
-| `dtype`        | <tt>DTypes</tt>  | The data type (default: `float32`).                             |
-| `zeros`        | <tt>bool</tt>    | Fill the array with zeros (default: `True`).                    |
-| **RETURNS**    | <tt>ArrayXd</tt> | An array of the correct shape and data type.                    |
+| Argument       | Type             | Description                                  |
+| -------------- | ---------------- | -------------------------------------------- |
+| `shape`        | <tt>Shape</tt>   | The shape.                                   |
+| _keyword-only_ |                  |                                              |
+| `dtype`        | <tt>DTypes</tt>  | The data type (default: `float32`).          |
+| `zeros`        | <tt>bool</tt>    | Fill the array with zeros (default: `True`). |
+| **RETURNS**    | <tt>ArrayXd</tt> | An array of the correct shape and data type. |
 
 ### Ops.to_numpy {#to_numpy tag="method"}
 


### PR DESCRIPTION
I've added a new keyword arg `uninitialized` to the allocator methods in the `NumpyOps` and `Ops` classes. Also replaced some zero-init'd allocations where the elements in the destination array were immediately replaced.