### PR TITLE
Multi gpu

### DIFF
--- a/examples/benchmarks/lstm_tagger.py
+++ b/examples/benchmarks/lstm_tagger.py
@@ -112,7 +112,7 @@ def set_backend(name, gpu_id):
         if gpu_id == -1:
             set_current_ops(NumpyOps(use_blis=True))
         else:
-            set_current_ops(CupyOps())
+            set_current_ops(CupyOps(device_id=gpu_id))
         if name == "pytorch":
             import torch
 

--- a/thinc/backends/__init__.py
+++ b/thinc/backends/__init__.py
@@ -112,7 +112,7 @@ def get_ops(name: str, **kwargs) -> Ops:
 def get_array_ops(arr):
     """Return CupyOps for a cupy array, NumpyOps otherwise."""
     if is_cupy_array(arr):
-        return CupyOps()
+        return CupyOps(device_id=arr.device)
     else:
         return NumpyOps()
 

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -26,7 +26,7 @@ class CupyOps(Ops):
         **kwargs
     ) -> None:
         self.device_type = device_type
-        if device_id is None:
+        if device_id is None or device_id < 0:
             device_id = self.xp.cuda.runtime.getDevice()
         self.device_id = device_id
 

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -1,6 +1,7 @@
 # cython: cdivision=True
 # cython: infer_types=True
 # cython: profile=True
+from contextlib import contextmanager
 from typing import Optional
 from collections.abc import Sized
 import numpy
@@ -60,6 +61,11 @@ class NumpyOps(Ops):
         self.use_blis = use_blis
         if self.use_blis and not has_blis:
             raise ValueError("BLIS support requires blis: pip install blis")
+
+    @contextmanager
+    def context(self):
+        # Dummy context for compatibility with CupyOps.context()
+        yield self
 
     def asarray(self, data, dtype=None):
         if isinstance(data, self.xp.ndarray):

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -98,7 +98,7 @@ class Ops:
         # return our SizedGenerator object, which provides a __len__.
         def _iter_items():
             if shuffle:
-                numpy.random.shuffle(indices)
+                self.xp.random.shuffle(indices)
             queue = []
             i = 0
             for size in sizes:

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -35,7 +35,7 @@ class Model(Generic[InT, OutT]):
     _context_operators = context_operators
 
     name: str
-    ops: Ops
+    ops: NumpyOps
     id: int
     _func: Callable
     init: Callable

--- a/thinc/model.py
+++ b/thinc/model.py
@@ -510,7 +510,7 @@ class Model(Generic[InT, OutT]):
         import cupy.cuda.device
 
         with cupy.cuda.device.Device(gpu_id):
-            self._to_ops(CupyOps())
+            self._to_ops(CupyOps(device_id=gpu_id))
 
     def to_cpu(self) -> None:  # pragma: no cover
         """Transfer the model to CPU."""

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -38,7 +38,7 @@ def get_torch_default_device() -> "torch.device":
 
     ops = get_current_ops()
     if isinstance(ops, CupyOps):
-        device_id = torch.cuda.current_device()
+        device_id = ops.device_id
         return torch.device(f"cuda:{device_id}")
     elif isinstance(ops, MPSOps):
         return torch.device("mps")

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -195,7 +195,7 @@ def require_gpu(gpu_id: int = 0) -> bool:  # pragma: no cover
         raise ValueError("No GPU devices detected")
 
     if has_cupy_gpu:
-        set_current_ops(CupyOps())
+        set_current_ops(CupyOps(device_id=gpu_id))
         set_active_gpu(gpu_id)
     else:
         set_current_ops(MPSOps())


### PR DESCRIPTION
This PR adds support for the `CupyOps.device_id` by creating an `Ops.context()` interface that wraps a [cupy.cuda.Device](https://docs.cupy.dev/en/stable/reference/generated/cupy.cuda.Device.html).

It was tested with a multi-GPU chain model here:
https://code.ornl.gov/99R/autoencoder.

The above test works with the current thinc after one change to CupyOps.asarray -- forcing `return self.xp.asarray(data, dtype)` for cupy inputs.

After merging this PR, the above example simplifies to: https://code.ornl.gov/99R/autoencoder/-/tree/multi_gpu_thinc.

The example outputs for a 3-GPU run are:
```
# multi_gpu branches, num_gpu = 3, size = 7000
$ jsrun -n1 -g3 -c21 -bpacked:21 python3 autoencoder.py
Initialized model with input dimension nI=7000 and output dimension nO=7000
0: iteration time = 3.619584083557129 mem = 697 M / gpu 0
1: iteration time = 3.61960506439209 mem = 969 M / gpu 1
2: iteration time = 3.6196165084838867 mem = 647 M / gpu 2
0: iteration time = 0.3242201805114746 mem = 0 M / gpu 0
1: iteration time = 0.32422947883605957 mem = 0 M / gpu 1
2: iteration time = 0.3242321014404297 mem = 0 M / gpu 2
0: iteration time = 0.31447744369506836 mem = 0 M / gpu 0
1: iteration time = 0.31448888778686523 mem = 0 M / gpu 1
2: iteration time = 0.3144950866699219 mem = 0 M / gpu 2
0: iteration time = 0.31055688858032227 mem = 0 M / gpu 0
1: iteration time = 0.31056880950927734 mem = 0 M / gpu 1
2: iteration time = 0.310575008392334 mem = 0 M / gpu 2
0: main time = 9.183293342590332 mem = 961 M / gpu 0
1: main time = 9.183251857757568 mem = 1211 M / gpu 1
2: main time = 9.183244705200195 mem = 808 M / gpu 2
```

This PR uses encapsulation of cupy array math in these contexts to remove warnings (encountered during testing) about non-cupy.cuda.Device()-context bound accesses:
```
thinc/thinc/backends/cupy_ops.py:256: PerformanceWarning: The device where the array resides (1) is different from the current device (0). Peer access has been activated automatically.
  gradient *= cupy.minimum(threshold, grad_norm) / grad_norm
thinc/thinc/backends/cupy_ops.py:343: PerformanceWarning: The device where the array resides (1) is different from the current device (0). Peer access has been activated automatically.
  adam_kernel(
...
```

closes #713