### PR TITLE
Unroll `argmax` in `maxout` for small sizes of `P`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ MOD_NAMES = [
 ]
 COMPILE_OPTIONS = {
     "msvc": ["/Ox", "/EHsc"],
-    "other": ["-O3", "-Wno-strict-prototypes", "-Wno-unused-function"],
+    "other": ["-O3", "-Wno-strict-prototypes", "-Wno-unused-function", "-std=c++11"],
 }
 COMPILER_DIRECTIVES = {
     "language_level": -3,

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -25,7 +25,7 @@ argmax_result<T, L> argmax(T const *arr, L len)
         "Array should be floating point");
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
-    argmax_result<T, L> r { .max = arr[0], .max_idx = 0 };
+    argmax_result<T, L> r { arr[0],  0 };
 
     for (L i = 1; i < len; ++i) {
         if (arr[i] > r.max) {
@@ -42,7 +42,7 @@ argmax_result<T, L> argmax(T const *arr, L len)
 template <typename T, typename L>
 argmax_result<T, L> argmax(T a) {
     static_assert(std::is_floating_point<T>::value, "Argument should be floating point");
-    argmax_result<T, L> acc { .max = a, .max_idx = 0 };
+    argmax_result<T, L> acc { a, 0 };
     return acc;
 }
 

--- a/thinc/backends/cpu_kernels.hh
+++ b/thinc/backends/cpu_kernels.hh
@@ -11,22 +11,57 @@
 
 // All elementwise functions, such as most activations, work in-place.
 
-template <typename A, typename L>
-L argmax(A* arr, L len)
+
+template <typename T, typename L>
+struct argmax_result {
+    T max;
+    L max_idx;
+};
+
+template <typename T, typename L>
+argmax_result<T, L> argmax(T const *arr, L len)
 {
-    static_assert(std::is_floating_point<A>::value,
+    static_assert(std::is_floating_point<T>::value,
         "Array should be floating point");
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
-    L max = 0;
+    argmax_result<T, L> r { .max = arr[0], .max_idx = 0 };
+
     for (L i = 1; i < len; ++i) {
-        if (arr[i] > arr[max]) {
-            max = i;
+        if (arr[i] > r.max) {
+            r.max = arr[i];
+            r.max_idx = i;
         }
     }
 
-    return max;
+    return r;
 }
+
+// The next two templates define argmax for a fixed number of elements.
+
+template <typename T, typename L>
+argmax_result<T, L> argmax(T a) {
+    static_assert(std::is_floating_point<T>::value, "Argument should be floating point");
+    argmax_result<T, L> acc { .max = a, .max_idx = 0 };
+    return acc;
+}
+
+template<typename T, typename L, typename... Args>
+argmax_result<T, L> argmax(T a, Args... args) {
+    static_assert(std::is_floating_point<T>::value, "Arguments should be floating point");
+
+    auto acc = argmax<T, L>(args...);
+
+    if (acc.max > a) {
+        acc.max_idx += 1;
+    } else {
+        acc.max_idx = 0;
+        acc.max = a;
+    }
+
+    return acc;
+}
+
 
 template <typename A, typename L>
 void vec_add(A* X, const A* Y, A scale, L N)
@@ -46,11 +81,30 @@ void cpu_maxout(A* best__bo, L* which__bo, const A* cands__bop, L B, L O, L P)
         "Array should be floating point");
     static_assert(std::is_integral<L>::value, "Array length should be integral");
 
-    for (int i = 0; i < B * O; ++i) {
-        which__bo[i] = argmax(cands__bop + i * P, P);
-        best__bo[i] = cands__bop[i * P + which__bo[i]];
+    // For small inputs, we use an unrolled argmax.
+    if (P == 2) {
+        for (int i = 0; i < B * O; ++i) {
+            A const *input = cands__bop + i * P;
+            auto r = argmax<A, L>(input[0], input[1]);
+            which__bo[i] = r.max_idx;
+            best__bo[i] = r.max;
+        }
+    } else if (P == 3) {
+        for (int i = 0; i < B * O; ++i) {
+            A const *input = cands__bop + i * P;
+            auto r = argmax<A, L>(input[0], input[1], input[2]);
+            which__bo[i] = r.max_idx;
+            best__bo[i] = r.max;
+        }
+    } else {
+        for (int i = 0; i < B * O; ++i) {
+            auto r = argmax<A, L>(cands__bop + i * P, P);
+            which__bo[i] = r.max_idx;
+            best__bo[i] = r.max;
+        }
     }
 }
+
 
 template <typename A, typename L>
 void cpu_backprop_maxout(A* dX__bop, const A* dX__bo, const L* which__bo,


### PR DESCRIPTION
`maxout` uses the `argmax` function to determine the index of the maximum value of each `P` inputs. `argmax` uses a generic array loop, which impedes speculative execution and could also prevent unrolling of the outer `maxout` loop.

This change unrolls `argmax` with small values of `P` using a variadic template. This leads to a small performance improvement.

Before this change, `maxout` takes ~3.9% of the runtime:

<img width="1206" alt="Screen Shot 2022-06-15 at 16 58 57" src="https://user-images.githubusercontent.com/49398/173871859-fc918963-2a33-45ca-8c3f-25d84dcaeab4.png">

After this change, `maxout` takes ~2.7% of the runtime:

<img width="989" alt="Screen Shot 2022-06-15 at 16 56 33" src="https://user-images.githubusercontent.com/49398/173872011-bcce3e59-90b0-430e-af0c-e062582efdc5.png">

(The unrolled `argmax` function is no longer a separate unit in the profile.)