### PR TITLE
Make `CBlas` methods standalone functions to avoid using vtables

### DIFF
--- a/thinc/backends/cblas.pxd
+++ b/thinc/backends/cblas.pxd
@@ -18,7 +18,13 @@ cdef struct BlasFuncs
 
 cdef class CBlas:
     cdef shared_ptr[BlasFuncs] ptr
-    cdef saxpy_ptr saxpy(self) nogil
-    cdef sgemm_ptr sgemm(self) nogil
-    cdef void set_saxpy(self, saxpy_ptr saxpy) nogil
-    cdef void set_sgemm(self, sgemm_ptr sgemm) nogil
+
+
+# Note: the following functions are intentionally standalone. If we make them
+# methods of CBlas, Cython will generate and use a vtable. This makes it
+# impossible to add new BLAS functions later without breaking the ABI.
+
+cdef saxpy_ptr saxpy(CBlas cblas) nogil
+cdef sgemm_ptr sgemm(CBlas cblas) nogil
+cdef void set_saxpy(CBlas cblas, saxpy_ptr saxpy) nogil
+cdef void set_sgemm(CBlas cblas, sgemm_ptr sgemm) nogil

--- a/thinc/backends/cblas.pxd
+++ b/thinc/backends/cblas.pxd
@@ -23,6 +23,8 @@ cdef class CBlas:
 # Note: the following functions are intentionally standalone. If we make them
 # methods of CBlas, Cython will generate and use a vtable. This makes it
 # impossible to add new BLAS functions later without breaking the ABI.
+#
+# See https://github.com/explosion/thinc/pull/700 for more information.
 
 cdef saxpy_ptr saxpy(CBlas cblas) nogil
 cdef sgemm_ptr sgemm(CBlas cblas) nogil

--- a/thinc/backends/cblas.pyx
+++ b/thinc/backends/cblas.pyx
@@ -19,14 +19,14 @@ cdef class CBlas:
         funcs.sgemm = blis.cy.sgemm
         self.ptr = make_shared[BlasFuncs](funcs)
 
-    cdef saxpy_ptr saxpy(self) nogil:
-        return deref(self.ptr).saxpy
+cdef saxpy_ptr saxpy(CBlas cblas) nogil:
+    return deref(cblas.ptr).saxpy
 
-    cdef sgemm_ptr sgemm(self) nogil:
-        return deref(self.ptr).sgemm
+cdef sgemm_ptr sgemm(CBlas cblas) nogil:
+    return deref(cblas.ptr).sgemm
 
-    cdef void set_saxpy(self, saxpy_ptr saxpy) nogil:
-        deref(self.ptr).saxpy = saxpy
+cdef void set_saxpy(CBlas cblas, saxpy_ptr saxpy) nogil:
+    deref(cblas.ptr).saxpy = saxpy
 
-    cdef void set_sgemm(self, sgemm_ptr sgemm) nogil:
-        deref(self.ptr).sgemm = sgemm
+cdef void set_sgemm(CBlas cblas, sgemm_ptr sgemm) nogil:
+    deref(cblas.ptr).sgemm = sgemm


### PR DESCRIPTION
When testing #696, we found that adding new `CBlas` methods results in an ABI compatibility. This would mean that every time we add a CBlas method, we also have to rebuild spaCy.

The ABI incompatibility occurs because Cython generates a vtable for `cdef` methods, even when the class or its methods are final. This vtable is used by the caller to look up the (address of) the methods. When methods are added, the vtable of the caller is out-of-sync when the calling code is not recompiled.

This change works around this issue by making the methods of `CBlas` standalone functions.

Many thanks to @shadeMe for discussing the solution space.