### PR TITLE
Fix performance regressions in parser caused by `get_ops`

### DIFF
--- a/thinc/compat.py
+++ b/thinc/compat.py
@@ -77,5 +77,21 @@ try:
 except ImportError:  # pragma: no cover
     h5py = None
 
+try:
+    from thinc_apple_ops import AppleOps
+
+    has_thinc_apple_ops = True
+except ImportError:
+    AppleOps = None
+    has_thinc_apple_ops = False
+
+try:
+    from thinc_bigendian_ops import BigEndianOps
+
+    has_thinc_bigendian_ops = True
+except ImportError:
+    BigEndianOps = None
+    has_thinc_bigendian_ops = False
+
 
 has_gpu = has_cupy_gpu or has_torch_mps_gpu


### PR DESCRIPTION
The `thinc.backends.get_ops` function gets called in the parser model's hotpath to fetch the correct `CBlas` struct (when executing on the GPU/`CupyOps` is used). 

This was problematic for two reasons:

- Firstly, the function [attempts to import a couple of external packages](https://github.com/explosion/thinc/blob/c7b0d6759645babe94315a36c84d56ec877252f2/thinc/backends/__init__.py#L79) (which adds a lot of overhead when the package in question is not found on the host machine, leading to the Python runtime making a lot of IO syscalls).
- Secondly, it attempts to [enumerate all possible, registered ops](https://github.com/explosion/thinc/blob/c7b0d6759645babe94315a36c84d56ec877252f2/thinc/backends/__init__.py#L95). The get_all method it calls on the Registry object performs a copy of a global REGISTRY dict and iterates over it, incurring even more overhead.

This PR introduces the following changes:

- It moves the imports of `thinc_apple_ops` and `thinc_backend_ops` to the `compat` module to make it an one-off operation.
- It modifies `get_ops` to directly use the specific `Ops` types when querying for CPU backends instead of looking it up by name in the global ops registry.