### PR TITLE
Speed up HashEmbed layer by avoiding large temporary arrays

### DIFF
--- a/thinc/backends/_custom_kernels.cu
+++ b/thinc/backends/_custom_kernels.cu
@@ -22,6 +22,26 @@ struct Constants<float> {
 };
 
 
+template <typename U>
+__global__ void gather_add(U* out_bo, const U* table_to, const int* indices_bk,
+        int T, int O, int B, int K)
+{
+    int _loop_start = blockIdx.x * blockDim.x + threadIdx.x;
+    int _loop_stride = blockDim.x * gridDim.x;
+
+    for (int b = _loop_start; b < B; b += _loop_stride) {
+        for (int k = 0; k < K; ++k) {
+            int idx = indices_bk[b * K + k];
+            const U* table = table_to + idx * O;
+            U* out = out_bo + b * O;
+            for (int o = 0; o < O; ++o) {
+                out[o] += table[o];
+            }
+        }
+    }
+}
+
+
 template <typename T>
 __global__ void seq2col(T* output, const T* X, const int* lengths,
         int nW, int B, int I, int nL)

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -170,6 +170,10 @@ def clipped_linear(
 
 
 def gather_add(table, indices, *, threads_per_block=128, num_blocks=128):
+    if table.ndim != 2:
+        raise ValueError(f"gather_add expects table with dimensionality 2, was: {table.ndim}")
+    if indices.ndim != 2:
+        raise ValueError(f"gather_add expects indices with dimensionality 2, was: {indices.ndim}")
     _is_float_array(table)
     indices = indices.astype("int32")
     _check_indices(indices, table.shape[0])

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -32,6 +32,8 @@ KERNELS_LIST = [
     "backprop_swish<float>",
     "clipped_linear<double>",
     "clipped_linear<float>",
+    "gather_add<double>",
+    "gather_add<float>",
     "gelu<double>",
     "gelu<float>",
     "maxout<double>",
@@ -76,6 +78,8 @@ MMH_SRC = (PWD / "_murmur3.cu").read_text(encoding="utf8")
 
 clipped_linear_kernel_float = _get_kernel("clipped_linear<float>")
 clipped_linear_kernel_double = _get_kernel("clipped_linear<double>")
+gather_add_kernel_float = _get_kernel("gather_add<float>")
+gather_add_kernel_double = _get_kernel("gather_add<double>")
 gelu_kernel_float = _get_kernel("gelu<float>")
 gelu_kernel_double = _get_kernel("gelu<double>")
 hash_data_kernel = compile_mmh(MMH_SRC)
@@ -161,6 +165,28 @@ def clipped_linear(
             (num_blocks,),
             (threads_per_block,),
             (out, X, slope, offset, min_val, max_val, X.size),
+        )
+    return out
+
+
+def gather_add(table, indices, *, threads_per_block=128, num_blocks=128):
+    _is_float_array(table)
+    indices = indices.astype("int32")
+    _check_indices(indices, table.shape[0])
+
+    B = indices.shape[0]
+    K = indices.shape[1]
+    T = table.shape[0]
+    O = table.shape[1]
+
+    out = _alloc((B, O), dtype=table.dtype, zeros=True)
+    if table.dtype == "float32":
+        gather_add_kernel_float(
+            (num_blocks,), (threads_per_block,), (out, table, indices, T, O, B, K)
+        )
+    else:
+        gather_add_kernel_double(
+            (num_blocks,), (threads_per_block,), (out, table, indices, T, O, B, K)
         )
     return out
 
@@ -645,6 +671,13 @@ def _check_lengths(lengths, n_elems: int, *, min_length=0):
         raise ValueError(f"all sequence lengths must be >= {min_length}")
     if cupy.sum(lengths) != n_elems:
         raise IndexError("lengths must sum up to the batch size")
+
+
+def _check_indices(indices, n: int):
+    assert indices.dtype == "int32", "indices should be encoded as 32-bit integers"
+
+    if not _values_within_range(indices, 0, n):
+        raise IndexError(f"index out of bounds, must be >= 0 && < {n}")
 
 
 def _check_which_maxout(which, B: int, I: int, P: int):

--- a/thinc/backends/cblas.pxd
+++ b/thinc/backends/cblas.pxd
@@ -10,6 +10,10 @@ ctypedef void (*saxpy_ptr)(int N, float alpha, const float* X, int incX,
                            float *Y, int incY) nogil
 
 
+ctypedef void (*daxpy_ptr)(int N, double alpha, const double* X, int incX,
+                           double *Y, int incY) nogil
+
+
 # Forward-declaration of the BlasFuncs struct. This struct must be opaque, so
 # that consumers of the CBlas class cannot become dependent on its size or
 # ordering.
@@ -18,7 +22,9 @@ cdef struct BlasFuncs
 
 cdef class CBlas:
     cdef shared_ptr[BlasFuncs] ptr
+    cdef daxpy_ptr daxpy(self) nogil
     cdef saxpy_ptr saxpy(self) nogil
     cdef sgemm_ptr sgemm(self) nogil
+    cdef void set_daxpy(self, daxpy_ptr daxpy) nogil
     cdef void set_saxpy(self, saxpy_ptr saxpy) nogil
     cdef void set_sgemm(self, sgemm_ptr sgemm) nogil

--- a/thinc/backends/cblas.pyx
+++ b/thinc/backends/cblas.pyx
@@ -4,6 +4,7 @@ from libcpp.memory cimport make_shared
 
 
 cdef struct BlasFuncs:
+    daxpy_ptr daxpy
     saxpy_ptr saxpy
     sgemm_ptr sgemm
 
@@ -15,15 +16,22 @@ cdef class CBlas:
         """Construct a CBlas instance set to use BLIS implementations of the
            supported BLAS functions."""
         cdef BlasFuncs funcs
+        funcs.daxpy = blis.cy.daxpy
         funcs.saxpy = blis.cy.saxpy
         funcs.sgemm = blis.cy.sgemm
         self.ptr = make_shared[BlasFuncs](funcs)
+
+    cdef daxpy_ptr daxpy(self) nogil:
+        return deref(self.ptr).daxpy
 
     cdef saxpy_ptr saxpy(self) nogil:
         return deref(self.ptr).saxpy
 
     cdef sgemm_ptr sgemm(self) nogil:
         return deref(self.ptr).sgemm
+
+    cdef void set_daxpy(self, daxpy_ptr daxpy) nogil:
+        deref(self.ptr).daxpy = daxpy
 
     cdef void set_saxpy(self, saxpy_ptr saxpy) nogil:
         deref(self.ptr).saxpy = saxpy

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 // Ideally we'd use an alias declaration for a generic definition of
-// *axpy. But Cython does support alias declarations yet:
+// *axpy. But Cython doesn't support alias declarations yet:
 //
 // https://github.com/cython/cython/issues/3272
 //

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -9,6 +9,9 @@
 #include <type_traits>
 
 
+typedef void (*saxpy_ptr)(int N, float alpha, const float* X, int incX,
+                          float *Y, int incY);
+
 // All elementwise functions, such as most activations, work in-place.
 
 template <typename A, typename L>
@@ -394,5 +397,21 @@ void backprop_seq2col(A* d_seqs, const A* d_cols, const L* lengths, L B, L I, L 
         seq_start += lengths[i];
     }
 }
+
+
+template <typename I, typename L>
+void cpu_gather_add(saxpy_ptr saxpy, float* out_bo, const float* table_to, const I* indices_bk, L T, L O, L B, L K)
+{
+    for (L b = 0; b < B; ++b) {
+        for (L k = 0; k < K; ++k) {
+            I idx = indices_bk[b * K + k];
+            if (idx > T) {
+                throw std::out_of_range("Embedding index out-of-bounds");
+            }
+            (*saxpy)(O, 1.0, table_to + idx * O, 1, out_bo + b * O, 1);
+        }
+    }
+}
+
 
 #endif // CPU_KERNELS_HH

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -408,7 +408,7 @@ void cpu_gather_add(saxpy_ptr saxpy, float* out_bo, const float* table_to, const
             if (idx > T) {
                 throw std::out_of_range("Embedding index out-of-bounds");
             }
-            (*saxpy)(O, 1.0, table_to + idx * O, 1, out_bo + b * O, 1);
+            saxpy(O, 1.0, table_to + idx * O, 1, out_bo + b * O, 1);
         }
     }
 }

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -14,8 +14,8 @@
 // https://github.com/cython/cython/issues/3272
 //
 // template <typename T>
