### PR TITLE
Backport #663 to v8.0.x

### DIFF
--- a/thinc/tests/layers/test_pytorch_wrapper.py
+++ b/thinc/tests/layers/test_pytorch_wrapper.py
@@ -4,6 +4,7 @@ from thinc.api import chain, get_current_ops, Relu
 from thinc.backends import context_pools
 from thinc.shims.pytorch_grad_scaler import PyTorchGradScaler
 from thinc.util import has_torch, has_torch_amp, has_torch_gpu
+from thinc.util import has_cupy
 import numpy
 import pytest
 
@@ -63,7 +64,7 @@ def test_pytorch_wrapper(nN, nI, nO):
     assert isinstance(model.predict(X), numpy.ndarray)
 
 
-@pytest.mark.skipif(not has_torch_gpu, reason="needs PyTorch with CUDA-capable GPU")
+@pytest.mark.skipif(not has_cupy or not has_torch_gpu, reason="needs PyTorch with CUDA-capable GPU")
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
 @pytest.mark.parametrize("mixed_precision", TORCH_MIXED_PRECISION)
 def test_pytorch_wrapper_thinc_input(nN, nI, nO, mixed_precision):


### PR DESCRIPTION
Backport #663 to v8.0.x:

This test checked whether the allocator was set to the PyTorch allocator
when the PyTorch shim is used. However, this is not the case when
PyTorch is installed, but CuPy isn't, so the test would fail. Since this
test relies on CuPy, disable it when CuPy is not available.