### PR TITLE
Move compatiblity-related code into a separate `compat` module

### DIFF
--- a/examples/00_intro_to_thinc.ipynb
+++ b/examples/00_intro_to_thinc.ipynb
@@ -44,9 +44,9 @@
    },
    "outputs": [],
    "source": [
-    "import thinc.util\n",
+    "import thinc.compat\n",
     "# If you want to run this notebook on GPU, you'll need to install cupy.\n",
-    "if not thinc.util.has_cupy:\n",
+    "if not thinc.compat.has_cupy:\n",
     "    !pip install \"cupy-cuda101\""
    ]
   },
@@ -59,11 +59,11 @@
    },
    "outputs": [],
    "source": [
-    "import thinc.util\n",
+    "import thinc.compat\n",
     "# If you want to try out the tensorflow integration, you'll need to install that.\n",
     "# You'll either need to do tensorflow or tensorflow-gpu, depending on your\n",
     "# requirements.\n",
-    "if not thinc.util.has_tensorflow:\n",
+    "if not thinc.compat.has_tensorflow:\n",
     "    !pip install \"tensorflow-gpu>=2\""
    ]
   },
@@ -75,9 +75,9 @@
    },
    "outputs": [],
    "source": [
-    "import thinc.util\n",
+    "import thinc.compat\n",
     "# If you want to try out the PyTorch integration, you'll need to install it.\n",
-    "if not thinc.util.has_torch:\n",
+    "if not thinc.compat.has_torch:\n",
     "    !pip install \"torch\""
    ]
   },
@@ -89,9 +89,9 @@
    },
    "outputs": [],
    "source": [
-    "import thinc.util\n",
+    "import thinc.compat\n",
     "# If you want to try out the MxNet integration, you'll need to install it.\n",
-    "if not thinc.util.has_mxnet:\n",
+    "if not thinc.compat.has_mxnet:\n",
     "    !pip install \"mxnet>=1.5.1,<1.6.0\""
    ]
   },
@@ -117,10 +117,10 @@
    "outputs": [],
    "source": [
     "from thinc.api import prefer_gpu\n",
-    "import thinc.util\n",
+    "import thinc.compat\n",
     "print(\"Thinc GPU?\", prefer_gpu())\n",
     "\n",
-    "if thinc.util.has_tensorflow:\n",
+    "if thinc.compat.has_tensorflow:\n",
     "    import tensorflow as tf\n",
     "    print(\"Tensorflow GPU?\", bool(tf.config.experimental.list_physical_devices('GPU')))"
    ]
@@ -1374,9 +1374,9 @@
    "source": [
     "from mxnet.gluon.nn import Dense, Sequential, Dropout\n",
     "from thinc.api import MXNetWrapper, chain, Softmax\n",
-    "import thinc.util\n",
+    "import thinc.compat\n",
     "\n",
-    "assert thinc.util.has_mxnet\n",
+    "assert thinc.compat.has_mxnet\n",
     "\n",
     "width = 32\n",
     "nO = 10\n",

--- a/examples/00_intro_to_thinc.ipynb
+++ b/examples/00_intro_to_thinc.ipynb
@@ -44,9 +44,9 @@
    },
    "outputs": [],
    "source": [
-    "import thinc.compat\n",
+    "import thinc.util\n",
     "# If you want to run this notebook on GPU, you'll need to install cupy.\n",
-    "if not thinc.compat.has_cupy:\n",
+    "if not thinc.util.has_cupy:\n",
     "    !pip install \"cupy-cuda101\""
    ]
   },
@@ -59,11 +59,11 @@
    },
    "outputs": [],
    "source": [
-    "import thinc.compat\n",
+    "import thinc.util\n",
     "# If you want to try out the tensorflow integration, you'll need to install that.\n",
     "# You'll either need to do tensorflow or tensorflow-gpu, depending on your\n",
     "# requirements.\n",
-    "if not thinc.compat.has_tensorflow:\n",
+    "if not thinc.util.has_tensorflow:\n",
     "    !pip install \"tensorflow-gpu>=2\""
    ]
   },