-// using axpy = void (*)(int N, float alpha, const float* X, int incX,
-//                       float *Y, int incY);
+// using axpy = void (*)(int N, T alpha, const T* X, int incX,
+//                       T *Y, int incY);
 //
 // So, instead we'll do this the pre-C++11 way:
 

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -30,6 +30,12 @@ class CupyOps(Ops):
             data = numpy.asarray(data, dtype=dtype)
         return data
 
+    def gather_add(self, table, indices):
+        if table.dtype in ("float32", "float64"):
+            return _custom_kernels.gather_add(table, indices)
+        else:
+            return super().gather_add(table, indices)
+
     def gelu(self, X, inplace=False):
         if X.dtype in ("float32", "float64"):
             return _custom_kernels.gelu(X, inplace=inplace, threshold=6.0)

--- a/thinc/backends/numpy_ops.pxd
+++ b/thinc/backends/numpy_ops.pxd
@@ -4,6 +4,12 @@ ctypedef double[:, ::1] double2d_t
 ctypedef double[:, :, ::1] double3d_t
 ctypedef float[:, ::1] float2d_t
 ctypedef float[:, :, ::1] float3d_t
+ctypedef int[:, ::1] int2d_t
+ctypedef unsigned int[:, ::1] uint2d_t
+
+cdef fused ints2d_ft:
+    int2d_t
+    uint2d_t
 
 cdef fused reals2d_ft:
     float2d_t

