### PR TITLE
Make resizable layer work with textcat and transformers

### DIFF
--- a/thinc/layers/resizable.py
+++ b/thinc/layers/resizable.py
@@ -54,10 +54,13 @@ def resize_linear_weighted(
     assert not layer.shims
 
     # return the original layer if it wasn't initialized or if nO didn't change
-    if layer.has_dim("nO") is None or layer.has_dim("nI") is None:
-        layer.set_dim("nO", new_nO, force=True)
+    if layer.has_dim("nO") is None:
+        layer.set_dim("nO", new_nO)
         return layer
     elif new_nO == layer.get_dim("nO"):
+        return layer
+    elif layer.has_dim("nI") is None:
+        layer.set_dim("nO", new_nO, force=True)
         return layer
 
     dims = {name: layer.maybe_get_dim(name) for name in layer.dim_names}

--- a/thinc/layers/resizable.py
+++ b/thinc/layers/resizable.py
@@ -54,8 +54,8 @@ def resize_linear_weighted(
     assert not layer.shims
 
     # return the original layer if it wasn't initialized or if nO didn't change
-    if layer.has_dim("nO") is None:
-        layer.set_dim("nO", new_nO)
+    if layer.has_dim("nO") is None or layer.has_dim("nI") is None:
+        layer.set_dim("nO", new_nO, force=True)
         return layer
     elif new_nO == layer.get_dim("nO"):
         return layer

--- a/thinc/tests/layers/test_resizable.py
+++ b/thinc/tests/layers/test_resizable.py
@@ -1,0 +1,39 @@
+import pytest
+from mock import MagicMock
+from functools import partial
+from hypothesis import given, settings
+import numpy
+from numpy.testing import assert_allclose
+from thinc.api import resizable, Linear, chain, Dropout, SGD
+from thinc.layers.resizable import resize_model, resize_linear_weighted
+
+from ..strategies import arrays_OI_O_BI
+from ..util import get_model, get_shape
+
+
+@pytest.fixture
+def model():
+    output_layer = Linear(nO=None, nI=None)
+    fill_defaults = {"b": 0, "W": 0}
+    model = resizable(
+        output_layer,
+        resize_layer=partial(resize_linear_weighted, fill_defaults=fill_defaults),
+    )
+    return model
+
+
+def test_resizable_linear_default_name(model):
+    assert model.name == "resizable(linear)"
+
+
+def test_resize_model(model):
+    """Test that resizing the model doesn't cause an exception."""
+    resize_model(model, new_nO=10)
+    resize_model(model, new_nO=11)
+
+    model.set_dim("nO", 0, force=True)
+    resize_model(model, new_nO=10)
+
+    model.set_dim("nI", 10, force=True)
+    model.set_dim("nO", 0, force=True)
+    resize_model(model, new_nO=10)

--- a/thinc/tests/layers/test_resizable.py
+++ b/thinc/tests/layers/test_resizable.py
@@ -1,14 +1,7 @@
 import pytest
-from mock import MagicMock
 from functools import partial
-from hypothesis import given, settings
-import numpy
-from numpy.testing import assert_allclose
-from thinc.api import resizable, Linear, chain, Dropout, SGD
+from thinc.api import resizable, Linear
 from thinc.layers.resizable import resize_model, resize_linear_weighted
-
-from ..strategies import arrays_OI_O_BI
-from ..util import get_model, get_shape
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR is an attempted fix of the issue outlined in https://github.com/explosion/spaCy/issues/11968. I don't completely understand how the resizable textcat is supposed to work yet, and am not sure if this is the right approach, but locally it got rid of errors and I was able to train a model with reasonable performance.

There are also no tests yet. 