### PR TITLE
Update CI around conflicting extras requirements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ jobs:
       pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
-      pip install -U -r requirements.txt
+      pip install -r requirements.txt
     displayName: 'Install test dependencies'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,12 +82,12 @@ jobs:
     displayName: 'Install from sdist'
 
   - script: |
-      pip install -r requirements.txt
       pip install "protobuf~=3.20.0" "tensorflow~=2.5.0"
       pip install "mxnet; sys_platform != 'win32'"
-      pip install "torch==1.9.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
+      pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
+      pip install -U -r requirements.txt
     displayName: 'Install test dependencies'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,27 +19,27 @@ jobs:
     NOTEBOOK_KERNEL: "thinc-notebook-tests"
   strategy:
     matrix:
-#      Python36Windows:
-#        imageName: 'windows-2019'
-#        python.version: '3.6'
-#      Python37Mac:
-#        imageName: 'macos-latest'
-#        python.version: '3.7'
-#      Python38Linux:
-#        imageName: 'ubuntu-latest'
-#        python.version: '3.8'
-#      Python39Windows:
-#        imageName: 'windows-latest'
-#        python.version: '3.9'
-#      Python310Linux:
-#        imageName: 'ubuntu-latest'
-#        python.version: '3.10'
+      Python36Windows:
+        imageName: 'windows-2019'
+        python.version: '3.6'
+      Python37Mac:
+        imageName: 'macos-latest'
+        python.version: '3.7'
+      Python38Linux:
+        imageName: 'ubuntu-latest'
+        python.version: '3.8'
+      Python39Windows:
+        imageName: 'windows-latest'
+        python.version: '3.9'
+      Python310Linux:
+        imageName: 'ubuntu-latest'
+        python.version: '3.10'
       Python310Windows:
         imageName: 'windows-latest'
         python.version: '3.10'
-#      Python310Mac:
-#        imageName: 'macos-latest'
-#        python.version: '3.10'
+      Python310Mac:
+        imageName: 'macos-latest'
+        python.version: '3.10'
     maxParallel: 4
   pool:
     vmImage: $(imageName)
@@ -91,10 +91,15 @@ jobs:
   - script: |
       pip install "protobuf~=3.20.0" "tensorflow~=2.5.0"
       pip install "mxnet; sys_platform != 'win32'"
-      pip install "torch<1.12.0" --extra-index-url https://download.pytorch.org/whl/cpu
+      pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
+      # torch does not have a direct numpy requirement but is compiled against
+      # a newer version than the oldest supported numpy for windows and
+      # python 3.10; this version of numpy would not work with
+      # tensorflow~=2.5.0 as specified above, but there is no release for
+      # python 3.10 anyway
+      pip install "numpy~=1.23.0; python_version=='3.10' and sys_platform=='win32'"
       pip install -r requirements.txt
       pip uninstall -y mypy
-      pip install numpy==1.22.0
     displayName: 'Install extras for testing'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
       pip install "torch<1.12.0" --extra-index-url https://download.pytorch.org/whl/cpu
       pip install -r requirements.txt
       pip uninstall -y mypy
-      pip install -U numpy
+      pip install numpy==1.22.0
     displayName: 'Install extras for testing'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,9 +104,9 @@ jobs:
       pip install thinc-apple-ops
       python -m pytest --pyargs thinc_apple_ops
     displayName: 'Run tests for thinc-apple-ops'
-    condition: and(startsWith(variables['imageName'], 'macos'), eq(variables['python.version'], '3.9'))
+    condition: and(startsWith(variables['imageName'], 'macos'), eq(variables['python.version'], '3.10'))
 
   - script: |
       python -m pytest --pyargs thinc
     displayName: 'Run tests with thinc-apple-ops'