@@ -75,9 +75,9 @@
    },
    "outputs": [],
    "source": [
-    "import thinc.compat\n",
+    "import thinc.util\n",
     "# If you want to try out the PyTorch integration, you'll need to install it.\n",
-    "if not thinc.compat.has_torch:\n",
+    "if not thinc.util.has_torch:\n",
     "    !pip install \"torch\""
    ]
   },
@@ -89,9 +89,9 @@
    },
    "outputs": [],
    "source": [
-    "import thinc.compat\n",
+    "import thinc.util\n",
     "# If you want to try out the MxNet integration, you'll need to install it.\n",
-    "if not thinc.compat.has_mxnet:\n",
+    "if not thinc.util.has_mxnet:\n",
     "    !pip install \"mxnet>=1.5.1,<1.6.0\""
    ]
   },
@@ -117,10 +117,10 @@
    "outputs": [],
    "source": [
     "from thinc.api import prefer_gpu\n",
-    "import thinc.compat\n",
+    "import thinc.util\n",
     "print(\"Thinc GPU?\", prefer_gpu())\n",
     "\n",
-    "if thinc.compat.has_tensorflow:\n",
+    "if thinc.util.has_tensorflow:\n",
     "    import tensorflow as tf\n",
     "    print(\"Tensorflow GPU?\", bool(tf.config.experimental.list_physical_devices('GPU')))"
    ]
