### PR TITLE
Skip mypy tests for non-compiled mypy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pytest-cov>=2.7.0,<2.8.0
 coverage>=5.0.0,<6.0.0
 mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
-mypy>=0.980,<0.990; platform_machine != "aarch64" and python_version >= "3.7"
+mypy>=0.980,<0.990; python_version >= "3.7"
 types-mock>=0.1.1
 types-contextvars>=0.1.2; python_version < "3.7"
 types-dataclasses>=0.1.3; python_version < "3.7"

--- a/thinc/tests/mypy/test_mypy.py
+++ b/thinc/tests/mypy/test_mypy.py
@@ -6,6 +6,8 @@ import sys
 
 import pytest
 
+mypy = pytest.importorskip("mypy")
+
 # You can change the following variable to True during development to overwrite expected output with generated output
 GENERATE = False
 
@@ -17,11 +19,13 @@ cases = [
 ]
 
 
+@pytest.mark.skipif(
+    mypy.__file__.endswith(".py"), reason="Non-compiled mypy is too slow"
+)
 @pytest.mark.parametrize("config_filename,python_filename,output_filename", cases)
 def test_mypy_results(
     config_filename, python_filename, output_filename, tmpdir, monkeypatch
 ):
-    pytest.importorskip("mypy")
     from mypy import api as mypy_api
 
     os.chdir(tmpdir)
@@ -77,9 +81,11 @@ def test_mypy_results(
     assert actual_returncode == expected_returncode
 
 
+@pytest.mark.skipif(
+    mypy.__file__.endswith(".py"), reason="Non-compiled mypy is too slow"
+)
 def test_generation_is_disabled():
     """
     Makes sure we don't accidentally leave generation on
     """
-    pytest.importorskip("mypy")
     assert not GENERATE


### PR DESCRIPTION
Non-compiled mypy is too slow for practical use in particular in the test suite in the CI. Skipping by whether it's compiled or not becomes easier across a wider range of platforms and python versions than trying to specify it in `requirements.txt`.