### PR TITLE
Correct sequence length errors for reduce_first/last

### DIFF
--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -1188,7 +1188,7 @@ class Ops:
         if lengths.size == 0:
             return self.alloc2f(0, X.shape[1]), lengths
         if not self.xp.all(lengths > 0):
-            raise ValueError(f"all sequence lengths must be >= 0")
+            raise ValueError(f"all sequence lengths must be > 0")
         starts_ends = self.alloc1i(lengths.shape[0] + 1, zeros=False)
         starts_ends[0] = 0
         starts_ends[1:] = lengths.cumsum()
@@ -1201,7 +1201,7 @@ class Ops:
         if lengths.size == 0:
             return self.alloc2f(0, X.shape[1]), lengths
         if not self.xp.all(lengths > 0):
-            raise ValueError(f"all sequence lengths must be >= 0")
+            raise ValueError(f"all sequence lengths must be > 0")
         lasts = lengths.cumsum() - 1
         if lasts[-1] + 1 != X.shape[0]:
             raise IndexError("lengths must sum up to the number of rows")

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -835,7 +835,7 @@ def test_reduce_first(ops, dtype):
     ops.xp.testing.assert_allclose(Y, [[1.0, 6.0], [4.0, 9.0]])
 
     lengths = ops.asarray1i([3, 0, 2])
-    with pytest.raises(ValueError, match=r"all sequence lengths must be >= 0"):
+    with pytest.raises(ValueError, match=r"all sequence lengths must be > 0"):
         ops.reduce_last(X, lengths)
 
     lengths = ops.asarray1i([3, 2, 1])
@@ -866,7 +866,7 @@ def test_reduce_last(ops, dtype):
     ops.xp.testing.assert_allclose(Y, [[3.0, 8.0], [5.0, 10.0]])
 
     lengths = ops.asarray1i([3, 0, 2])
-    with pytest.raises(ValueError, match=r"all sequence lengths must be >= 0"):
+    with pytest.raises(ValueError, match=r"all sequence lengths must be > 0"):
         ops.reduce_last(X, lengths)
 
     lengths = ops.asarray1i([3, 2, 1])


### PR DESCRIPTION
Correct sequence length errors for `reduce_first/last`.