### PR TITLE
CI: test lower-bound PyTorch version with Python 3.6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
     displayName: 'Install test dependencies'
 
   - script: |
-      pip install "torch==1.5.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch==1.6.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
     displayName: 'Install PyTorch (lower bound)'
     condition: eq(variables['python.version'], '3.6')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,24 +22,31 @@ jobs:
       Python36Windows:
         imageName: 'windows-2019'
         python.version: '3.6'
+        torchCpuSuffix: '+cpu'
       Python37Mac:
         imageName: 'macos-10.15'
         python.version: '3.7'
+        torchCpuSuffix: ''
       Python38Linux:
         imageName: 'ubuntu-latest'
         python.version: '3.8'
+        torchCpuSuffix: '+cpu'
       Python39Windows:
         imageName: 'windows-latest'
         python.version: '3.9'
+        torchCpuSuffix: '+cpu'
       Python310Linux:
         imageName: 'ubuntu-latest'
         python.version: '3.10'
+        torchCpuSuffix: '+cpu'
       Python310Windows:
         imageName: 'windows-latest'
         python.version: '3.10'
+        torchCpuSuffix: '+cpu'
       Python310Mac:
         imageName: 'macos-latest'
         python.version: '3.10'
+        torchCpuSuffix: ''
     maxParallel: 4
   pool:
     vmImage: $(imageName)
@@ -94,7 +101,7 @@ jobs:
     condition: eq(variables['python.version'], '3.6')
 
   - script: |
-      pip install "torch==1.11.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install "torch==1.11.0$(torchCpuSuffix)" -f https://download.pytorch.org/whl/torch_stable.html
     displayName: 'Install PyTorch'
     condition: ne(variables['python.version'], '3.6')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,10 +84,19 @@ jobs:
       pip install -r requirements.txt
       pip install "tensorflow~=2.5.0"
       pip install "mxnet; sys_platform != 'win32'"
-      pip install "torch==1.9.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
     displayName: 'Install test dependencies'
+
+  - script: |
+      pip install "torch==1.5.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
+    displayName: 'Install PyTorch (lower bound)'
+    condition: eq(variables['python.version'], '3.6')
+
+  - script: |
+      pip install "torch==1.11.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
+    displayName: 'Install PyTorch'
+    condition: ne(variables['python.version'], '3.6')
 
   - script: |
       python -m pytest --pyargs thinc --cov=thinc --cov-report=term


### PR DESCRIPTION
Also use PyTorch 1.11.0 for other PyTorch versions.
