### PR TITLE
`with_flatten`: make the layer input/output types symmetric

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -42,7 +42,7 @@ from .layers import with_reshape, with_getitem, strings2arrays, list2array
 from .layers import list2ragged, ragged2list, list2padded, padded2list, remap_ids
 from .layers import array_getitem, with_cpu, with_debug, with_nvtx_range
 from .layers import with_signpost_interval
-from .layers import tuplify
+from .layers import tuplify, with_flatten_v2
 
 from .layers import reduce_first, reduce_last, reduce_max, reduce_mean, reduce_sum
 
@@ -104,7 +104,7 @@ __all__ = [
     "list2ragged", "ragged2list", "list2padded", "padded2list", "remap_ids",
     "array_getitem", "with_cpu", "with_debug", "with_nvtx_range",
     "with_signpost_interval",
-    "tuplify",
+    "tuplify", "with_flatten_v2",
     "pytorch_to_torchscript_wrapper",
 
     "reduce_first", "reduce_last", "reduce_max", "reduce_mean", "reduce_sum",

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -66,6 +66,7 @@ from .with_array import with_array
 from .with_array2d import with_array2d
 from .with_cpu import with_cpu
 from .with_flatten import with_flatten
+from .with_flatten_v2 import with_flatten_v2
 from .with_padded import with_padded
 from .with_list import with_list
 from .with_ragged import with_ragged
@@ -134,6 +135,7 @@ __all__ = [
     "with_ragged",
     "with_padded",
     "with_flatten",
+    "with_flatten_v2",
     "with_debug",
     "with_nvtx_range",
     "with_signpost_interval",

--- a/thinc/layers/with_flatten.py
+++ b/thinc/layers/with_flatten.py
@@ -2,31 +2,32 @@ from typing import Tuple, Callable, Sequence, Any, cast, TypeVar, Optional, List
 
 from ..model import Model
 from ..config import registry
-from ..types import ListXd
-
+from ..types import ArrayXd, ListXd
 
 ItemT = TypeVar("ItemT")
 InT = Sequence[Sequence[ItemT]]
-OutT = TypeVar("OutT", bound=ListXd)
+OutT = ListXd
+InnerInT = Sequence[ItemT]
+InnerOutT = ArrayXd
 
 
 @registry.layers("with_flatten.v1")
-def with_flatten(layer: Model[InT, InT]) -> Model[OutT, OutT]:
+def with_flatten(layer: Model[InnerInT[ItemT], InnerOutT]) -> Model[InT[ItemT], OutT]:
     return Model(f"with_flatten({layer.name})", forward, layers=[layer], init=init)
 
 
 def forward(
-    model: Model[OutT, OutT], Xnest: OutT, is_train: bool
+    model: Model[InT, OutT], Xnest: InT, is_train: bool
 ) -> Tuple[OutT, Callable]:
-    layer: Model[InT, InT] = model.layers[0]
-    Xflat: Sequence[Sequence[Any]] = _flatten(Xnest)
+    layer: Model[InnerInT, InnerOutT] = model.layers[0]
+    Xflat = _flatten(Xnest)
     Yflat, backprop_layer = layer(Xflat, is_train)
     # Get the split points. We want n-1 splits for n items.
     arr = layer.ops.asarray1i([len(x) for x in Xnest[:-1]])
     splits = arr.cumsum()
     Ynest = layer.ops.xp.split(Yflat, splits, axis=0)
 
-    def backprop(dYnest: OutT) -> OutT:
+    def backprop(dYnest: OutT) -> InT:
         dYflat = model.ops.flatten(dYnest)  # type: ignore[arg-type, var-annotated]
         # type ignore necessary for older versions of Mypy/Pydantic
         dXflat = backprop_layer(dYflat)
@@ -36,7 +37,7 @@ def forward(
     return Ynest, backprop
 
 
-def _flatten(nested: OutT) -> InT:
+def _flatten(nested: InT) -> InnerInT:
     flat: List = []
     for item in nested:
         flat.extend(item)
@@ -44,7 +45,7 @@ def _flatten(nested: OutT) -> InT:
 
 
 def init(
-    model: Model[OutT, OutT], X: Optional[OutT] = None, Y: Optional[OutT] = None
+    model: Model[InT, OutT], X: Optional[InT] = None, Y: Optional[OutT] = None
 ) -> None:
     model.layers[0].initialize(
         _flatten(X) if X is not None else None,

--- a/thinc/layers/with_flatten.py
+++ b/thinc/layers/with_flatten.py
@@ -2,64 +2,49 @@ from typing import Tuple, Callable, Sequence, Any, cast, TypeVar, Optional, List
 
 from ..model import Model
 from ..config import registry
+from ..types import ListXd
 
 
-InItemT = TypeVar("InItemT")
-OutItemT = TypeVar("OutItemT")
 ItemT = TypeVar("ItemT")
-
-NestedT = List[List[ItemT]]
-FlatT = List[ItemT]
+InT = Sequence[Sequence[ItemT]]
+OutT = TypeVar("OutT", bound=ListXd)
 
 
 @registry.layers("with_flatten.v1")
-def with_flatten(
-    layer: Model[FlatT[InItemT], FlatT[OutItemT]]
-) -> Model[NestedT[InItemT], NestedT[OutItemT]]:
+def with_flatten(layer: Model[InT, InT]) -> Model[OutT, OutT]:
     return Model(f"with_flatten({layer.name})", forward, layers=[layer], init=init)
 
 
 def forward(
-    model: Model[NestedT[InItemT], NestedT[OutItemT]],
-    Xnest: NestedT[InItemT],
-    is_train: bool,
-) -> Tuple[NestedT[OutItemT], Callable]:
-    layer: Model[FlatT[InItemT], FlatT[OutItemT]] = model.layers[0]
-    Xflat = _flatten(Xnest)
+    model: Model[OutT, OutT], Xnest: OutT, is_train: bool
+) -> Tuple[OutT, Callable]:
+    layer: Model[InT, InT] = model.layers[0]
+    Xflat: Sequence[Sequence[Any]] = _flatten(Xnest)
     Yflat, backprop_layer = layer(Xflat, is_train)
     # Get the split points. We want n-1 splits for n items.
-    lens = [len(x) for x in Xnest]
-    Ynest = _unflatten(Yflat, lens)
+    arr = layer.ops.asarray1i([len(x) for x in Xnest[:-1]])
+    splits = arr.cumsum()
+    Ynest = layer.ops.xp.split(Yflat, splits, axis=0)
 
-    def backprop(dYnest: NestedT[InItemT]) -> NestedT[OutItemT]:
-        dYflat = _flatten(dYnest)  # type: ignore[arg-type, var-annotated]
+    def backprop(dYnest: OutT) -> OutT:
+        dYflat = model.ops.flatten(dYnest)  # type: ignore[arg-type, var-annotated]
         # type ignore necessary for older versions of Mypy/Pydantic
         dXflat = backprop_layer(dYflat)
-        dXnest = _unflatten(dXflat, lens)
+        dXnest = layer.ops.xp.split(dXflat, splits, axis=-1)
         return dXnest
 
     return Ynest, backprop
 
 
-def _flatten(nested: NestedT[ItemT]) -> FlatT[ItemT]:
+def _flatten(nested: OutT) -> InT:
     flat: List = []
     for item in nested:
         flat.extend(item)
-    return cast(FlatT[ItemT], flat)
-
-
-def _unflatten(flat: FlatT[ItemT], lens: List[int]) -> NestedT[ItemT]:
-    nested = []
-    for l in lens:
-        nested.append(flat[:l])
-        flat = flat[l:]
-    return nested
+    return cast(InT, flat)
 
 
 def init(
-    model: Model[NestedT[InItemT], NestedT[OutItemT]],
-    X: Optional[NestedT[InItemT]] = None,
-    Y: Optional[NestedT[OutItemT]] = None,
+    model: Model[OutT, OutT], X: Optional[OutT] = None, Y: Optional[OutT] = None
 ) -> None:
     model.layers[0].initialize(
         _flatten(X) if X is not None else None,

--- a/thinc/layers/with_flatten.py
+++ b/thinc/layers/with_flatten.py
@@ -2,49 +2,64 @@ from typing import Tuple, Callable, Sequence, Any, cast, TypeVar, Optional, List
 
 from ..model import Model
 from ..config import registry
-from ..types import ListXd
 
 
+InItemT = TypeVar("InItemT")
+OutItemT = TypeVar("OutItemT")
 ItemT = TypeVar("ItemT")
-InT = Sequence[Sequence[ItemT]]
-OutT = TypeVar("OutT", bound=ListXd)
+
+NestedT = List[List[ItemT]]
+FlatT = List[ItemT]
 
 
 @registry.layers("with_flatten.v1")
-def with_flatten(layer: Model[InT, InT]) -> Model[OutT, OutT]:
+def with_flatten(
+    layer: Model[FlatT[InItemT], FlatT[OutItemT]]
+) -> Model[NestedT[InItemT], NestedT[OutItemT]]:
     return Model(f"with_flatten({layer.name})", forward, layers=[layer], init=init)
 
 
 def forward(
-    model: Model[OutT, OutT], Xnest: OutT, is_train: bool
-) -> Tuple[OutT, Callable]:
-    layer: Model[InT, InT] = model.layers[0]
-    Xflat: Sequence[Sequence[Any]] = _flatten(Xnest)
+    model: Model[NestedT[InItemT], NestedT[OutItemT]],
+    Xnest: NestedT[InItemT],
+    is_train: bool,
+) -> Tuple[NestedT[OutItemT], Callable]:
+    layer: Model[FlatT[InItemT], FlatT[OutItemT]] = model.layers[0]
+    Xflat = _flatten(Xnest)
     Yflat, backprop_layer = layer(Xflat, is_train)
     # Get the split points. We want n-1 splits for n items.
-    arr = layer.ops.asarray1i([len(x) for x in Xnest[:-1]])
-    splits = arr.cumsum()
-    Ynest = layer.ops.xp.split(Yflat, splits, axis=0)
+    lens = [len(x) for x in Xnest]
+    Ynest = _unflatten(Yflat, lens)
 
-    def backprop(dYnest: OutT) -> OutT:
-        dYflat = model.ops.flatten(dYnest)  # type: ignore[arg-type, var-annotated]
+    def backprop(dYnest: NestedT[InItemT]) -> NestedT[OutItemT]:
+        dYflat = _flatten(dYnest)  # type: ignore[arg-type, var-annotated]
         # type ignore necessary for older versions of Mypy/Pydantic
         dXflat = backprop_layer(dYflat)
-        dXnest = layer.ops.xp.split(dXflat, splits, axis=-1)
+        dXnest = _unflatten(dXflat, lens)
         return dXnest
 
     return Ynest, backprop
 
 
-def _flatten(nested: OutT) -> InT:
+def _flatten(nested: NestedT[ItemT]) -> FlatT[ItemT]:
     flat: List = []
     for item in nested:
         flat.extend(item)
-    return cast(InT, flat)
+    return cast(FlatT[ItemT], flat)
+
+
+def _unflatten(flat: FlatT[ItemT], lens: List[int]) -> NestedT[ItemT]:
+    nested = []
+    for l in lens:
+        nested.append(flat[:l])
+        flat = flat[l:]
+    return nested
 
 
 def init(
-    model: Model[OutT, OutT], X: Optional[OutT] = None, Y: Optional[OutT] = None
+    model: Model[NestedT[InItemT], NestedT[OutItemT]],
+    X: Optional[NestedT[InItemT]] = None,
+    Y: Optional[NestedT[OutItemT]] = None,
 ) -> None:
     model.layers[0].initialize(
         _flatten(X) if X is not None else None,

--- a/thinc/layers/with_flatten_v2.py
+++ b/thinc/layers/with_flatten_v2.py
@@ -1,0 +1,67 @@
+from typing import Tuple, Callable, Sequence, Any, cast, TypeVar, Optional, List
+
+from ..model import Model
+from ..config import registry
+
+
+InItemT = TypeVar("InItemT")
+OutItemT = TypeVar("OutItemT")
+ItemT = TypeVar("ItemT")
+
+NestedT = List[List[ItemT]]
+FlatT = List[ItemT]
+
+
+@registry.layers("with_flatten.v2")
+def with_flatten_v2(
+    layer: Model[FlatT[InItemT], FlatT[OutItemT]]
+) -> Model[NestedT[InItemT], NestedT[OutItemT]]:
+    return Model(f"with_flatten({layer.name})", forward, layers=[layer], init=init)
+
+
+def forward(
+    model: Model[NestedT[InItemT], NestedT[OutItemT]],
+    Xnest: NestedT[InItemT],
+    is_train: bool,
+) -> Tuple[NestedT[OutItemT], Callable]:
+    layer: Model[FlatT[InItemT], FlatT[OutItemT]] = model.layers[0]
+    Xflat = _flatten(Xnest)
+    Yflat, backprop_layer = layer(Xflat, is_train)
+    # Get the split points. We want n-1 splits for n items.
+    lens = [len(x) for x in Xnest]
+    Ynest = _unflatten(Yflat, lens)
+
+    def backprop(dYnest: NestedT[InItemT]) -> NestedT[OutItemT]:
+        dYflat = _flatten(dYnest)  # type: ignore[arg-type, var-annotated]
+        # type ignore necessary for older versions of Mypy/Pydantic
+        dXflat = backprop_layer(dYflat)
+        dXnest = _unflatten(dXflat, lens)
+        return dXnest
+
+    return Ynest, backprop
+
+
+def _flatten(nested: NestedT[ItemT]) -> FlatT[ItemT]:
+    flat: List = []
+    for item in nested:
+        flat.extend(item)
+    return cast(FlatT[ItemT], flat)
+
+
+def _unflatten(flat: FlatT[ItemT], lens: List[int]) -> NestedT[ItemT]:
+    nested = []
+    for l in lens:
+        nested.append(flat[:l])
+        flat = flat[l:]
+    return nested
+
+
+def init(
+    model: Model[NestedT[InItemT], NestedT[OutItemT]],
+    X: Optional[NestedT[InItemT]] = None,
+    Y: Optional[NestedT[OutItemT]] = None,
+) -> None:
+    model.layers[0].initialize(
+        _flatten(X) if X is not None else None,
+        model.layers[0].ops.xp.hstack(Y) if Y is not None else None,
+    )

--- a/thinc/tests/layers/test_with_flatten.py
+++ b/thinc/tests/layers/test_with_flatten.py
@@ -1,5 +1,5 @@
 from typing import List
-from thinc.api import Model, with_flatten
+from thinc.api import Model, with_flatten_v2
 
 INPUT = [[1, 2, 3], [4, 5], [], [6, 7, 8]]
 INPUT_FLAT = [1, 2, 3, 4, 5, 6, 7, 8]
@@ -23,7 +23,7 @@ def _memoize_input_forward(
 
 
 def test_with_flatten():
-    model = with_flatten(_memoize_input())
+    model = with_flatten_v2(_memoize_input())
     Y, backprop = model(INPUT, is_train=True)
     assert Y == OUTPUT
     assert model.layers[0].attrs["last_input"] == INPUT_FLAT

--- a/thinc/tests/layers/test_with_flatten.py
+++ b/thinc/tests/layers/test_with_flatten.py
@@ -1,0 +1,30 @@
+from typing import List
+from thinc.api import Model, with_flatten
+
+INPUT = [[1, 2, 3], [4, 5], [], [6, 7, 8]]
+INPUT_FLAT = [1, 2, 3, 4, 5, 6, 7, 8]
+OUTPUT = [[2, 3, 4], [5, 6], [], [7, 8, 9]]
+BACKPROP_OUTPUT = [[3, 4, 5], [6, 7], [], [8, 9, 10]]
+
+
+def _memoize_input() -> Model[List[int], List[int]]:
+    return Model(name="memoize_input", forward=_memoize_input_forward)
+
+
+def _memoize_input_forward(
+    model: Model[List[int], List[int]], X: List[int], is_train: bool
+):
+    model.attrs["last_input"] = X
+
+    def backprop(dY: List[int]):
+        return [v + 2 for v in dY]
+
+    return [v + 1 for v in X], backprop
+
+
+def test_with_flatten():
+    model = with_flatten(_memoize_input())
+    Y, backprop = model(INPUT, is_train=True)
+    assert Y == OUTPUT
+    assert model.layers[0].attrs["last_input"] == INPUT_FLAT
+    assert backprop(INPUT) == BACKPROP_OUTPUT

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1401,18 +1401,18 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/with_array.py
 
 <inline-list>
 
-- **Input:** <tt>Sequence[Sequence[Any]]</tt>
-- **Output:** <tt>ListXd</tt>
+- **Input:** <tt>Sequence[Sequence[InItemT]]</tt>
+- **Output:** <tt>List[List[OutItemT]]</tt>
 
 </inline-list>
 
 Flatten nested inputs on the way into a layer and reverse the transformation
 over the outputs.
 
-| Argument    | Type                                                             | Description        |
-| ----------- | ---------------------------------------------------------------- | ------------------ |
-| `layer`     | <tt>Model[Sequence[Sequence[Any]], Sequence[Sequence[Any]]]</tt> | The layer to wrap. |
-| **RETURNS** | <tt>Model[ListXd, ListXd]</tt>                                   | The wrapped layer. |
+| Argument    | Type                                                              | Description        |
+| ----------- | ----------------------------------------------------------------- | ------------------ |
+| `layer`     | <tt>Model[List[InItemT], List[OutItemT]]</tt>                     | The layer to wrap. |
+| **RETURNS** | <tt>Model[Sequence[Sequence[InItemT]], List[List[OutItemT]]]</tt> | The wrapped layer. |
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/with_flatten.py
@@ -1748,7 +1748,7 @@ script_model = pytorch_to_torchscript_wrapper(model)
 | `convert_outputs`   | <tt>Callable</tt>                         | Function to convert outputs from PyTorch tensors (same signature as `forward` function). |
 | `mixed_precision`   | <tt>bool</tt>                             | Enable mixed-precision training.                                                         |
 | `grad_scaler`       | <tt>Optional[PyTorchGradScaler]</tt>      | Gradient scaler to use during mixed-precision training.                                  |
-| `device`            | <tt>Optional[torch.Device]</tt>         | The Torch device to execute the model on.                                                |
+| `device`            | <tt>Optional[torch.Device]</tt>           | The Torch device to execute the model on.                                                |
 | **RETURNS**         | <tt>Model[Any, Any]</tt>                  | The Thinc model.                                                                         |
 
 ```python

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1401,7 +1401,7 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/with_array.py
 
 <inline-list>
 
-- **Input:** <tt>Sequence[Sequence[InItemT]]</tt>
+- **Input:** <tt>List[List[InItemT]]</tt>
 - **Output:** <tt>List[List[OutItemT]]</tt>
 
 </inline-list>
@@ -1409,10 +1409,10 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/with_array.py
 Flatten nested inputs on the way into a layer and reverse the transformation
 over the outputs.
 
-| Argument    | Type                                                              | Description        |
-| ----------- | ----------------------------------------------------------------- | ------------------ |
-| `layer`     | <tt>Model[List[InItemT], List[OutItemT]]</tt>                     | The layer to wrap. |
-| **RETURNS** | <tt>Model[Sequence[Sequence[InItemT]], List[List[OutItemT]]]</tt> | The wrapped layer. |
+| Argument    | Type                                                      | Description        |
+| ----------- | --------------------------------------------------------- | ------------------ |
+| `layer`     | <tt>Model[List[InItemT], List[OutItemT]]</tt>             | The layer to wrap. |
+| **RETURNS** | <tt>Model[List[List[InItemT]], List[List[OutItemT]]]</tt> | The wrapped layer. |
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/with_flatten.py

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1401,6 +1401,35 @@ https://github.com/explosion/thinc/blob/master/thinc/layers/with_array.py
 
 <inline-list>
 
+- **Input:** <tt>Sequence[Sequence[Any]]</tt>
+- **Output:** <tt>ListXd</tt>
+
+</inline-list>
+
+Flatten nested inputs on the way into a layer and reverse the transformation
+over the outputs.
+
+<infobox variant="warning">
+
+Even though `with_flatten` is a layer wrapper, it does not preserve symmetry
+between the input and output data types. This often makes it hard to compose
+with other layers. [`with_flatten_v2`](#with_flatten_v2) solves this issue.
+
+</infobox>
+
+| Argument    | Type                                                             | Description        |
+| ----------- | ---------------------------------------------------------------- | ------------------ |
+| `layer`     | <tt>Model[Sequence[Sequence[Any]], Sequence[Sequence[Any]]]</tt> | The layer to wrap. |
+| **RETURNS** | <tt>Model[ListXd, ListXd]</tt>                                   | The wrapped layer. |
+
+```python
+https://github.com/explosion/thinc/blob/master/thinc/layers/with_flatten.py
+```
+
+### with_flatten_v2 {#with_flatten_v2 tag="function" new="8.1.6"}
+
+<inline-list>
+
 - **Input:** <tt>List[List[InItemT]]</tt>
 - **Output:** <tt>List[List[OutItemT]]</tt>
 
@@ -1415,7 +1444,7 @@ over the outputs.
 | **RETURNS** | <tt>Model[List[List[InItemT]], List[List[OutItemT]]]</tt> | The wrapped layer. |
 
 ```python
-https://github.com/explosion/thinc/blob/master/thinc/layers/with_flatten.py
+https://github.com/explosion/thinc/blob/master/thinc/layers/with_flatten_v2.py
 ```
 
 ### with_padded {#with_padded tag="function"}

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1413,7 +1413,7 @@ over the outputs.
 
 Even though `with_flatten` is a layer wrapper, it does not preserve symmetry
 between the input and output data types. This often makes it hard to compose
-with other layers. [`with_flatten_v2`](#with_flatten_v2) instead.
+with other layers. Use [`with_flatten_v2`](#with_flatten_v2) instead.
 
 </infobox>
 

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -1413,14 +1413,14 @@ over the outputs.
 
 Even though `with_flatten` is a layer wrapper, it does not preserve symmetry
 between the input and output data types. This often makes it hard to compose
-with other layers. [`with_flatten_v2`](#with_flatten_v2) solves this issue.
+with other layers. [`with_flatten_v2`](#with_flatten_v2) instead.
 
 </infobox>
 
-| Argument    | Type                                                             | Description        |
-| ----------- | ---------------------------------------------------------------- | ------------------ |
-| `layer`     | <tt>Model[Sequence[Sequence[Any]], Sequence[Sequence[Any]]]</tt> | The layer to wrap. |
-| **RETURNS** | <tt>Model[ListXd, ListXd]</tt>                                   | The wrapped layer. |
+| Argument    | Type                                            | Description        |
+| ----------- | ----------------------------------------------- | ------------------ |
+| `layer`     | <tt>Model[Sequence[Any], ArrayXd]</tt>          | The layer to wrap. |
+| **RETURNS** | <tt>Model[Sequence[Sequence[Any]], ListXd]</tt> | The wrapped layer. |
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/with_flatten.py


### PR DESCRIPTION
The idea of the `with_flatten` layer is that it flattens a nested sequence, passes it to the wrapped layer, and then unflattens the output of the wrapped layer.

However, the layer was asymmetric in that it passes a list to the wrapped layer, but expects back an XP array. This breaks composition with other Thinc layers, such as `with_array`.

This change makes `with_flatten` symmetric, in that the inputs/outputs of the `with_flatten` and the wrapped layer are symmetric.

It seems that this layer is not used in Thinc or spaCy, so maybe it never worked correctly? At any rate, I needed to flatten a nested list in distillation with `with_flatten(with_array(...))` in distillation and found that it doesn't actually work.