### PR TITLE
Fix PyTorch tensor handling in `CupyOps.asarray`

### DIFF
--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -19,6 +19,14 @@ from .ops import Ops
 from .numpy_ops import NumpyOps
 from . import _custom_kernels
 from ..types import DeviceTypes
+from ..util import (
+    torch2xp,
+    tensorflow2xp,
+    is_mxnet_array,
+    mxnet2xp,
+    is_torch_array,
+    is_tensorflow_array,
+)
 
 
 @registry.ops("CupyOps")
@@ -73,29 +81,28 @@ class CupyOps(Ops):
         # This is sort of frustrating, but we can't easily otherwise pass
         # forward "unset".
         dtype = {"dtype": dtype} if dtype is not None else {}
+
+        # We'll try to perform a zero-copy conversion if possible.
+        array = None
+        cast_array = False
         if isinstance(data, cupy.ndarray):
-            return self.xp.asarray(data, **dtype)
-        elif (
-            hasattr(data, "data_ptr")
-            and hasattr(data, "storage")
-            and hasattr(data, "device")
-        ):
-            # Handles PyTorch Tensors
-            assert data.device.type == "cuda", "Non-CUDA tensor passed to CupyOps"
-
-            ext_pointer_wrapper = cupy.cuda.UnownedMemory(
-                ptr=data.data_ptr(),
-                size=data.storage().size(),
-                owner=data,
-                device_id=data.device.index,
-            )
-
-            pointer = cupy.cuda.MemoryPointer(ext_pointer_wrapper, offset=0)
-            array = self.xp.ndarray(shape=data.shape, memptr=pointer, **dtype)
-            return array
+            array = self.xp.asarray(data, **dtype)
+        elif is_torch_array(data) and data.device.type == "cuda":
+            array = torch2xp(data)
+            cast_array = True
+        elif is_tensorflow_array(data) and "GPU:" in data.device:
+            array = tensorflow2xp(data)
+            cast_array = True
+        elif is_mxnet_array(data) and data.context.device_type != "cpu":
+            array = mxnet2xp(data)
+            cast_array = True
         else:
-            result = self.xp.array(data, **dtype)
-            return result
+            array = self.xp.array(data, **dtype)
+
+        if cast_array and dtype != {}:
+            array = array.astype(dtype["dtype"])
+
+        return array
 
     def maxout(self, X):
         return _custom_kernels.maxout(X)

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -84,15 +84,14 @@ class CupyOps(Ops):
             assert data.device.type == "cuda", "Non-CUDA tensor passed to CupyOps"
 
             ext_pointer_wrapper = cupy.cuda.UnownedMemory(
-                data.data_ptr(),
-                data.storage().size(),
-                data.storage(),
-                data.device.index,
+                ptr=data.data_ptr(),
+                size=data.storage().size(),
+                owner=data,
+                device_id=data.device.index,
             )
 
             pointer = cupy.cuda.MemoryPointer(ext_pointer_wrapper, 0)
-            shape = data.shape
-            array = self.xp.ndarray(shape, memptr=pointer, **dtype)
+            array = self.xp.ndarray(shape=data.shape, memptr=pointer, **dtype)
             return array
         else:
             result = self.xp.array(data, **dtype)

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -19,14 +19,8 @@ from .ops import Ops
 from .numpy_ops import NumpyOps
 from . import _custom_kernels
 from ..types import DeviceTypes
-from ..util import (
-    torch2xp,
-    tensorflow2xp,
-    is_mxnet_array,
-    mxnet2xp,
-    is_torch_array,
-    is_tensorflow_array,
-)
+from ..util import torch2xp, tensorflow2xp, mxnet2xp
+from ..util import is_torch_array, is_tensorflow_array, is_mxnet_array
 
 
 @registry.ops("CupyOps")

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -90,7 +90,7 @@ class CupyOps(Ops):
                 device_id=data.device.index,
             )
 
-            pointer = cupy.cuda.MemoryPointer(ext_pointer_wrapper, 0)
+            pointer = cupy.cuda.MemoryPointer(ext_pointer_wrapper, offset=0)
             array = self.xp.ndarray(shape=data.shape, memptr=pointer, **dtype)
             return array
         else:

--- a/thinc/tests/regression/test_issue564.py
+++ b/thinc/tests/regression/test_issue564.py
@@ -1,8 +1,14 @@
+import pytest
+
 from thinc.api import CupyOps
-import torch
+from thinc.util import has_torch, has_torch_amp, has_torch_gpu
 
 
+@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not has_torch_gpu, reason="needs a GPU")
 def test_issue564():
+    import torch
+
     if CupyOps.xp is not None:
         ops = CupyOps()
         t = torch.zeros((10, 2)).cuda()

--- a/thinc/tests/regression/test_issue564.py
+++ b/thinc/tests/regression/test_issue564.py
@@ -1,0 +1,15 @@
+from thinc.api import CupyOps
+import torch
+
+
+def test_issue564():
+    if CupyOps.xp is not None:
+        ops = CupyOps()
+        t = torch.zeros((10, 2)).cuda()
+        a = ops.asarray(t)
+
+        assert a.shape == t.shape
+        ops.xp.testing.assert_allclose(
+            a,
+            ops.alloc2f(10, 2),
+        )

--- a/thinc/tests/regression/test_issue564.py
+++ b/thinc/tests/regression/test_issue564.py
@@ -1,7 +1,7 @@
 import pytest
 
 from thinc.api import CupyOps
-from thinc.util import has_torch, has_torch_amp, has_torch_gpu
+from thinc.util import has_torch, has_torch_gpu
 
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")


### PR DESCRIPTION
This PR fixes the following and adds a regression test:

- The original invocation of `cupy.cuda.MemoryPointer` was missing the mandatory `offset` argument. This should be `0`.
- `cupy.cuda.MemoryPointer` expects a wrapper to a `cupy`-owned CUDA memory and not a raw pointer to it. So, CUDA memory allocated by external libraries needs to be wrapped with `UnownedMemory` and then passed to the array c'tor [[1](https://github.com/cupy/cupy/issues/4644#issuecomment-775480279)].
- We weren't testing that the incoming array-like obj was owned by a CUDA device.
- We were incorrectly passing the array stride as its shape.

Should fix #564.

