### PR TITLE
Add `test_slow_gpu` explosion-bot command

### DIFF
--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -23,5 +23,5 @@ jobs:
         env:
           INPUT_TOKEN: ${{ secrets.EXPLOSIONBOT_TOKEN }}
           INPUT_BK_TOKEN: ${{ secrets.BUILDKITE_SECRET }}
-          ENABLED_COMMANDS: "test_gpu,test_slow"
+          ENABLED_COMMANDS: "test_gpu,test_slow,test_slow_gpu"
           ALLOWED_TEAMS: "spacy-maintainers"


### PR DESCRIPTION
Enables support for the [`test_slow_gpu` explosion-bot command](https://github.com/explosion/explosion-bot/pull/4).