### PR TITLE
search.Beam: Fix invalid indexing

### DIFF
--- a/thinc/extra/search.pyx
+++ b/thinc/extra/search.pyx
@@ -193,13 +193,14 @@ cdef class Beam:
                         entry.first = s.score + scores[i][j]
                         entry.second = move_id + j
                         entries.push_back(entry)
-        cdef double max_ = entries[0].first
-        cdef double Z = 0.
-        cdef double cutoff = 0.0
+        cdef double max_, Z, cutoff
         if self.min_density == 0.0:
             for i in range(entries.size()):
                 q.push(entries[i])
-        else:
+        elif not entries.empty():
+            max_ = entries[0].first
+            Z = 0.
+            cutoff = 0.
             # Softmax into probabilities, so we can prune
             for i in range(entries.size()):
                 if entries[i].first > max_:


### PR DESCRIPTION
If none of the states of the beam have valid moves, it was attempted to  index into the vector of scored valid moves anyway, which results in invalid memory access.

Fix this by first checking that there valid moves before attempting to  index into them.

@honnibal: I am not sure if this is the valid way to address this issue, but this is the source of access violations on Windows in https://github.com/explosion/spaCy/pull/10633.
