### PR TITLE
Allow escaped section names

### DIFF
--- a/thinc/tests/test_config.py
+++ b/thinc/tests/test_config.py
@@ -82,6 +82,18 @@ warmup_steps = 10000
 total_steps = 100000
 """
 
+EXAMPLE_WITH_ESCAPED_SECTION_CFG = """
+["pipeline.with.dots.v1"]
+param = 0.5
+
+["pipeline.with.dots.v1".parser]
+name = "parser"
+factory = "parser"
+
+["pipeline.with.dots.v1".parser.'foo.bar']
+name = "foo"
+"""
+
 
 class my_registry(thinc.config.registry):
     cats = catalogue.create("thinc", "tests", "cats", entry_points=False)
@@ -311,6 +323,20 @@ def test_optimizer_config():
     cfg = Config().from_str(OPTIMIZER_CFG)
     optimizer = my_registry.resolve(cfg, validate=True)["optimizer"]
     assert optimizer.b1 == 0.9
+
+
+def test_config_with_escaped_section():
+    byte_string = EXAMPLE_WITH_ESCAPED_SECTION_CFG.encode("utf8")
+    cfg = Config().from_bytes(byte_string)
+
+    assert cfg['pipeline.with.dots.v1']["param"] == 0.5
+    assert cfg['pipeline.with.dots.v1']["parser"]["name"] == "parser"
+    assert cfg['pipeline.with.dots.v1']["parser"]["foo.bar"]["name"] == "foo"
+
+
+def test_config_with_escaped_section_to_str():
+    cfg = Config().from_str(EXAMPLE_WITH_ESCAPED_SECTION_CFG)
+    assert cfg.to_str().strip() == EXAMPLE_WITH_ESCAPED_SECTION_CFG.replace("'", '"').strip()
 
 
 def test_config_to_str():


### PR DESCRIPTION
Hi ! Currently, Thinc config's system cannot export nor can it read section names that contain dots.
This PR makes the Config object able to:
- loads escaped sections
- export sections that contain dots by escaping them

For instance
```toml
[components."org.parser".v1]
param = 2
```
is now parsed as / exported from
```json
{
  "components": {
    "org.parser": {
      "v1": {
        "param": 2
      }
    }
  }
}
```

This fixes an issue with spacy (https://github.com/explosion/spaCy/issues/10954) that produces configs with dots in component section names when the factory's name contains dots.