### PR TITLE
Docs: Fix/update `label_smoothing` description

### DIFF
--- a/website/docs/api-loss.md
+++ b/website/docs/api-loss.md
@@ -70,9 +70,8 @@ are expected to be in the range of `[0, 1]`. They can both represent exclusive
 classes from multi-class cross-entropy (generally coming from a `softmax` layer)
 or could be classwise binary decisions for multi-label cross-entropy (`sigmoid`
 layer). The `truths` are most commonly provided as labels in `Ints1d`,
-`List[int]` or `List[str]` format. 
-Alternatively, users can provide `truths` as a `Floats2d` for
-example to encode label-confidences.
+`List[int]` or `List[str]` format. Alternatively, users can provide `truths` as
+a `Floats2d` for example to encode label-confidences.
 
 <grid>
 
@@ -98,7 +97,7 @@ normalize = true
 | `normalize`       | <tt>bool</tt>            | Normalize and divide by number of examples given.                                                                                                |
 | `neg_prefix`      | <tt>str</tt>             | Prefix used to indicate that a label is negative e.g. "!sci-fi".                                                                                 |
 | `missing_value`   | <tt>Union[str, int]</tt> | Specific label that indicates the value is missing and should not be considered for training/evaluation purposes, e.g. empty string `""` or `0`. |
-| `label_smoothing` | <tt>float</tt>           | Smoothing-coefficient for label-smoothing in range of [0, 0.5[.                                                                                  |
+| `label_smoothing` | <tt>float</tt>           | Smoothing-coefficient for label-smoothing.                                                                                                       |
 
 ### SequenceCategoricalCrossentropy {#sequence_categorical_crossentropy tag="class"}
 
@@ -138,7 +137,7 @@ normalize = true
 | `normalize`       | <tt>bool</tt>            | Normalize and divide by number of examples given.                   |
 | `neg_prefix`      | <tt>str</tt>             | Symbol that indicates that a label is negative e.g. "!sci-fi".      |
 | `missing_value`   | <tt>Union[str, int]</tt> | Symbol for "missing value" among the labels.                        |
-| `label_smoothing` | <tt>float</tt>           | Smoothing-coefficient for label-smoothing in range of [0, 0.5].     |
+| `label_smoothing` | <tt>float</tt>           | Smoothing-coefficient for label-smoothing.                          |
 
 ### L2Distance {#l2distance tag="class"}
 

--- a/website/docs/api-util.md
+++ b/website/docs/api-util.md
@@ -133,11 +133,13 @@ element).
 Converts a class vector (integers) to binary class matrix. Based on
 [`keras.utils.to_categorical`](https://keras.io/utils/).
 
-| Argument    | Type                   | Description                                                                                    |
-| ----------- | ---------------------- | ---------------------------------------------------------------------------------------------- |
-| `Y`         | <tt>IntsXd</tt>        | Class vector to be converted into a matrix (integers from `0` to `n_classes`).                 |
-| `n_classes` | <tt>Optional[int]</tt> | Total number of classes.                                                                       |
-| **RETURNS** |  <tt>Floats2d</tt>     | A binary matrix representation of the input. The axis representing the classes is placed last. |
+| Argument          | Type                   | Description                                                                                    |
+| ----------------- | ---------------------- | ---------------------------------------------------------------------------------------------- |
+| `Y`               | <tt>IntsXd</tt>        | Class vector to be converted into a matrix (integers from `0` to `n_classes`).                 |
+| `n_classes`       | <tt>Optional[int]</tt> | Total number of classes.                                                                       |
+| _keyword-only_    |                        |                                                                                                |
+| `label_smoothing` | <tt>float</tt>         | Smoothing-coefficient for label-smoothing.                                                     |
+| **RETURNS**       | <tt>Floats2d</tt>      | A binary matrix representation of the input. The axis representing the classes is placed last. |
 
 ### xp2torch {#xp2torch tag="function"}
 


### PR DESCRIPTION
- Remove the note about the expected range (cf. https://github.com/explosion/thinc/pull/707).
- Add the parameter to `to_categorical`.