@@ -1374,9 +1374,9 @@
    "source": [
     "from mxnet.gluon.nn import Dense, Sequential, Dropout\n",
     "from thinc.api import MXNetWrapper, chain, Softmax\n",
-    "import thinc.compat\n",
+    "import thinc.util\n",
     "\n",
-    "assert thinc.compat.has_mxnet\n",
+    "assert thinc.util.has_mxnet\n",
     "\n",
     "width = 32\n",
     "nO = 10\n",

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -17,7 +17,7 @@ from .util import DataValidationError, data_validation
 from .util import to_categorical, get_width, get_array_module, to_numpy
 from .util import torch2xp, xp2torch, tensorflow2xp, xp2tensorflow, mxnet2xp, xp2mxnet
 from .backends import get_ops, set_current_ops, get_current_ops, use_ops
-from .backends import Ops, CupyOps, NumpyOps, has_cupy, set_gpu_allocator
+from .backends import Ops, CupyOps, NumpyOps, set_gpu_allocator
 from .backends import use_pytorch_for_gpu_memory, use_tensorflow_for_gpu_memory
 
 from .layers import Dropout, Embed, expand_window, HashEmbed, LayerNorm, Linear

--- a/thinc/api.py
+++ b/thinc/api.py
@@ -16,6 +16,7 @@ from .util import prefer_gpu, require_gpu, require_cpu
 from .util import DataValidationError, data_validation
 from .util import to_categorical, get_width, get_array_module, to_numpy
 from .util import torch2xp, xp2torch, tensorflow2xp, xp2tensorflow, mxnet2xp, xp2mxnet
+from .compat import has_cupy
 from .backends import get_ops, set_current_ops, get_current_ops, use_ops
 from .backends import Ops, CupyOps, NumpyOps, set_gpu_allocator
 from .backends import use_pytorch_for_gpu_memory, use_tensorflow_for_gpu_memory

--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -12,7 +12,7 @@ from ._param_server import ParamServer
 from ..util import assert_tensorflow_installed, assert_pytorch_installed
 from ..util import is_cupy_array, set_torch_tensor_type_for_ops, require_cpu
 from .. import registry
-from ..compat import cupy
+from ..compat import cupy, has_cupy
 
 
 context_ops: ContextVar[Optional[Ops]] = ContextVar("context_ops", default=None)
@@ -47,8 +47,6 @@ def use_pytorch_for_gpu_memory() -> None:  # pragma: no cover
     We'd like to support routing Tensorflow memory allocation via PyTorch as well
     (or vice versa), but do not currently have an implementation for it.
     """
-    import cupy.cuda
-
     assert_pytorch_installed()
     pools = context_pools.get()
     if "pytorch" not in pools:
@@ -66,8 +64,6 @@ def use_tensorflow_for_gpu_memory() -> None:  # pragma: no cover
     We'd like to support routing PyTorch memory allocation via Tensorflow as
     well (or vice versa), but do not currently have an implementation for it.
     """
-    import cupy.cuda
-
     assert_tensorflow_installed()
     pools = context_pools.get()
     if "tensorflow" not in pools:
@@ -175,4 +171,5 @@ __all__ = [
     "Ops",
     "CupyOps",
     "NumpyOps",
+    "has_cupy",
 ]

--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -5,13 +5,14 @@ from contextvars import ContextVar
 import threading
 
 from .ops import Ops
-from .cupy_ops import CupyOps, has_cupy
+from .cupy_ops import CupyOps
 from .numpy_ops import NumpyOps
 from ._cupy_allocators import cupy_tensorflow_allocator, cupy_pytorch_allocator
 from ._param_server import ParamServer
 from ..util import assert_tensorflow_installed, assert_pytorch_installed
 from ..util import is_cupy_array, set_torch_tensor_type_for_ops, require_cpu
 from .. import registry
+from ..compat import cupy
 
 
 context_ops: ContextVar[Optional[Ops]] = ContextVar("context_ops", default=None)
@@ -94,7 +95,7 @@ def get_ops(name: str, **kwargs) -> Ops:
 
     cls: Optional[Callable[..., Ops]] = None
     if name == "cpu":
-        _import_extra_cpu_backends()        
+        _import_extra_cpu_backends()
         cls = ops_by_name.get("numpy")
         cls = ops_by_name.get("apple", cls)
         cls = ops_by_name.get("bigendian", cls)
@@ -174,5 +175,4 @@ __all__ = [
     "Ops",
     "CupyOps",
     "NumpyOps",
-    "has_cupy",
 ]

--- a/thinc/backends/_cupy_allocators.py
+++ b/thinc/backends/_cupy_allocators.py
@@ -2,22 +2,7 @@ from typing import cast
 
 from ..types import ArrayXd
 from ..util import tensorflow2xp
-
-try:
-    import tensorflow
-except ImportError:
-    pass
-
-try:
-    import torch
-except ImportError:
-    pass
-
-try:
-    from cupy.cuda.memory import MemoryPointer
-    from cupy.cuda.memory import UnownedMemory
-except ImportError:
-    pass
+from ..compat import torch, cupy, tensorflow
 
 
 def cupy_tensorflow_allocator(size_in_bytes: int):
@@ -32,9 +17,9 @@ def cupy_tensorflow_allocator(size_in_bytes: int):
     cupy_array = cast(ArrayXd, tensorflow2xp(tensor))
     address = int(cupy_array.data)
     # cupy has a neat class to help us here. Otherwise it will try to free.
-    memory = UnownedMemory(address, size_in_bytes, cupy_array)
+    memory = cupy.cuda.memory.UnownedMemory(address, size_in_bytes, cupy_array)
     # Now return a new memory pointer.
-    return MemoryPointer(memory, 0)
+    return cupy.cuda.memory.MemoryPointer(memory, 0)
 
 
 def cupy_pytorch_allocator(size_in_bytes: int):
@@ -53,6 +38,6 @@ def cupy_pytorch_allocator(size_in_bytes: int):
     # cupy has a neat class to help us here. Otherwise it will try to free.
     # I think this is a private API? It's not in the types.
     address = torch_tensor.data_ptr()  # type: ignore
-    memory = UnownedMemory(address, size_in_bytes, torch_tensor)
+    memory = cupy.cuda.memory.UnownedMemory(address, size_in_bytes, torch_tensor)
     # Now return a new memory pointer.
-    return MemoryPointer(memory, 0)
+    return cupy.cuda.memory.MemoryPointer(memory, 0)

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -2,11 +2,7 @@ from typing import Optional, Tuple
 import re
 from pathlib import Path
 from collections import defaultdict
-
-try:
-    import cupy
-except ImportError:
-    cupy = None
+from ..compat import cupy, has_cupy_gpu
 
 
 PWD = Path(__file__).parent
@@ -55,7 +51,7 @@ KERNELS = (
     cupy.RawModule(
         code=KERNELS_SRC, options=("--std=c++11",), name_expressions=KERNELS_LIST
     )
-    if cupy is not None
+    if has_cupy_gpu
     else None
 )
 
@@ -70,7 +66,7 @@ def _get_kernel(name):
 
 
 def compile_mmh(src):
-    if cupy is None:
+    if not has_cupy_gpu:
         return None
     return cupy.RawKernel(src, "hash_data")
 
@@ -672,7 +668,7 @@ _values_within_range = (
         "true",
         "within_range",
     )
-    if cupy is not None
+    if has_cupy_gpu
     else None
 )
 

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -1,19 +1,4 @@
 import numpy
