### PR TITLE
Fix type safety issue with model ID assignment

### DIFF
--- a/thinc/model.py
+++ b/thinc/model.py
@@ -95,7 +95,7 @@ class Model(Generic[InT, OutT]):
         # across all models.
         with Model.global_id_lock:
             Model.global_id += 1
-        self.id = Model.global_id
+            self.id = Model.global_id
         self._has_params = {}
         for name, value in params.items():
             self._has_params[name] = None


### PR DESCRIPTION
It was observed that the test checking typesafe assignment of model IDs failed very occasionally. The issue fixed here is likely to have been the cause of this, although unfortunately there is no way of verifying this.