### PR TITLE
Ops: replace FloatsType by constrained typevar

### DIFF
--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -726,22 +726,22 @@ class Ops:
             # To prevent overflows and help with regularization/numerical stability
             X = self.xp.clip(X, -20.0, 20.0, out=X)
             self.xp.exp(-X, out=X)
-            X += 1.0  # type: ignore[assignment]
-            X **= -1.0  # type: ignore[assignment]
-            return cast(FloatsXdT, X)
+            X += 1.0
+            X **= -1.0
+            return X
         else:
             X = self.xp.clip(X, -20.0, 20.0)
-            return cast(FloatsXdT, 1.0 / (1.0 + self.xp.exp(-X)))
+            return 1.0 / (1.0 + self.xp.exp(-X))
 
     def backprop_sigmoid(
         self, dY: FloatsXdT, Y: FloatsXdT, *, inplace: bool = False
     ) -> FloatsXdT:
         if inplace:
             self.dsigmoid(Y, inplace=True)
-            Y *= dY  # type: ignore
+            Y *= dY
             return Y
         else:
-            return dY * self.dsigmoid(Y, inplace=inplace)  # type: ignore
+            return dY * self.dsigmoid(Y, inplace=inplace)
 
     def dsigmoid(self, Y: FloatsXdT, *, inplace: bool = False) -> FloatsXdT:
         if inplace:
@@ -872,11 +872,11 @@ class Ops:
         inplace: bool = False,
     ) -> FloatsXdT:
         if inplace:
-            X *= slope  # type: ignore[assignment]
-            X += offset  # type: ignore[assignment]
-            return cast(FloatsXdT, self.xp.clip(X, min_val, max_val, out=X))
-        out = X * slope + offset  # type: ignore[assignment]
-        return cast(FloatsXdT, self.xp.clip(out, min_val, max_val))
+            X *= slope
+            X += offset
+            return self.xp.clip(X, min_val, max_val, out=X)
+        out = X * slope + offset
+        return self.xp.clip(out, min_val, max_val)
 
     def backprop_clipped_linear(
         self,
@@ -924,28 +924,28 @@ class Ops:
 
     def swish(self, X: FloatsXdT, inplace: bool = False) -> FloatsXdT:
         if inplace:
-            X *= self.sigmoid(X)  # type: ignore[operator, assignment]
-            return cast(FloatsXdT, X)
-        out = X * self.sigmoid(X)  # type: ignore[operator]
-        return cast(FloatsXdT, out)
+            X *= self.sigmoid(X)
+            return X
+        out = X * self.sigmoid(X)
+        return out
 
     def backprop_swish(
         self, dY: FloatsXdT, X: FloatsXdT, Y: FloatsXdT, inplace: bool = False
     ) -> FloatsXdT:
-        Y = Y + self.sigmoid(X) * (1 - Y)  # type: ignore[operator]
+        Y = Y + self.sigmoid(X) * (1 - Y)
         if inplace:
-            dY *= Y  # type: ignore[operator, assignment]
-            return cast(FloatsXdT, dY)
-        out = dY * Y  # type: ignore[operator]
-        return cast(FloatsXdT, out)
+            dY *= Y
+            return dY
+        out = dY * Y
+        return out
 
     # Following https://www.scitepress.org/Papers/2019/74696/74696.pdf
     def hard_swish(self, X: FloatsXdT, inplace: bool = False) -> FloatsXdT:
         if inplace:
-            X *= self.hard_sigmoid(X)  # type: ignore[operator, assignment]
-            return cast(FloatsXdT, X)
-        out = X * self.hard_sigmoid(X)  # type: ignore[operator]
-        return cast(FloatsXdT, out)
+            X *= self.hard_sigmoid(X)
+            return X
+        out = X * self.hard_sigmoid(X)
+        return out
 
     def backprop_hard_swish(
         self, dY: FloatsXdT, X: FloatsXdT, inplace: bool = False
@@ -1035,15 +1035,15 @@ class Ops:
         # GELU(x) = x · Φ(x)
         cdf = gaussian_cdf(self, X)
         if inplace:
-            X *= cdf  # type: ignore[operator, assignment]
+            X *= cdf
             return X
-        return X * cdf  # type: ignore[operator, return-value]
+        return X * cdf
 
     def backprop_gelu(
         self, dY: FloatsXdT, X: FloatsXdT, inplace: bool = False
     ) -> FloatsXdT:
         # GELU'(x) = Φ(x) + x · PDF(x)
-        dX = gaussian_cdf(self, X) + X * gaussian_pdf(self, X)  # type: ignore[operator]
+        dX = gaussian_cdf(self, X) + X * gaussian_pdf(self, X)
         if inplace:
             dY *= dX
             return dY

--- a/thinc/layers/sigmoid_activation.py
+++ b/thinc/layers/sigmoid_activation.py
@@ -2,23 +2,23 @@ from typing import TypeVar, Tuple, Callable, cast
 
 from ..model import Model
 from ..config import registry
-from ..types import FloatsXd
-
-
-InT = TypeVar("InT", bound=FloatsXd)
+from ..types import FloatsXdT
 
 
 @registry.layers("sigmoid_activation.v1")
-def sigmoid_activation() -> Model[InT, InT]:
+def sigmoid_activation() -> Model[FloatsXdT, FloatsXdT]:
     return Model("sigmoid_activation", forward)
 
 
-def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callable]:
+def forward(
+    model: Model[FloatsXdT, FloatsXdT], X: FloatsXdT, is_train: bool
+) -> Tuple[FloatsXdT, Callable]:
     Y = model.ops.sigmoid(X, inplace=False)
 
-    def backprop(dY: InT) -> InT:
+    def backprop(dY: FloatsXdT) -> FloatsXdT:
         return cast(
-            InT, dY * model.ops.dsigmoid(Y, inplace=False)  # type:ignore[operator]
+            FloatsXdT,
+            dY * model.ops.dsigmoid(Y, inplace=False),  # type:ignore[operator]
         )
 
     return Y, backprop

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -46,6 +46,7 @@ ListXd = Union[List1d, List2d, List3d, List4d]
 ArrayT = TypeVar("ArrayT")
 SelfT = TypeVar("SelfT")
 Array1dT = TypeVar("Array1dT", bound="Array1d")
+FloatsXdT = TypeVar("FloatsXdT", "Floats1d", "Floats2d", "Floats3d", "Floats4d")
 
 # These all behave the same as far as indexing is concerned
 Slicish = Union[slice, List[int], "ArrayXd"]


### PR DESCRIPTION
Ops used the `FloatsType`, which had `FloatsXd` as its bound. MyPy could not infer that code such as the following is correct,
    
```
def dish(self, X: FloatsType, inplace: bool = False) -> FloatsType:
    tmp = X * X
    # ...
```
    
because the inferred type is the union (or a subtype). If we instead constrain the type variable as follows:
    
```
FloatsType = TypeVar("FloatsType", Floats1d, Floats2d, Floats3d, Floats4d)
```
    
the type parameter will be instantiated with a single concrete type, solving such issues.