### PR TITLE
Tests: Correctly handle GPU-resident Tensorflow tensors

### DIFF
--- a/thinc/tests/util.py
+++ b/thinc/tests/util.py
@@ -5,6 +5,7 @@ import shutil
 from thinc.api import Linear, Ragged, Padded, ArgsKwargs
 import numpy
 import pytest
+from thinc.util import has_cupy
 
 
 @contextlib.contextmanager
@@ -95,18 +96,29 @@ def check_input_converters(Y, backprop, data, n_args, kwargs_keys, type_):
     assert all(isinstance(arg, type_) for arg in Y.args)
     assert all(isinstance(arg, type_) for arg in Y.kwargs.values())
     dX = backprop(Y)
+
+    def is_supported_backend_array(arr):
+        if has_cupy:
+            import cupy
+
+            return isinstance(arr, cupy.ndarray) or isinstance(arr, numpy.ndarray)
+        else:
+            return isinstance(arr, numpy.ndarray)
+
     input_type = type(data) if not isinstance(data, list) else tuple
-    assert isinstance(dX, input_type)
+    assert isinstance(dX, input_type) or is_supported_backend_array(dX)
+
     if isinstance(data, dict):
         assert list(dX.keys()) == kwargs_keys
-        assert all(isinstance(arr, numpy.ndarray) for arr in dX.values())
+        assert all(is_supported_backend_array(arr) for arr in dX.values())
     elif isinstance(data, (list, tuple)):
         assert isinstance(dX, tuple)
-        assert all(isinstance(arr, numpy.ndarray) for arr in dX)
+        assert all(is_supported_backend_array(arr) for arr in dX)
     elif isinstance(data, ArgsKwargs):
         assert len(dX.args) == n_args
         assert list(dX.kwargs.keys()) == kwargs_keys
-        assert all(isinstance(arg, numpy.ndarray) for arg in dX.args)
-        assert all(isinstance(arg, numpy.ndarray) for arg in dX.kwargs.values())
+
+        assert all(is_supported_backend_array(arg) for arg in dX.args)
+        assert all(is_supported_backend_array(arg) for arg in dX.kwargs.values())
     elif not isinstance(data, numpy.ndarray):
         pytest.fail(f"Bad data type: {dX}")


### PR DESCRIPTION
Tensorflow automatically allocates on the GPU if possible, which is something the tests below didn't correctly account for. Since the CI host machine's CUDA libraries were not correctly configured, TF silently always used the CPU thereby hiding this bug.