-
-try:
-    import cupy
-    import cupyx
-    import cupy.cuda
-    from cupy.cuda.compiler import compile_with_cache  # noqa: F401
-
-    has_cupy = True
-
-    # We no longer have to set up the memory pool, fortunately.
-except ImportError:
-    cupy = None
-    cupyx = None
-    has_cupy = False
-
 from .. import registry
 from .ops import Ops
 from .numpy_ops import NumpyOps
@@ -22,6 +7,7 @@ from ..types import DeviceTypes
 from ..util import torch2xp, tensorflow2xp, mxnet2xp
 from ..util import is_cupy_array
 from ..util import is_torch_gpu_array, is_tensorflow_gpu_array, is_mxnet_gpu_array
+from ..compat import cupy, cupyx
 
 
 @registry.ops("CupyOps")

--- a/thinc/compat.py
+++ b/thinc/compat.py
@@ -1,0 +1,70 @@
+from packaging.version import Version
+
+try:  # pragma: no cover
+    import cupy
+    import cupyx
+
+    has_cupy = True
+    cupy_version = Version(cupy.__version__)
+    try:
+        cupy.cuda.runtime.getDeviceCount()
+        has_cupy_gpu = True
+    except cupy.cuda.runtime.CUDARuntimeError:
+        has_cupy_gpu = False
+
+    if cupy_version.major >= 10:
+        # fromDlpack was deprecated in v10.0.0.
+        cupy_from_dlpack = cupy.from_dlpack
+    else:
+        cupy_from_dlpack = cupy.fromDlpack
+except (ImportError, AttributeError):
+    cupy = None
+    cupyx = None
+    cupy_version = Version("0.0.0")
+    has_cupy = False
+    cupy_from_dlpack = None
+    has_cupy_gpu = False
+
+
+try:  # pragma: no cover
+    import torch.utils.dlpack
+    import torch
+
+    has_torch = True
+    has_torch_gpu = torch.cuda.device_count() != 0
+    torch_version = Version(str(torch.__version__))
+    has_torch_amp = (
+        torch_version >= Version("1.9.0")
+        and not torch.cuda.amp.common.amp_definitely_not_available()
+    )
+except ImportError:  # pragma: no cover
+    torch = None
+    has_torch = False
+    has_torch_gpu = False
+    has_torch_amp = False
+    torch_version = Version("0.0.0")
+
+try:  # pragma: no cover
+    import tensorflow.experimental.dlpack
+    import tensorflow
+
+    has_tensorflow = True
+    has_tensorflow_gpu = len(tensorflow.config.get_visible_devices("GPU")) > 0
+except ImportError:  # pragma: no cover
+    tensorflow = None
+    has_tensorflow = False
+    has_tensorflow_gpu = False
+
+
+try:  # pragma: no cover
+    import mxnet
+
+    has_mxnet = True
+except ImportError:  # pragma: no cover
+    mxnet = None
+    has_mxnet = False
+
+try:
+    import h5py
+except ImportError:  # pragma: no cover
+    h5py = None

--- a/thinc/layers/tensorflowwrapper.py
+++ b/thinc/layers/tensorflowwrapper.py
@@ -7,11 +7,7 @@ from ..shims import TensorFlowShim, keras_model_fns, maybe_handshake_model
 from ..util import xp2tensorflow, tensorflow2xp, assert_tensorflow_installed
 from ..util import is_tensorflow_array, convert_recursive, is_xp_array
 from ..types import ArrayXd, ArgsKwargs
-
-try:
-    import tensorflow as tf
-except ImportError:  # pragma: no cover
-    pass
+from ..compat import tensorflow as tf
 
 InT = TypeVar("InT")
 OutT = TypeVar("OutT")

--- a/thinc/shims/mxnet.py
+++ b/thinc/shims/mxnet.py
@@ -2,18 +2,12 @@ from typing import Any, cast
 import srsly
 import copy
 
