### PR TITLE
Fixes for slow tests

### DIFF
--- a/thinc/compat.py
+++ b/thinc/compat.py
@@ -38,7 +38,7 @@ try:  # pragma: no cover
         and not torch.cuda.amp.common.amp_definitely_not_available()
     )
 except ImportError:  # pragma: no cover
-    torch = None
+    torch = None  # type: ignore
     has_torch = False
     has_torch_gpu = False
     has_torch_amp = False

--- a/thinc/tests/layers/test_basic_tagger.py
+++ b/thinc/tests/layers/test_basic_tagger.py
@@ -8,13 +8,14 @@ from thinc.api import chain, with_array, Adam, strings2arrays
 def ancora():
     pytest.importorskip("ml_datasets")
     import ml_datasets
+
     return ml_datasets.ud_ancora_pos_tags()
 
 
 def create_embed_relu_relu_softmax(depth, width, vector_length):
     with Model.define_operators({">>": chain}):
         model = strings2arrays() >> with_array(
-            HashEmbed(width, vector_length)
+            HashEmbed(width, vector_length, column=0)
             >> expand_window(window_size=1)
             >> Relu(width, width * 3)
             >> Relu(width, width)

--- a/thinc/tests/layers/test_mnist.py
+++ b/thinc/tests/layers/test_mnist.py
@@ -1,6 +1,7 @@
 import pytest
 from thinc.api import Relu, Softmax, chain, clone, Adam
 from thinc.api import PyTorchWrapper, TensorFlowWrapper
+from thinc.api import get_current_ops
 from thinc.compat import has_torch, has_tensorflow
 
 
@@ -80,9 +81,14 @@ def test_small_end_to_end(width, nb_epoch, min_score, create_model, mnist):
     optimizer = Adam(0.001)
     losses = []
     scores = []
+    ops = get_current_ops()
+
     for i in range(nb_epoch):
         for X, Y in model.ops.multibatch(batch_size, train_X, train_Y, shuffle=True):
             Yh, backprop = model.begin_update(X)
+            # Ensure that the tensor is type-compatible with the current backend.
+            Yh = ops.asarray(Yh)
+
             backprop(Yh - Y)
             model.finish_update(optimizer)
             losses.append(((Yh - Y) ** 2).sum())
@@ -90,6 +96,8 @@ def test_small_end_to_end(width, nb_epoch, min_score, create_model, mnist):
         total = 0
         for X, Y in model.ops.multibatch(batch_size, dev_X, dev_Y):
             Yh = model.predict(X)
+            Yh = ops.asarray(Yh)
+
             correct += (Yh.argmax(axis=1) == Y.argmax(axis=1)).sum()
             total += Yh.shape[0]
         score = correct / total

--- a/thinc/tests/regression/issue519/program.py
+++ b/thinc/tests/regression/issue519/program.py
@@ -5,16 +5,12 @@ from thinc.types import Floats2d
 n_hidden = 32
 dropout = 0.2
 
-model1 = chain(
-    Relu(nO=n_hidden, dropout=dropout),
-    Relu(nO=n_hidden, dropout=dropout),
-    Softmax()
+model1: Model[Floats2d, Floats2d] = chain(
+    Relu(nO=n_hidden, dropout=dropout), Relu(nO=n_hidden, dropout=dropout), Softmax()
 )
 
-model2 = chain(
-    Relu(nO=n_hidden, dropout=dropout),
-    Relu(nO=n_hidden, dropout=dropout),
-    Softmax()
+model2: Model[Floats2d, Floats2d] = chain(
+    Relu(nO=n_hidden, dropout=dropout), Relu(nO=n_hidden, dropout=dropout), Softmax()
 )
 
 model3: Model[Floats2d, Floats2d] = concatenate(*[model1, model2])

--- a/thinc/tests/regression/issue519/test_issue519.py
+++ b/thinc/tests/regression/issue519/test_issue519.py
@@ -1,4 +1,6 @@
 import subprocess
+import sys
+
 try:
     import importlib.resources as importlib_resources
 except ImportError:
@@ -16,10 +18,12 @@ def test_issue519():
     This test can take up to 45 seconds, and is thus marked as slow.
     """
     # Determine the name of the parent module (which contains the test program)
-    parent_module_name = __name__[:__name__.rfind(".")]
+    parent_module_name = __name__[: __name__.rfind(".")]
 
     # Load test program that calls a Thinc API with variadic arguments
     program_text = importlib_resources.read_text(parent_module_name, "program.py")
 
     # Ask Mypy to type-check the loaded program text
-    subprocess.run(["mypy", "--command", program_text], check=True)
+    subprocess.run(
+        [sys.executable, "-m", "mypy", "--command", program_text], check=True
+    )


### PR DESCRIPTION
Will leave this in draft mode until `explosionbot` is updated to support the Buildkite thinc slow test suite. 

### Requirements
* explosion/explosion-bot#3
* #672