### PR TITLE
Fix reductions when applied to zero-length sequences

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -314,7 +314,7 @@ def reduce_max(X, lengths, *, threads_per_block=128, num_blocks=128):
     T = X.shape[0]
     O = X.shape[1]
 
-    _check_lengths(lengths, T)
+    _check_lengths(lengths, T, min_length=1)
 
     out_shape = (B, O)
     maxes = _alloc(out_shape, dtype=X.dtype, zeros=False)
@@ -577,7 +577,7 @@ def backprop_reduce_max(
     B = len(lengths)
     T = int(lengths.sum())
     O = d_maxes.shape[1]
-    _check_lengths(lengths, T)
+    _check_lengths(lengths, T, min_length=1)
 
     out = _alloc((T, O), dtype=d_maxes.dtype, zeros=True)
 
@@ -643,10 +643,10 @@ def _is_float_array(out, *, shape: Optional[Tuple] = None):
         raise ValueError(msg)
 
 
-def _check_lengths(lengths, n_elems: int):
+def _check_lengths(lengths, n_elems: int, *, min_length=0):
     assert lengths.dtype == "int32", "lengths should be encoded as 32-bit integers"
-    if not cupy.all(lengths >= 0):
-        raise ValueError("all sequence lengths must be >= 0")
+    if not cupy.all(lengths >= min_length):
+        raise ValueError(f"all sequence lengths must be >= {min_length}")
     if cupy.sum(lengths) != n_elems:
         raise IndexError("lengths must sum up to the batch size")
 

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -83,9 +83,7 @@ void cpu_reduce_max(A* maxes__bo, L* which__bo, const A* X__to,
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
     for (const L* length = lengths__b; length < lengths__b + B; ++length) {
-        if (*length == 0)
-            continue;
-        else if (*length < 0)
+        if (*length <= 0)
             throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
         else if (*length > T) {
             throw std::out_of_range("lengths must sum up to the number of rows");

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -143,9 +143,7 @@ void cpu_reduce_mean(A* means__bo, const A* X__to, const L* lengths__b,
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
     for (const L* length = lengths__b; length < lengths__b + B; ++length) {
-        if (*length == 0)
-            continue;
-        else if (*length < 0)
+        if (*length < 0)
             throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
         else if (*length > T) {
             throw std::out_of_range("lengths must sum up to the number of rows");
@@ -226,9 +224,7 @@ void cpu_reduce_sum(A* sums__bo, const A* X__to, const L* lengths__b,
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
     for (const L* length = lengths__b; length < lengths__b + B; ++length) {
-        if (*length == 0)
-            continue;
-        else if (*length < 0)
+        if (*length < 0)
             throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
         else if (*length > T) {
             throw std::out_of_range("lengths must sum up to the number of rows");

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -141,8 +141,13 @@ void cpu_reduce_mean(A* means__bo, const A* X__to, const L* lengths__b,
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
     for (const L* length = lengths__b; length < lengths__b + B; ++length) {
-        if (*length < 0)
+        if (*length < 0) {
             throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
+        }
+        else if (length == 0) {
+            means__bo += O;
+            continue;
+        }
         else if (*length > T) {
             throw std::out_of_range("lengths must sum up to the number of rows");
         }
@@ -222,8 +227,13 @@ void cpu_reduce_sum(A* sums__bo, const A* X__to, const L* lengths__b,
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
     for (const L* length = lengths__b; length < lengths__b + B; ++length) {
-        if (*length < 0)
+        if (*length < 0) {
             throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
+        }
+        else if (length == 0) {
+            sums__bo += O;
+            continue;
+        }
         else if (*length > T) {
             throw std::out_of_range("lengths must sum up to the number of rows");
         }

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -84,7 +84,7 @@ void cpu_reduce_max(A* maxes__bo, L* which__bo, const A* X__to,
 
     for (const L* length = lengths__b; length < lengths__b + B; ++length) {
         if (*length <= 0)
-            throw std::invalid_argument(std::string("all sequence lengths must be >= 0, was: ") + std::to_string(*length));
+            throw std::invalid_argument(std::string("all sequence lengths must be > 0, was: ") + std::to_string(*length));
         else if (*length > T) {
             throw std::out_of_range("lengths must sum up to the number of rows");
         }

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -412,8 +412,8 @@ class NumpyOps(Ops):
         cdef int T = 0
 
         for length in lengths[:B]:
-            if length < 0:
-                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
+            if length <= 0:
+                raise ValueError(f"all sequence lengths must be > 0, got {length}")
             T += length
 
         assert T != 0

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1048,6 +1048,8 @@ class Ops:
             elif length:
                 Y[i] = X[start : start + length].sum(axis=0)
                 start += length
+            else:
+                Y[i] = 0.0
         return Y
 
     def reduce_mean(self, X: Floats2d, lengths: Ints1d) -> Floats2d:
@@ -1060,6 +1062,8 @@ class Ops:
                 raise IndexError("lengths must sum up to the number of rows")
             elif length:
                 Y[i] = X[start : start + length].mean(axis=0)
+            else:
+                Y[i] = 0.0
             start += length
         return Y
 

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1072,7 +1072,7 @@ class Ops:
         which = self.alloc2i(lengths.shape[0], X.shape[1], zeros=False)
         start = 0
         for i, length in enumerate(lengths):
-            if length < 0:
+            if length <= 0:
                 raise ValueError(f"all sequence lengths must be >= 0, got {length}")
             elif start + length > X.shape[0]:
                 raise IndexError("lengths must sum up to the number of rows")
@@ -1112,6 +1112,9 @@ class Ops:
         dX = self.alloc2f(lengths.sum(), d_maxes.shape[1], dtype=d_maxes.dtype)
         start = 0
         for i, length in enumerate(lengths):
+            if length <= 0:
+                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
+
             self.xp.put_along_axis(
                 dX[start : start + length], which[i].reshape((1, -1)), d_maxes[i], 0
             )

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1073,7 +1073,7 @@ class Ops:
         start = 0
         for i, length in enumerate(lengths):
             if length <= 0:
-                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
+                raise ValueError(f"all sequence lengths must be > 0, got {length}")
             elif start + length > X.shape[0]:
                 raise IndexError("lengths must sum up to the number of rows")
             elif length:
@@ -1113,7 +1113,7 @@ class Ops:
         start = 0
         for i, length in enumerate(lengths):
             if length <= 0:
-                raise ValueError(f"all sequence lengths must be >= 0, got {length}")
+                raise ValueError(f"all sequence lengths must be > 0, got {length}")
 
             self.xp.put_along_axis(
                 dX[start : start + length], which[i].reshape((1, -1)), d_maxes[i], 0

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -732,17 +732,25 @@ def test_flatten_unflatten_roundtrip(cpu_ops, X):
 @pytest.mark.parametrize("ops", ALL_OPS)
 @pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_reduce_sum(ops, dtype):
-    m = ops.xp.zeros((19, 5), dtype=dtype)
-    m += 1
-    lengths = ops.xp.array([5, 5, 3, 6], dtype="i")
-    output = ops.reduce_sum(m, lengths)
-    assert output.sum() == m.sum(), (output.sum(), m.sum())
+    X = ops.asarray2f(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0], [3.0, 4.0]], dtype=dtype
+    )
+    lengths = ops.asarray1i([3, 2])
+    ops.xp.testing.assert_allclose(
+        ops.reduce_sum(X, lengths), [[9.0, 12.0], [4.0, 6.0]]
+    )
+
+    # Zero-length array
+    lengths = ops.asarray1i([3, 0, 2])
+    ops.xp.testing.assert_allclose(
+        ops.reduce_sum(X, lengths), [[9.0, 12.0], [0.0, 0.0], [4.0, 6.0]]
+    )
 
     with pytest.raises(IndexError):
-        ops.reduce_sum(m, ops.xp.array([5, 5, 5, 5], dtype="i"))
+        ops.reduce_sum(X, ops.xp.array([5, 5, 5, 5], dtype="i"))
 
     with pytest.raises(ValueError):
-        ops.reduce_sum(m, ops.xp.array([-1, 10, 5, 5], dtype="i"))
+        ops.reduce_sum(X, ops.xp.array([-1, 10, 5, 5], dtype="i"))
 
 
 @pytest.mark.parametrize("ops", ALL_OPS)
@@ -833,11 +841,24 @@ def test_backprop_reduce_max(ops, dtype):
 @pytest.mark.parametrize("dtype", FLOAT_TYPES)
 def test_reduce_mean(ops, dtype):
     X = ops.asarray2f(
-        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2], [3.0, 4.0]], dtype=dtype
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0], [3.0, 4.0]], dtype=dtype
     )
     lengths = ops.asarray1i([3, 2])
     ops.xp.testing.assert_allclose(
         ops.reduce_mean(X, lengths), [[3.0, 4.0], [2.0, 3.0]]
+    )
+
+    # Zero-length array
+    lengths = ops.asarray1i([3, 0, 2])
+    ops.xp.testing.assert_allclose(
+        ops.reduce_mean(X, lengths), [[3.0, 4.0], [0.0, 0.0], [2.0, 3.0]]
+    )
+
+    # Zero-length array last.
+    X = ops.asarray2f([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=dtype)
+    lengths = ops.asarray1i([3, 0])
+    ops.xp.testing.assert_allclose(
+        ops.reduce_mean(X, lengths), [[3.0, 4.0], [0.0, 0.0]]
     )
 
     with pytest.raises(IndexError):

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -801,6 +801,9 @@ def test_reduce_max(ops, dtype):
     with pytest.raises(ValueError):
         ops.reduce_max(m, ops.xp.array([-1, 10, 5, 5], dtype="i"))
 
+    with pytest.raises(ValueError):
+        ops.reduce_max(m, ops.xp.array([5, 5, 0, 3, 6], dtype="i"))
+
 
 @pytest.mark.parametrize("ops", ALL_OPS)
 @pytest.mark.parametrize("dtype", FLOAT_TYPES)
@@ -834,6 +837,13 @@ def test_backprop_reduce_max(ops, dtype):
             ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),
             ops.xp.array([[2, 1, 0], [1, 0, 1]]).astype("int32"),
             ops.xp.array([-3, 2], dtype="int32"),
+        )
+
+    with pytest.raises(ValueError):
+        ops.backprop_reduce_max(
+            ops.xp.arange(1, 7, dtype=dtype).reshape(2, 3),
+            ops.xp.array([[2, 1, 0], [1, 0, 1], [1, 0, 1]]).astype("int32"),
+            ops.xp.array([3, 0, 2], dtype="int32"),
         )
 
 

--- a/website/docs/api-backends.md
+++ b/website/docs/api-backends.md
@@ -1278,7 +1278,7 @@ Backpropagate the `reduce_mean` operation.
 </inline-list>
 
 Perform sequence-wise max pooling for data in the ragged format. Zero-length
-sequences are not allowed. A `ValueError` is raised if one any element in
+sequences are not allowed. A `ValueError` is raised if any element in
 `lengths` is zero.
 
 | Argument    | Type                             | Description                 |
@@ -1297,7 +1297,7 @@ sequences are not allowed. A `ValueError` is raised if one any element in
 
 </inline-list>
 
-Backpropagate the `reduce_max` operation. A `ValueError` is raised if one any
+Backpropagate the `reduce_max` operation. A `ValueError` is raised if any
 element in `lengths` is zero.
 
 | Argument    | Type              | Description                                 |

--- a/website/docs/api-backends.md
+++ b/website/docs/api-backends.md
@@ -1204,7 +1204,7 @@ Backpropagate the hard Swish MobileNet activation.
 </inline-list>
 
 Perform sequence-wise summation for data in the ragged format. Zero-length
-sequences are reduced to a zero vector.
+sequences are reduced to the zero vector.
 
 | Argument    | Type              | Description                   |
 | ----------- | ----------------- | ----------------------------- |
@@ -1241,7 +1241,7 @@ Backpropagate the `reduce_sum` operation.
 </inline-list>
 
 Perform sequence-wise averaging for data in the ragged format. Zero-length
-sequences are reduced to a zero vector.
+sequences are reduced to the zero vector.
 
 | Argument    | Type              | Description                 |
 | ----------- | ----------------- | --------------------------- |

--- a/website/docs/api-backends.md
+++ b/website/docs/api-backends.md
@@ -1203,7 +1203,8 @@ Backpropagate the hard Swish MobileNet activation.
 
 </inline-list>
 
-Perform sequence-wise summation for data in the ragged format.
+Perform sequence-wise summation for data in the ragged format. Zero-length
+sequences are reduced to a zero vector.
 
 | Argument    | Type              | Description                   |
 | ----------- | ----------------- | ----------------------------- |
@@ -1239,7 +1240,8 @@ Backpropagate the `reduce_sum` operation.
 
 </inline-list>
 
-Perform sequence-wise averaging for data in the ragged format.
+Perform sequence-wise averaging for data in the ragged format. Zero-length
+sequences are reduced to a zero vector.
 
 | Argument    | Type              | Description                 |
 | ----------- | ----------------- | --------------------------- |
@@ -1275,7 +1277,9 @@ Backpropagate the `reduce_mean` operation.
 
 </inline-list>
 
-Perform sequence-wise max pooling for data in the ragged format.
+Perform sequence-wise max pooling for data in the ragged format. Zero-length
+sequences are not allowed. A `ValueError` is raised if one any element in
+`lengths` is zero.
 
 | Argument    | Type                             | Description                 |
 | ----------- | -------------------------------- | --------------------------- |
@@ -1293,7 +1297,8 @@ Perform sequence-wise max pooling for data in the ragged format.
 
 </inline-list>
 
-Backpropagate the `reduce_max` operation.
+Backpropagate the `reduce_max` operation. A `ValueError` is raised if one any
+element in `lengths` is zero.
 
 | Argument    | Type              | Description                                 |
 | ----------- | ----------------- | ------------------------------------------- |

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -884,7 +884,7 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_max.py
 </inline-list>
 
 Pooling layer that reduces the dimensions of the data by computing the average
-value of each feature. Zero-length sequences are reduced to a zero vector.
+value of each feature. Zero-length sequences are reduced to the zero vector.
 
 | Argument    | Type                             | Description                |
 | ----------- | -------------------------------- | -------------------------- |
@@ -904,7 +904,7 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_mean.py
 </inline-list>
 
 Pooling layer that reduces the dimensions of the data by computing the sum for
-each feature. Zero-length sequences are reduced to a zero vector.
+each feature. Zero-length sequences are reduced to the zero vector.
 
 | Argument    | Type                             | Description                |
 | ----------- | -------------------------------- | -------------------------- |

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -863,7 +863,7 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_last.py
 </inline-list>
 
 Pooling layer that reduces the dimensions of the data by selecting the maximum
-value for each feature. A `ValueError` is raised if one any element in `lengths`
+value for each feature. A `ValueError` is raised if any element in `lengths`
 is zero.
 
 | Argument    | Type                             | Description                |

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -863,7 +863,8 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_last.py
 </inline-list>
 
 Pooling layer that reduces the dimensions of the data by selecting the maximum
-value for each feature.
+value for each feature. A `ValueError` is raised if one any element in `lengths`
+is zero.
 
 | Argument    | Type                             | Description                |
 | ----------- | -------------------------------- | -------------------------- |
@@ -883,7 +884,7 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_max.py
 </inline-list>
 
 Pooling layer that reduces the dimensions of the data by computing the average
-value of each feature.
+value of each feature. Zero-length sequences are reduced to a zero vector.
 
 | Argument    | Type                             | Description                |
 | ----------- | -------------------------------- | -------------------------- |
@@ -903,7 +904,7 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_mean.py
 </inline-list>
 
 Pooling layer that reduces the dimensions of the data by computing the sum for
-each feature.
+each feature. Zero-length sequences are reduced to a zero vector.
 
 | Argument    | Type                             | Description                |
 | ----------- | -------------------------------- | -------------------------- |


### PR DESCRIPTION
* A bug was introduced in `NumpyOps` that caused the output pointer not to be incremented for zero-length sequences.
* When using uninitialized arrays, the sum or mean for a zero-length array was not correctly set to zero in `Ops`.

We should also do something about zero-length sequences for `reduce_max`. However, it's unclear what the corresponding `which` should be set to (since `0` is not a valid index for a zero-sized sequence). Maybe we should throw an exception when trying to apply `reduce_max` to a zero-length sequence?