-try:
-    import mxnet.autograd
-    import mxnet.optimizer
-    import mxnet as mx
-except ImportError:  # pragma: no cover
-    pass
-
 from ..util import mxnet2xp, convert_recursive, make_tempfile, xp2mxnet
 from ..util import get_array_module
 from ..optimizers import Optimizer
 from ..types import ArgsKwargs, FloatsXd
 from .shim import Shim
+from ..compat import mxnet as mx
 
 
 class MXNetShim(Shim):
@@ -33,7 +27,7 @@ class MXNetShim(Shim):
         evaluation mode.
         """
         mx.autograd.set_training(train_mode=False)
-        with mxnet.autograd.pause():
+        with mx.autograd.pause():
             outputs = self._model(*inputs.args, **inputs.kwargs)
         mx.autograd.set_training(train_mode=True)
         return outputs
@@ -50,7 +44,7 @@ class MXNetShim(Shim):
 
         def backprop(grads):
             mx.autograd.set_recording(False)
-            mxnet.autograd.backward(*grads.args, **grads.kwargs)
+            mx.autograd.backward(*grads.args, **grads.kwargs)
             return convert_recursive(
                 lambda x: hasattr(x, "grad"), lambda x: x.grad, inputs
             )

--- a/thinc/shims/pytorch_grad_scaler.py
+++ b/thinc/shims/pytorch_grad_scaler.py
@@ -1,11 +1,7 @@
 from typing import Dict, Iterable, List, Union, cast
 
-from ..util import has_torch_amp, is_torch_array
-
-try:
-    import torch
-except ImportError:  # pragma: no cover
-    pass
+from ..compat import has_torch_amp, torch
+from ..util import is_torch_array
 
 
 class PyTorchGradScaler:

--- a/thinc/shims/tensorflow.py
+++ b/thinc/shims/tensorflow.py
@@ -10,21 +10,8 @@ from ..optimizers import Optimizer
 from ..types import ArgsKwargs, ArrayXd
 from ..util import get_array_module
 from .shim import Shim
-
-try:
-    import cupy
-except ImportError:
-    cupy = None
-
-try:
-    import tensorflow as tf
-except ImportError:  # pragma: no cover
-    pass
-
-try:
-    import h5py
-except ImportError:  # pragma: no cover
-    pass
+from ..compat import tensorflow as tf
+from ..compat import cupy, h5py
 
 keras_model_fns = catalogue.create("thinc", "keras", entry_points=True)
 

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -8,7 +8,8 @@ from numpy.testing import assert_allclose
 from packaging.version import Version
 from thinc.api import NumpyOps, CupyOps, Ops, get_ops
 from thinc.api import get_current_ops, use_ops
-from thinc.util import has_torch, torch2xp, xp2torch, torch_version, gpu_is_available
+from thinc.util import torch2xp, xp2torch, gpu_is_available
+from thinc.compat import has_torch, torch_version
 from thinc.api import fix_random_seed
 from thinc.api import LSTM
 from thinc.types import Floats2d

--- a/thinc/tests/layers/test_layers_api.py
+++ b/thinc/tests/layers/test_layers_api.py
@@ -5,7 +5,7 @@ from thinc.api import registry, with_padded, Dropout, NumpyOps, Model
 from thinc.backends import NumpyOps
 from thinc.util import data_validation, get_width
 from thinc.types import Ragged, Padded, Array2d, Floats2d, FloatsXd, Shape
-from thinc.util import has_torch
+from thinc.compat import has_torch
 import numpy
 import pytest
 

--- a/thinc/tests/layers/test_lstm.py
+++ b/thinc/tests/layers/test_lstm.py
@@ -2,7 +2,7 @@ import numpy
 import timeit
 from thinc.api import NumpyOps, LSTM, PyTorchLSTM, with_padded, fix_random_seed
 from thinc.api import Ops
-from thinc.util import has_torch
+from thinc.compat import has_torch
 import pytest
 
 

--- a/thinc/tests/layers/test_mnist.py
+++ b/thinc/tests/layers/test_mnist.py
@@ -1,13 +1,14 @@
 import pytest
 from thinc.api import Relu, Softmax, chain, clone, Adam
 from thinc.api import PyTorchWrapper, TensorFlowWrapper
-from thinc.util import has_torch, has_tensorflow
+from thinc.compat import has_torch, has_tensorflow
 
 
 @pytest.fixture(scope="module")
 def mnist(limit=5000):
     pytest.importorskip("ml_datasets")
     import ml_datasets
+
     (train_X, train_Y), (dev_X, dev_Y) = ml_datasets.mnist()
     return (train_X[:limit], train_Y[:limit]), (dev_X[:limit], dev_Y[:limit])
 

--- a/thinc/tests/layers/test_mxnet_wrapper.py
+++ b/thinc/tests/layers/test_mxnet_wrapper.py
@@ -5,7 +5,8 @@ import pytest
 from thinc.api import Adam, ArgsKwargs, Model, Ops, MXNetWrapper
 from thinc.api import get_current_ops, mxnet2xp, xp2mxnet
 from thinc.types import Array2d, Array1d, IntsXd
-from thinc.util import has_cupy, has_mxnet, to_categorical
+from thinc.compat import has_cupy, has_mxnet
+from thinc.util import to_categorical
 
 from ..util import check_input_converters, make_tempdir
 

--- a/thinc/tests/layers/test_pytorch_wrapper.py
+++ b/thinc/tests/layers/test_pytorch_wrapper.py
@@ -3,7 +3,7 @@ from thinc.api import xp2torch, torch2xp, ArgsKwargs, use_ops
 from thinc.api import chain, get_current_ops, Relu
 from thinc.backends import context_pools
 from thinc.shims.pytorch_grad_scaler import PyTorchGradScaler
-from thinc.util import has_torch, has_torch_amp, has_torch_gpu
+from thinc.compat import has_torch, has_torch_amp, has_torch_gpu
 import numpy
 import pytest
 

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -2,7 +2,8 @@ import numpy
 import pytest
 from thinc.api import Adam, ArgsKwargs, Linear, Model, TensorFlowWrapper
 from thinc.api import get_current_ops, keras_subclass, tensorflow2xp, xp2tensorflow
-from thinc.util import gpu_is_available, has_tensorflow, to_categorical
+from thinc.util import gpu_is_available, to_categorical
+from thinc.compat import has_tensorflow
 
 from ..util import check_input_converters, make_tempdir
 

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -4,9 +4,10 @@ import threading
 import time
 from thinc.api import Adam, CupyOps, Dropout, Linear, Model, Relu
 from thinc.api import Shim, Softmax, chain, change_attr_values
-from thinc.api import concatenate, has_cupy, set_dropout_rate
+from thinc.api import concatenate, set_dropout_rate
 from thinc.api import use_ops, with_debug, wrap_model_recursive
 from thinc.util import gpu_is_available
+from thinc.compat import has_cupy
 import numpy
 
 from ..util import make_tempdir
@@ -349,10 +350,10 @@ def test_all_operators(op):
             with pytest.raises(TypeError):
                 value = m1 % m2
         if op == "**":
-            value = m1 ** m2
+            value = m1**m2
         else:
             with pytest.raises(TypeError):
-                value = m1 ** m2
+                value = m1**m2
         if op == "<<":
             value = m1 << m2
         else:

--- a/thinc/tests/regression/test_issue564.py
+++ b/thinc/tests/regression/test_issue564.py
@@ -1,7 +1,7 @@
 import pytest
 
 from thinc.api import CupyOps
-from thinc.util import has_torch, has_torch_gpu
+from thinc.compat import has_torch, has_torch_gpu
 
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")

--- a/thinc/tests/shims/test_pytorch_grad_scaler.py
+++ b/thinc/tests/shims/test_pytorch_grad_scaler.py
@@ -2,7 +2,7 @@ import pytest
 
 from hypothesis import given, settings
 from hypothesis.strategies import lists, one_of, tuples
-from thinc.util import has_torch, has_torch_amp, has_torch_gpu
+from thinc.compat import has_torch, has_torch_amp, has_torch_gpu, torch
 from thinc.util import is_torch_array
 from thinc.api import PyTorchGradScaler
 
@@ -10,15 +10,7 @@ from ..strategies import ndarrays
 
 
 def tensors():
-    # This function is not used without Torch + CUDA,
-    # but we have to do some wrapping to avoid import
-    # failures.
-    try:
-        import torch
-
-        return ndarrays().map(lambda a: torch.tensor(a).cuda())
-    except ImportError:
-        pass
+    return ndarrays().map(lambda a: torch.tensor(a).cuda())
 
 
 @pytest.mark.skipif(not has_torch, reason="needs PyTorch")
@@ -97,6 +89,7 @@ def test_grad_scaler():
 )
 def test_raises_on_old_pytorch():
     import torch
+
     scaler = PyTorchGradScaler(enabled=True)
     with pytest.raises(ValueError, match=r"not supported.*1.9.0"):
         scaler.scale([torch.tensor([1.0], device="cpu")])

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -4,12 +4,11 @@ from typing import Optional, List, overload
 from dataclasses import dataclass
 import numpy
 import sys
+from .compat import has_cupy, cupy
 
-try:
-    import cupy
-
+if has_cupy:
     get_array_module = cupy.get_array_module
-except (ImportError, AttributeError):
+else:
     get_array_module = lambda obj: numpy
 
 # Use typing_extensions for Python versions < 3.8

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -123,9 +123,10 @@ def to_numpy(data):  # pragma: no cover
         return numpy.array(data)
 
 
-def set_active_gpu(gpu_id: int) -> "cupy.cuda.Device":  # pragma: no cover
+def set_active_gpu(gpu_id: int) -> Optional["cupy.cuda.Device"]:  # pragma: no cover
     """Set the current GPU device for cupy and torch (if available)."""
-    import cupy.cuda.device
+    if not gpu_is_available():
+        return None
 
     device = cupy.cuda.device.Device(gpu_id)
     device.use()
@@ -162,8 +163,8 @@ def prefer_gpu(gpu_id: int = 0) -> bool:  # pragma: no cover
 def require_gpu(gpu_id: int = 0) -> bool:  # pragma: no cover
     from .backends import set_current_ops, CupyOps
 
-    if CupyOps.xp is None:
-        raise ValueError("GPU is not accessible. Was the library installed correctly?")
+    if not gpu_is_available():
+        raise ValueError("No GPU devices detected")
 
     set_current_ops(CupyOps())
     set_active_gpu(gpu_id)

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -123,10 +123,10 @@ def to_numpy(data):  # pragma: no cover
         return numpy.array(data)
 
 
-def set_active_gpu(gpu_id: int) -> Optional["cupy.cuda.Device"]:  # pragma: no cover
+def set_active_gpu(gpu_id: int) -> "cupy.cuda.Device":  # pragma: no cover
     """Set the current GPU device for cupy and torch (if available)."""
     if not gpu_is_available():
-        return None
+        raise ValueError("No GPU devices detected")
 
     device = cupy.cuda.device.Device(gpu_id)
     device.use()

--- a/website/docs/api-util.md
+++ b/website/docs/api-util.md
@@ -20,9 +20,9 @@ fix_random_seed(0)
 
 ### require_cpu {#require_cpu tag="function"}
 
-Allocate data and perform operations on CPU. 
-If data has already been allocated on GPU, it will not be moved.
-Ideally, this function should be called right after importing Thinc.
+Allocate data and perform operations on CPU. If data has already been allocated
+on GPU, it will not be moved. Ideally, this function should be called right
+after importing Thinc.
 
 ```python
 ### Example
@@ -69,7 +69,8 @@ require_gpu()
 
 ### set_active_gpu {#set_active_gpu tag="function"}
 
-Set the current GPU device for `cupy` and `torch` (if available).
+Set the current GPU device for `cupy` and `torch` and returns a `cupy` device,
+if available. Returns `None` otherwise.
 
 ```python
 ### Example
@@ -77,10 +78,10 @@ from thinc.api import set_active_gpu
 set_active_gpu(0)
 ```
 
-| Argument    | Type                      | Description             |
-| ----------- | ------------------------- | ----------------------- |
-| `gpu_id`    | <tt>int</tt>              | Device index to select. |
-| **RETURNS** | <tt>cupy.cuda.Device</tt> | The device.             |
+| Argument    | Type                                | Description             |
+| ----------- | ----------------------------------- | ----------------------- |
+| `gpu_id`    | <tt>int</tt>                        | Device index to select. |
+| **RETURNS** | <tt>Optional[cupy.cuda.Device]</tt> | The device.             |
 
 ### use_pytorch_for_gpu_memory {#use_pytorch_for_gpu_memory tag="function"}
 
@@ -162,10 +163,10 @@ Convert a PyTorch tensor to a `numpy` or `cupy` tensor.
 Convert a `numpy` or `cupy` tensor to a TensorFlow tensor.
 
 | Argument        | Type                       | Description                                           |
-| --------------- | -------------------------- | ----------------------------------------------------- |
+| --------------- | -------------------------- | ----------------------------------------------------- | --- |
 | `xp_tensor`     | <tt>ArrayXd</tt>           | The tensor to convert.                                |
 | `requires_grad` | <tt>bool</tt>              | Whether to backpropagate through the variable.        |
-| `as_variable`   | <tt>bool</tt>              | Convert the result to a `tensorflow.Variable` object. |  |
+| `as_variable`   | <tt>bool</tt>              | Convert the result to a `tensorflow.Variable` object. |     |
 | **RETURNS**     | <tt>tensorflow.Tensor</tt> | The converted tensor.                                 |
 
 ### tensorflow2xp {#tensorflow2xp tag="function"}

--- a/website/docs/api-util.md
+++ b/website/docs/api-util.md
@@ -163,10 +163,10 @@ Convert a PyTorch tensor to a `numpy` or `cupy` tensor.
 Convert a `numpy` or `cupy` tensor to a TensorFlow tensor.
 
 | Argument        | Type                       | Description                                           |
-| --------------- | -------------------------- | ----------------------------------------------------- | --- |
+| --------------- | -------------------------- | ----------------------------------------------------- |
 | `xp_tensor`     | <tt>ArrayXd</tt>           | The tensor to convert.                                |
 | `requires_grad` | <tt>bool</tt>              | Whether to backpropagate through the variable.        |
-| `as_variable`   | <tt>bool</tt>              | Convert the result to a `tensorflow.Variable` object. |     |
+| `as_variable`   | <tt>bool</tt>              | Convert the result to a `tensorflow.Variable` object. |
 | **RETURNS**     | <tt>tensorflow.Tensor</tt> | The converted tensor.                                 |
 
 ### tensorflow2xp {#tensorflow2xp tag="function"}

--- a/website/docs/api-util.md
+++ b/website/docs/api-util.md
@@ -69,8 +69,8 @@ require_gpu()
 
 ### set_active_gpu {#set_active_gpu tag="function"}
 
-Set the current GPU device for `cupy` and `torch` and returns a `cupy` device,
-if available. Returns `None` otherwise.
+Set the current GPU device for `cupy` (and for `torch`, if installed) and return
+a `cupy` device. Will raise an error if no GPU is available.
 
 ```python
 ### Example
@@ -78,10 +78,10 @@ from thinc.api import set_active_gpu
 set_active_gpu(0)
 ```
 
-| Argument    | Type                                | Description             |
-| ----------- | ----------------------------------- | ----------------------- |
-| `gpu_id`    | <tt>int</tt>                        | Device index to select. |
-| **RETURNS** | <tt>Optional[cupy.cuda.Device]</tt> | The device.             |
+| Argument    | Type                      | Description             |
+| ----------- | ------------------------- | ----------------------- |
+| `gpu_id`    | <tt>int</tt>              | Device index to select. |
+| **RETURNS** | <tt>cupy.cuda.Device</tt> | The device.             |
 
 ### use_pytorch_for_gpu_memory {#use_pytorch_for_gpu_memory tag="function"}
 


### PR DESCRIPTION
There are multiple places in the codebase where we attempt to import libraries inside `try...expect` clauses to safely determine their availability. This PR is primarily meant to replace the individual imports with code that calls into a central `compat` module that maintains the imports for all optional libraries.

Additional changes:
* Removal of the `has_cupy` exports from the `cupy_ops`~, `backends` and `api` modules (these were not explicitly exposed to the public API but used internally)~.
* Handle the deprecation of `cupy.fromDlpack` in `cupy >= 10.0.0`.
* ~`util.set_active_gpu` returns `None` when `cupy`/GPU support is unavailable. Prior to this change, the function could potentially raise an unhandled exception if the `cupy` library was not installed.~ `util.set_active_gpu` now raises an exception if no GPU support is detected.