### PR TITLE
Fix for `--slow` CI builds failing

### DIFF
--- a/thinc/tests/conftest.py
+++ b/thinc/tests/conftest.py
@@ -2,7 +2,12 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption("--slow", action="store_true", help="include slow tests")
+    try:
+        parser.addoption("--slow", action="store_true", help="include slow tests")
+    # Options are already added, e.g. if conftest is copied in a build pipeline
+    # and runs twice
+    except ValueError:
+        pass
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
Ported from [spacy's `conftest.py`](https://github.com/explosion/spaCy/blob/357be2614effdfdff858eca0eb5f17e167ceb265/spacy/tests/conftest.py#L5).