### PR TITLE
Update `Model.__call__` callback signature

### DIFF
--- a/thinc/model.py
+++ b/thinc/model.py
@@ -285,7 +285,7 @@ class Model(Generic[InT, OutT]):
         else:
             raise ValueError("Cannot add reference to node not in tree.")
 
-    def __call__(self, X: InT, is_train: bool) -> Tuple[OutT, Callable]:
+    def __call__(self, X: InT, is_train: bool) -> Tuple[OutT, Callable[[OutT], InT]]:
         """Call the model's `forward` function, returning the output and a
         callback to compute the gradients via backpropagation."""
         return self._func(self, X, is_train=is_train)


### PR DESCRIPTION
Since `Model` is generic, this should help with type inference when you're actually using the backprop/backward callback in layers/architectures/etc. Right now the type for every callback is `(...) -> Any`, meaning it can take anything and returns anything.

Hope this is okay 😄 