### PR TITLE
Add `with_signpost_interval` layer

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -40,6 +40,7 @@ from .layers import with_padded, with_list, with_ragged, with_flatten
 from .layers import with_reshape, with_getitem, strings2arrays, list2array
 from .layers import list2ragged, ragged2list, list2padded, padded2list, remap_ids
 from .layers import array_getitem, with_cpu, with_debug, with_nvtx_range
+from .layers import with_signpost_interval
 from .layers import tuplify
 
 from .layers import reduce_first, reduce_last, reduce_max, reduce_mean, reduce_sum

--- a/thinc/compat.py
+++ b/thinc/compat.py
@@ -78,4 +78,13 @@ except ImportError:  # pragma: no cover
     h5py = None
 
 
+try:  # pragma: no cover
+    import os_signpost
+
+    has_os_signpost = True
+except ImportError:
+    os_signpost = None
+    has_os_signpost = False
+
+
 has_gpu = has_cupy_gpu or has_torch_mps_gpu

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -71,6 +71,7 @@ from .with_reshape import with_reshape
 from .with_getitem import with_getitem
 from .with_debug import with_debug
 from .with_nvtx_range import with_nvtx_range
+from .with_signpost_interval import with_signpost_interval
 
 
 __all__ = [
@@ -128,5 +129,6 @@ __all__ = [
     "with_flatten",
     "with_debug",
     "with_nvtx_range",
+    "with_signpost_interval",
     "remap_ids",
 ]

--- a/thinc/layers/with_signpost_interval.py
+++ b/thinc/layers/with_signpost_interval.py
@@ -12,8 +12,8 @@ def with_signpost_interval(
     signposter: "os_signpost.Signposter",
     name: Optional[str] = None,
 ) -> _ModelT:
-    """Wraps any layer and marks the forward and backprop phases using
-    sigpost intervals for macOS Instruments profiling
+    """Wraps any layer and marks the init, forward and backprop phases using
+    signpost intervals for macOS Instruments profiling
 
     By default, the name of the layer is used as the name of the range,
     followed by the name of the pass.

--- a/thinc/layers/with_signpost_interval.py
+++ b/thinc/layers/with_signpost_interval.py
@@ -40,7 +40,8 @@ def with_signpost_interval(
 
     def init(_model: Model, X: Any, Y: Any) -> Model:
         if orig_init is not None:
-            return orig_init(layer, X, Y)
+            with signposter.use_interval(f"{name} init"):
+                return orig_init(layer, X, Y)
         else:
             return layer
 

--- a/thinc/layers/with_signpost_interval.py
+++ b/thinc/layers/with_signpost_interval.py
@@ -29,13 +29,11 @@ def with_signpost_interval(
     orig_init = layer.init
 
     def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
-        with signposter.use_interval(f"{name} forward", f"{name} forward"):
+        with signposter.use_interval(f"{name} forward"):
             layer_Y, layer_callback = orig_forward(model, X, is_train=is_train)
 
         def backprop(dY: Any) -> Any:
-            with signposter.use_interval(
-                f"{name} backprop", f"{name} backprop"
-            ):
+            with signposter.use_interval(f"{name} backprop"):
                 return layer_callback(dY)
 
         return layer_Y, backprop

--- a/thinc/layers/with_signpost_interval.py
+++ b/thinc/layers/with_signpost_interval.py
@@ -1,0 +1,51 @@
+from typing import Optional, Callable, Any, Tuple, TypeVar
+
+from ..compat import has_os_signpost, os_signpost
+from ..model import Model
+
+
+_ModelT = TypeVar("_ModelT", bound=Model)
+
+
+def with_signpost_interval(
+    layer: _ModelT,
+    signposter: "os_signpost.Signposter",
+    name: Optional[str] = None,
+) -> _ModelT:
+    """Wraps any layer and marks the forward and backprop phases using
+    sigpost intervals for macOS Instruments profiling
+
+    By default, the name of the layer is used as the name of the range,
+    followed by the name of the pass.
+    """
+    if not has_os_signpost:
+        raise ValueError(
+            "with_signpost_interval layer requires the 'os_signpost' package"
+        )
+
+    name = layer.name if name is None else name
+
+    orig_forward = layer._func
+    orig_init = layer.init
+
+    def forward(model: Model, X: Any, is_train: bool) -> Tuple[Any, Callable]:
+        with signposter.use_interval(f"{name} forward", f"{name} forward"):
+            layer_Y, layer_callback = orig_forward(model, X, is_train=is_train)
+
+        def backprop(dY: Any) -> Any:
+            with signposter.use_interval(
+                f"{name} backprop", f"{name} backprop"
+            ):
+                return layer_callback(dY)
+
+        return layer_Y, backprop
+
+    def init(_model: Model, X: Any, Y: Any) -> Model:
+        if orig_init is not None:
+            return orig_init(layer, X, Y)
+        else:
+            return layer
+
+    layer.replace_callbacks(forward, init=init)
+
+    return layer

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1531,7 +1531,7 @@ model.initialize()
 https://github.com/explosion/thinc/blob/master/thinc/layers/with_nvtx_range.py
 ```
 
-### with_signpost_interval {#with_signpost_interval tag="function"}
+### with_signpost_interval {#with_signpost_interval tag="function" new="8.1.1"}
 
 <inline-list>
 
@@ -1542,8 +1542,10 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/with_nvtx_range.py
 
 Layer that wraps any layer and marks the init, forward and backprop passes as a
 (macOS) signpost interval. This can be helpful when profiling the performance of
-a layer using macOS Instruments.app. Use of this layer requies that the
-`os-signpost` package is installed.
+a layer using macOS
+[Instruments.app](https://help.apple.com/instruments/mac/current/). Use of this
+layer requires that the
+[`os-signpost`](https://github.com/explosion/os-signpost) package is installed.
 
 ```python
 ### Example

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -835,8 +835,8 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/reduce_last.py
 </inline-list>
 
 Pooling layer that reduces the dimensions of the data by selecting the maximum
-value for each feature. A `ValueError` is raised if any element in `lengths`
-is zero.
+value for each feature. A `ValueError` is raised if any element in `lengths` is
+zero.
 
 | Argument    | Type                             | Description                |
 | ----------- | -------------------------------- | -------------------------- |
@@ -1529,6 +1529,43 @@ model.initialize()
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/with_nvtx_range.py
+```
+
+### with_signpost_interval {#with_signpost_interval tag="function"}
+
+<inline-list>
+
+- **Input:** <tt>Any</tt>
+- **Output:** <tt>Any</tt>
+
+</inline-list>
+
+Layer that wraps any layer and marks the forward and backprop passes as a
+(macOS) signpost interval. This can be helpful when profiling the performance of
+a layer using macOS Instruments.app. Use of this layer requies that the
+`os-signpost` package is installed.
+
+```python
+### Example
+from os_signpost import Signposter
+from thinc.api import Linear, with_signpost_interval
+
+signposter = Signposter("com.example.my_subsystem",
+    Signposter.Category.DynamicTracing)
+
+model = with_nvtx_range(Linear(2, 5), signposter)
+model.initialize()
+```
+
+| Argument     | Type                              | Description                                                                     |
+| ------------ | --------------------------------- | ------------------------------------------------------------------------------- |
+| `layer`      | <tt>Model</tt>                    | The layer to wrap.                                                              |
+| `signposter` | <tt>os_signposter.Signposter</tt> | `Signposter` object to log the interval with.                                   |
+| `name`       | <tt>Optional[str]</tt>            | Optional name for the wrapped layer. Defaults to the name of the wrapped layer. |
+| **RETURNS**  | <tt>Model</tt>                    | The wrapped layer.                                                              |
+
+```python
+https://github.com/explosion/thinc/blob/master/thinc/layers/with_signpost_interval.py
 ```
 
 ---

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1553,7 +1553,7 @@ from thinc.api import Linear, with_signpost_interval
 signposter = Signposter("com.example.my_subsystem",
     Signposter.Category.DynamicTracing)
 
-model = with_nvtx_range(Linear(2, 5), signposter)
+model = with_signpost_interval(Linear(2, 5), signposter)
 model.initialize()
 ```
 

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1540,7 +1540,7 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/with_nvtx_range.py
 
 </inline-list>
 
-Layer that wraps any layer and marks the forward and backprop passes as a
+Layer that wraps any layer and marks the init, forward and backprop passes as a
 (macOS) signpost interval. This can be helpful when profiling the performance of
 a layer using macOS Instruments.app. Use of this layer requies that the
 `os-signpost` package is installed.


### PR DESCRIPTION
This layer wraps a layer, adding macOS interval signposts for the forward and backward pass. These intervals can then be visualized in the macOS Instruments.app timeline (similar to NVTX ranges work).

Example of Thinc layers that are visualized in the Instruments.app timeline:

<img width="1469" alt="Screen Shot 2022-07-01 at 11 00 30" src="https://user-images.githubusercontent.com/49398/176862401-75285eac-43c6-4545-a88c-833d55eccd3d.png">

