### PR TITLE
Register fix_random_seed as a pytest-randomly entry point

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,10 @@ install_requires =
     dataclasses>=0.6,<1.0; python_version < "3.7"
     typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"
     contextvars>=2.4,<3; python_version < "3.7"
+    
+[options.entry_points]
+pytest_randomly.random_seeder =
+    thinc = thinc.api.fix_random_seed
 
 [options.extras_require]
 cuda =


### PR DESCRIPTION
Closes #747.

I chose to expose `fix_random_seed` from `thinc.api` instead of `thinc.util` because that's where you've stated your public API is consolidated, type definitions in `thinc.types` notwithstanding.

If this isn't something you're interested in, please feel free to close this without merging it.

Thanks for all your work!