-    condition: and(startsWith(variables['imageName'], 'macos'), eq(variables['python.version'], '3.9'))
+    condition: and(startsWith(variables['imageName'], 'macos'), eq(variables['python.version'], '3.10'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,7 @@ jobs:
       pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
+      pip install -r requirements.txt
     displayName: 'Install extras for testing'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,27 +19,27 @@ jobs:
     NOTEBOOK_KERNEL: "thinc-notebook-tests"
   strategy:
     matrix:
-      Python36Windows:
-        imageName: 'windows-2019'
-        python.version: '3.6'
-      Python37Mac:
-        imageName: 'macos-latest'
-        python.version: '3.7'
-      Python38Linux:
-        imageName: 'ubuntu-latest'
-        python.version: '3.8'
-      Python39Windows:
-        imageName: 'windows-latest'
-        python.version: '3.9'
-      Python310Linux:
-        imageName: 'ubuntu-latest'
-        python.version: '3.10'
+#      Python36Windows:
+#        imageName: 'windows-2019'
+#        python.version: '3.6'
+#      Python37Mac:
+#        imageName: 'macos-latest'
+#        python.version: '3.7'
+#      Python38Linux:
+#        imageName: 'ubuntu-latest'
+#        python.version: '3.8'
+#      Python39Windows:
+#        imageName: 'windows-latest'
+#        python.version: '3.9'
+#      Python310Linux:
+#        imageName: 'ubuntu-latest'
+#        python.version: '3.10'
       Python310Windows:
         imageName: 'windows-latest'
         python.version: '3.10'
-      Python310Mac:
-        imageName: 'macos-latest'
-        python.version: '3.10'
+#      Python310Mac:
+#        imageName: 'macos-latest'
+#        python.version: '3.10'
     maxParallel: 4
   pool:
     vmImage: $(imageName)
@@ -94,6 +94,7 @@ jobs:
       pip install "torch<1.12.0" --extra-index-url https://download.pytorch.org/whl/cpu
       pip install -r requirements.txt
       pip uninstall -y mypy
+      pip install -U numpy
     displayName: 'Install extras for testing'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,17 +82,21 @@ jobs:
     displayName: 'Install from sdist'
 
   - script: |
+      pip install -r requirements.txt
+      python -m pytest --pyargs thinc --cov=thinc --cov-report=term
+    displayName: 'Run tests without extras'
+
+  - script: |
       pip install "protobuf~=3.20.0" "tensorflow~=2.5.0"
       pip install "mxnet; sys_platform != 'win32'"
       pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
       pip install ipykernel pydot graphviz
       python -m ipykernel install --name thinc-notebook-tests --user
-      pip install -r requirements.txt
-    displayName: 'Install test dependencies'
+    displayName: 'Install extras for testing'
 
   - script: |
       python -m pytest --pyargs thinc --cov=thinc --cov-report=term
-    displayName: 'Run tests'
+    displayName: 'Run tests with extras'
 
   - script: |
       pip uninstall -y tensorflow

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
   - script: |
       pip install "protobuf~=3.20.0" "tensorflow~=2.5.0"
       pip install "mxnet; sys_platform != 'win32'"
-      pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
+      pip install "torch<1.12.0" --extra-index-url https://download.pytorch.org/whl/cpu
       pip install -r requirements.txt
       pip uninstall -y mypy
     displayName: 'Install extras for testing'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,6 +83,8 @@ jobs:
 
   - script: |
       pip install -r requirements.txt
+      pip install ipykernel pydot graphviz
+      python -m ipykernel install --name thinc-notebook-tests --user
       python -m pytest --pyargs thinc --cov=thinc --cov-report=term
     displayName: 'Run tests without extras'
 
@@ -90,8 +92,6 @@ jobs:
       pip install "protobuf~=3.20.0" "tensorflow~=2.5.0"
       pip install "mxnet; sys_platform != 'win32'"
       pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
-      pip install ipykernel pydot graphviz
-      python -m ipykernel install --name thinc-notebook-tests --user
       pip install -r requirements.txt
     displayName: 'Install extras for testing'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,7 @@ jobs:
       pip install "mxnet; sys_platform != 'win32'"
       pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
       pip install -r requirements.txt
+      pip uninstall -y mypy
     displayName: 'Install extras for testing'
 
   - script: |


### PR DESCRIPTION
* Run tests with and without extras
  * Without: can test with newest versions of `pydantic` and other dependencies
  * With: can test `tensorflow`, `torch`, etc. (there is no currently supported version of `tensorflow` that can be installed with the `pydantic` v1.10)
* Remove version restriction for `torch` so that there's an available wheel for all versions of python in the CI
* Add workaround for `tensorflow` for python 3.10 in windows (it appears to be compiled against numpy v1.22 rather than the oldest supported numpy, but since numpy is an optional requirement there's no direct metadata in the package to specify this)
* Update `thinc-apple-ops` steps for current CI jobs