### PR TITLE
Fix model.copy() bug where layer used more than once

### DIFF
--- a/thinc/model.py
+++ b/thinc/model.py
@@ -462,9 +462,11 @@ class Model(Generic[InT, OutT]):
         layers will also be deep-copied. The copy will receive a distinct `model.id`
         value.
         """
-        return self._copy({})
+        return self._copy()
 
-    def _copy(self: SelfT, seen: Dict[int, Union["Model", Shim]]) -> SelfT:
+    def _copy(self: SelfT, seen: Optional[Dict[int, Union["Model", Shim]]] = None) -> SelfT:
+        if seen is None:
+            seen = {}
         params = {}
         for name in self.param_names:
             params[name] = self.get_param(name) if self.has_param(name) else None

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -617,9 +617,40 @@ def test_walk_bfs_post_order_fails():
 
 
 def test_model_copy_with_loop():
+    class MyShim(Shim):
+        name = "testshim"
+
+        def to_bytes(self):
+            return test_replace_node_with_indirect_node_ref
+
+        def from_bytes(self, bytes):
+            pass
+
+    model_a = create_model("a")
+    working_shim = MyShim(None)
+    layer = Model(
+        "test",
+        lambda X: (X, lambda dY: dY),
+        dims={"nI": 5, "nO": 5},
+        params={"W": numpy.zeros((10,)), "b": None},
+        refs={"a": model_a, "b": None},
+        attrs={"foo": "bar"},
+        shims=[working_shim],
+        layers=[model_a, model_a],
+    )
+    layer2 = Model(
+        "test2",
+        lambda X: (X, lambda dY: dY),
+        dims={"nI": 5, "nO": 5},
+        params={"W": numpy.zeros((10,)), "b": None},
+        refs={"a": model_a, "b": None},
+        attrs={"foo": "bar"},
+        shims=[working_shim],
+        layers=[model_a, model_a],
+    )
     relu = Relu(5)
-    relu2 = Relu(5)
-    model = chain(relu, relu2, relu)
+    model = chain(layer, relu, layer, layer2)
     model2 = model.copy()
     model.from_dict(model2.to_dict())
-    assert model.name == "relu>>relu>>relu"
+    assert model2.name == "test>>relu>>test>>test2"
+    assert id(model2.layers[0].shims[0]) == id(model2.layers[3].shims[0])

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -653,4 +653,5 @@ def test_model_copy_with_loop():
     model2 = model.copy()
     model.from_dict(model2.to_dict())
     assert model2.name == "test>>relu>>test>>test2"
+    assert model2.layers[0] == model2.layers[2]
     assert id(model2.layers[0].shims[0]) == id(model2.layers[3].shims[0])

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -349,10 +349,10 @@ def test_all_operators(op):
             with pytest.raises(TypeError):
                 value = m1 % m2
         if op == "**":
-            value = m1 ** m2
+            value = m1**m2
         else:
             with pytest.raises(TypeError):
-                value = m1 ** m2
+                value = m1**m2
         if op == "<<":
             value = m1 << m2
         else:
@@ -614,3 +614,12 @@ def test_walk_bfs_post_order_fails():
     relu = Relu(5)
     with pytest.raises(ValueError, match="Invalid order"):
         relu.walk(order="dfs_post_order")
+
+
+def test_model_copy_with_loop():
+    relu = Relu(5)
+    relu2 = Relu(5)
+    model = chain(relu, relu2, relu)
+    model2 = model.copy()
+    model.from_dict(model2.to_dict())
+    assert model.name == "relu>>relu>>relu"


### PR DESCRIPTION
In the preexisting version of Thinc, `model.copy()` generated separate copies of layers and shims that were used at more than one place in the model structure. This led to inconsistencies e.g. between the outputs of `to_dict()` for the original and the copied models.

This PR creates model copies that preserve object identity between layers.