### PR TITLE
Revert return type for Ops.alloc to Any

### DIFF
--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -564,7 +564,7 @@ class Ops:
         *,
         dtype: Optional[DTypes] = "float32",
         zeros: bool = True,
-    ) -> ArrayXd:
+    ) -> Any:
         """Allocate an array of a certain shape."""
         if isinstance(shape, int):
             shape = (shape,)

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1,7 +1,7 @@
 import math
 
 from typing import Optional, List, Tuple, Sequence, Type, Union, cast, TypeVar
-from typing import Iterator, overload
+from typing import Iterator, overload, Any
 import numpy
 import itertools
 


### PR DESCRIPTION
Because the stricter type led to mypy failures in spacy, revert the changes for v8.1 and postpone to a later release.