### PR TITLE
Update CupyOps.asarray to always copy cupy arrays to the current device

### DIFF
--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -79,7 +79,7 @@ class CupyOps(Ops):
     def asarray(self, data, dtype=None):
         # We'll try to perform a zero-copy conversion if possible.
         if is_cupy_array(data):
-            array = self.xp.asarray(data, dtype)
+            array = self.xp.asarray(data, dtype=dtype)
         elif is_torch_cuda_array(data):
             array = torch2xp(data)
         elif is_tensorflow_gpu_array(data):

--- a/thinc/backends/cupy_ops.py
+++ b/thinc/backends/cupy_ops.py
@@ -79,7 +79,7 @@ class CupyOps(Ops):
     def asarray(self, data, dtype=None):
         # We'll try to perform a zero-copy conversion if possible.
         if is_cupy_array(data):
-            array = data
+            array = self.xp.asarray(data, dtype)
         elif is_torch_cuda_array(data):
             array = torch2xp(data)
         elif is_tensorflow_gpu_array(data):


### PR DESCRIPTION
[cupy.asarray](https://docs.cupy.dev/en/stable/reference/generated/cupy.asarray.html) only performs a copy if necessary.  However, calling this function here is necessary in case the data had a different format or resided on a different GPU.