### PR TITLE
Change Docker image tag to `thinc-ai`

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:11.15.0
 
-WORKDIR /thinc-io
+WORKDIR /thinc-ai
 
 RUN npm install -g gatsby-cli@2.7.4
 
@@ -13,4 +13,4 @@ RUN npm install
 # from where a user mounts files, so that they don't accidentally mount
 # their own node_modules from a different build
 # https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders
-WORKDIR /thinc-io/website/
+WORKDIR /thinc-ai/website/

--- a/website/README.md
+++ b/website/README.md
@@ -20,16 +20,16 @@ Rather than installing NPM locally, you can also build a Docker container with
 the prerequisite dependencies:
 
 ```bash
-docker build -t thinc-io .
+docker build -t thinc-ai .
 ```
 
 Afterwards, the website can be built and run in the container:
 
 ```bash
 docker run --rm -it \
-  -v $PWD:/thinc-io/website \
+  -v $PWD:/thinc-ai/website \
   -p 8000:8000 \
-  thinc-io \
+  thinc-ai \
   gatsby develop -H 0.0.0.0
 ```
 


### PR DESCRIPTION
This is purely a cosmetic change, but less confusing than thinc-io :).
