### PR TITLE
`util`: Explicitly call `__dlpack__` built-in method in `xp2tensorflow`

### DIFF
--- a/thinc/util.py
+++ b/thinc/util.py
@@ -404,7 +404,8 @@ def xp2tensorflow(
         dlpack_tensor = xp_tensor.toDlpack()  # type: ignore
         tf_tensor = tf.experimental.dlpack.from_dlpack(dlpack_tensor)
     elif hasattr(xp_tensor, "__dlpack__"):
-        tf_tensor = tf.experimental.dlpack.from_dlpack(xp_tensor)
+        dlpack_tensor = xp_tensor.__dlpack__()  # type: ignore
+        tf_tensor = tf.experimental.dlpack.from_dlpack(dlpack_tensor)
     else:
         tf_tensor = tf.convert_to_tensor(xp_tensor)
     if as_variable:


### PR DESCRIPTION
`tf.experimental.dlpack.from_dlpack` expects a `PyCapsule` object.