### PR TITLE
Fix to make 8.0.x pass tests

### DIFF
--- a/thinc/util.py
+++ b/thinc/util.py
@@ -38,6 +38,7 @@ try:  # pragma: no cover
         and not torch.cuda.amp.common.amp_definitely_not_available()
     )
 except ImportError:  # pragma: no cover
+    torch = None
     has_torch = False
     has_torch_gpu = False
     has_torch_amp = False


### PR DESCRIPTION
Otherwise `is_torch_array` does not function correctly.