### PR TITLE
disable mypy run for Python 3.10 (v9)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,7 @@ jobs:
   - script: |
       python -m mypy thinc
     displayName: 'Run mypy'
+    condition: ne(variables['python.version'], '3.10')
 
   - task: DeleteFiles@1
     inputs:


### PR DESCRIPTION
Until `mypy` 0.980 is released with [this fix](https://github.com/python/mypy/issues/13627), we're disabling the mypy tests on the CI for Python 3.10.