--- a/thinc/backends/numpy_ops.pxd
+++ b/thinc/backends/numpy_ops.pxd
@@ -15,6 +15,9 @@ cdef fused reals3d_ft:
 
 
 cdef extern from "cpu_kernels.hh":
+    cdef cppclass axpy[T]:
+        ctypedef void (*ptr)(int N, T alpha, const T* X, int incX, T *Y, int incY);
+
     void cpu_maxout[A, L](A* best__bo, L* which__bo, const A* cands_bop,
         L B, L O, L P)
     void cpu_backprop_maxout[A, L](A* dX__bop, const A* dX__bo, const L* which__bo,
@@ -37,5 +40,5 @@ cdef extern from "cpu_kernels.hh":
     void cpu_relu[A, L](A* X, L N)
     void backprop_seq2col[A, L](A* d_seqs, const A* d_cols, const L* lengths, L B, L I, L nW, L nL)
     void seq2col[A, L](A* output, const A* X, const L* lengths, L nW, L B, L I, L nL)
-    void cpu_gather_add[I, L](saxpy_ptr saxpy, float* out_bo, const float* table_to, const I* indices_bk,
-                              L T, L O, L B, L K) except +
+    void cpu_gather_add[F, I, L](axpy[F].ptr axpy, F* out_bo, const F* table_to, const I* indices_bk,
+                                 L T, L O, L B, L K) except +

--- a/thinc/backends/numpy_ops.pxd
+++ b/thinc/backends/numpy_ops.pxd
@@ -1,3 +1,5 @@
+from .cblas cimport saxpy_ptr
+
 ctypedef double[:, ::1] double2d_t
 ctypedef double[:, :, ::1] double3d_t
 ctypedef float[:, ::1] float2d_t
@@ -35,3 +37,5 @@ cdef extern from "cpu_kernels.hh":
     void cpu_relu[A, L](A* X, L N)
     void backprop_seq2col[A, L](A* d_seqs, const A* d_cols, const L* lengths, L B, L I, L nW, L nL)
     void seq2col[A, L](A* output, const A* X, const L* lengths, L nW, L B, L I, L nL)
+    void cpu_gather_add[I, L](saxpy_ptr saxpy, float* out_bo, const float* table_to, const I* indices_bk,
+                              L T, L O, L B, L K) except +

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -440,13 +440,21 @@ class NumpyOps(Ops):
 
         return dX
 
-    def gather_add(self, float[:, ::1] table, unsigned int[:, ::1] indices):
+    def gather_add(self, reals2d_ft table, unsigned int[:, ::1] indices):
         cdef CBlas cblas = self.cblas()
         rows = indices.shape[0]
         dims = table.shape[1]
-        cdef np.ndarray output = self.xp.zeros((rows, dims), dtype="float32")
-        cpu_gather_add(cblas.saxpy(), <float *>output.data, &table[0, 0], &indices[0, 0],
-                       table.shape[0], dims, rows, indices.shape[1])
+
+        cdef np.ndarray output
+        if reals2d_ft is float2d_t:
+            output = self.xp.zeros((rows, dims), dtype="float32")
+            cpu_gather_add(cblas.saxpy(), <float *>output.data, &table[0, 0], &indices[0, 0],
+                        table.shape[0], dims, rows, indices.shape[1])
+        else:
+            output = self.xp.zeros((rows, dims), dtype="float64")
+            cpu_gather_add(cblas.daxpy(), <double *>output.data, &table[0, 0], &indices[0, 0],
+                        table.shape[0], dims, rows, indices.shape[1])
+
         return output
 
     def scatter_add(self, np.ndarray table, np.ndarray indices, np.ndarray values):

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -440,6 +440,15 @@ class NumpyOps(Ops):
 
         return dX
 
+    def gather_add(self, float[:, ::1] table, unsigned int[:, ::1] indices):
+        cdef CBlas cblas = self.cblas()
+        rows = indices.shape[0]
+        dims = table.shape[1]
+        cdef np.ndarray output = self.xp.zeros((rows, dims), dtype="float32")
+        cpu_gather_add(cblas.saxpy(), <float *>output.data, &table[0, 0], &indices[0, 0],
+                       table.shape[0], dims, rows, indices.shape[1])
+        return output
+
     def scatter_add(self, np.ndarray table, np.ndarray indices, np.ndarray values):
         if table.dtype == 'float32' \
         and indices.dtype == 'int32' \

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -440,7 +440,7 @@ class NumpyOps(Ops):
 
         return dX
 
-    def gather_add(self, reals2d_ft table, unsigned int[:, ::1] indices):
+    def gather_add(self, reals2d_ft table, ints2d_ft indices):
         cdef CBlas cblas = self.cblas()
         rows = indices.shape[0]
         dims = table.shape[1]

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1254,6 +1254,9 @@ class Ops:
         numpy_ops = NumpyOps()
         return self.asarray2f(numpy_ops.position_encode(N, D, period, out))
 
+    def gather_add(self, table: FloatsXd, indices: IntsXd):
+        return table[indices].sum(axis=1)
+
     def scatter_add(
         self, table: FloatsXd, indices: IntsXd, values: FloatsXd
     ) -> FloatsXd:

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1254,7 +1254,7 @@ class Ops:
         numpy_ops = NumpyOps()
         return self.asarray2f(numpy_ops.position_encode(N, D, period, out))
 
-    def gather_add(self, table: FloatsXd, indices: IntsXd) -> FloatsXd:
+    def gather_add(self, table: Floats2d, indices: Ints2d) -> FloatsXd:
         return table[indices].sum(axis=1)  # type: ignore[call-overload]
 
     def scatter_add(

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1254,8 +1254,8 @@ class Ops:
         numpy_ops = NumpyOps()
         return self.asarray2f(numpy_ops.position_encode(N, D, period, out))
 
-    def gather_add(self, table: Floats2d, indices: Ints2d) -> FloatsXd:
-        return table[indices].sum(axis=1)  # type: ignore[call-overload]
+    def gather_add(self, table: Floats2d, indices: Ints2d) -> Floats2d:
+        return table[indices].sum(axis=1)  # type: ignore[return-value]
 
     def scatter_add(
         self, table: FloatsXd, indices: IntsXd, values: FloatsXd

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1254,8 +1254,8 @@ class Ops:
         numpy_ops = NumpyOps()
         return self.asarray2f(numpy_ops.position_encode(N, D, period, out))
 
-    def gather_add(self, table: FloatsXd, indices: IntsXd):
-        return table[indices].sum(axis=1)
+    def gather_add(self, table: FloatsXd, indices: IntsXd) -> FloatsXd:
+        return table[indices].sum(axis=1)  # type: ignore[call-overload]
 
     def scatter_add(
         self, table: FloatsXd, indices: IntsXd, values: FloatsXd

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -68,7 +68,7 @@ def forward(
         nN = ids.shape[0]
         seed: int = model.attrs["seed"]
         keys = model.ops.hash(ids, seed) % nV
-        output = model.ops.gather_add(vectors, keys)
+        output = cast(Floats2d, model.ops.gather_add(vectors, keys))
         drop_mask = None
         if is_train:
             dropout: Optional[float] = model.attrs.get("dropout_rate")

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -68,7 +68,7 @@ def forward(
         nN = ids.shape[0]
         seed: int = model.attrs["seed"]
         keys = model.ops.hash(ids, seed) % nV
-        output = cast(Floats2d, model.ops.gather_add(vectors, keys))
+        output = model.ops.gather_add(vectors, keys)
         drop_mask = None
         if is_train:
             dropout: Optional[float] = model.attrs.get("dropout_rate")

--- a/thinc/layers/hashembed.py
+++ b/thinc/layers/hashembed.py
@@ -68,7 +68,7 @@ def forward(
         nN = ids.shape[0]
         seed: int = model.attrs["seed"]
         keys = model.ops.hash(ids, seed) % nV
-        output = vectors[keys].sum(axis=1)
+        output = model.ops.gather_add(vectors, keys)
         drop_mask = None
         if is_train:
             dropout: Optional[float] = model.attrs.get("dropout_rate")

--- a/website/docs/api-backends.md
+++ b/website/docs/api-backends.md
@@ -1364,7 +1364,7 @@ Create hashed ngram features.
 | `keys`      | <tt>Ints1d</tt> | The input sequence.                        |
 | **RETURNS** | <tt>Ints1d</tt> | The hashed ngrams.                         |
 
-### Ops.gather_add {#gather_add tag="method"}
+### Ops.gather_add {#gather_add tag="method" new="8.1"}
 
 <inline-list>
 

--- a/website/docs/api-backends.md
+++ b/website/docs/api-backends.md
@@ -1298,8 +1298,8 @@ Backpropagate the `reduce_mean` operation.
 </inline-list>
 
 Perform sequence-wise max pooling for data in the ragged format. Zero-length
-sequences are not allowed. A `ValueError` is raised if any element in
-`lengths` is zero.
+sequences are not allowed. A `ValueError` is raised if any element in `lengths`
+is zero.
 
 | Argument    | Type                             | Description                 |
 | ----------- | -------------------------------- | --------------------------- |
@@ -1363,6 +1363,25 @@ Create hashed ngram features.
 | `n`         | <tt>int</tt>    | The window to calculate each feature over. |
 | `keys`      | <tt>Ints1d</tt> | The input sequence.                        |
 | **RETURNS** | <tt>Ints1d</tt> | The hashed ngrams.                         |
+
+### Ops.gather_add {#gather_add tag="method"}
+
+<inline-list>
+
+- **default:** <i name="yes"></i>
+- **numpy:** <i name="yes"></i>
+- **cupy:** <i name="yes"></i>
+
+</inline-list>
+
+Gather rows from `table` with shape `(T, O)` using array `indices` with shape
+`(B, K)`, then sum the resulting array with shape `(B, K, O)` over the `K` axis.
+
+| Argument    | Type              | Description             |
+| ----------- | ----------------- | ----------------------- |
+| `table`     | <tt>Floats2d</tt> | The array to increment. |
+| `indices`   | <tt>Ints2d</tt>   | The indices to use.     |
+| **RETURNS** | <tt>Floats2d</tt> | The summed rows.        |
 
 ### Ops.scatter_add {#scatter_add tag="method"}
 


### PR DESCRIPTION
The HashEmbed layer sums up keyed embeddings. For instance, a key matrix of the shape (50000, 4) will result in 50,000 embeddings, each computed by summing 4 embeddings. The HashEmbed layer computed the embeddings as follows:

```
vectors[keys].sum(axis=1)
```

where `vectors` is an embedding matrix. However, this way of computing embeddings results in very large allocations. Suppose that `vectors` is (4000, 64). Even though the final embedding matrix is (50000, 64), the first expression will construct a temporary array of shape (50000, 4, 64). The overhead is visible in the profile of tok2vec using Thinc `master`:

<img width="1630" alt="before" src="https://user-images.githubusercontent.com/49398/173344864-8a47fd08-d40c-40a5-b4fe-5ff699a2f194.png">

This change avoids this by introducing a `gather_add` op as a counterpart to `scatter_add`. In this particular example, the `NumpyOps` implementation only allocates the final (50000, 64) array, computing the embeddings in-place using the BLAS saxpy function.

In benchmarks with an M1 Max on de_core_news_lg, this improved processing speed from 40511 WPS to 45591 (12.5% faster). The profile of Thinc using this change shows that far less time is spent in `HashEmbed`:

<img width="1627" alt="after" src="https://user-images.githubusercontent.com/49398/173345099-fbf6aa60-47d9-47d0-8d81-645771ffe1b8.png">

