### PR TITLE
Prevent test failures on Azure CI hosts running Windows

### DIFF
--- a/thinc/tests/layers/test_uniqued.py
+++ b/thinc/tests/layers/test_uniqued.py
@@ -3,7 +3,7 @@ import numpy
 from thinc.layers import Embed
 from thinc.layers.uniqued import uniqued
 from numpy.testing import assert_allclose
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import integers, lists, composite
 
 ROWS = 10
@@ -46,6 +46,7 @@ def test_uniqued_calls_init():
 
 
 @given(X=lists_of_integers(lo=0, hi=ROWS - 1))
+@settings(deadline=None)
 def test_uniqued_doesnt_change_result(model, X):
     umodel = uniqued(model, column=model.attrs["column"]).initialize()
     Y, bp_Y = model(X, is_train=True)


### PR DESCRIPTION
By default, `pytest` fails when it encounters unexpected variability in test execution times between consecutive runs (with different parameters, etc). This was leading to occasional build failures on Windows hosts.  
 
The actual cause for this variability (specifically on Windows) is currently unknown, partly owing to the lack of options when it comes to debugging such non-deterministic issues on the remote machine. 