### PR TITLE
Set version to v8.1.0.dev0

### DIFF
--- a/thinc/about.py
+++ b/thinc/about.py
@@ -1,2 +1,2 @@
-__version__ = "8.0.15"
+__version__ = "v8.1.0.dev0"
 __release__ = True


### PR DESCRIPTION
I thought it would be a good idea to update the version in `master` to 
distinguish it from the v8.0.x branch.
