### PR TITLE
Smooth one hot fix

### DIFF
--- a/thinc/tests/test_util.py
+++ b/thinc/tests/test_util.py
@@ -1,4 +1,4 @@
-pmport pytest
+import pytest
 import numpy
 from hypothesis import given
 from thinc.api import get_width, Ragged, Padded

--- a/thinc/tests/test_util.py
+++ b/thinc/tests/test_util.py
@@ -1,11 +1,13 @@
-import pytest
+pmport pytest
 import numpy
 from hypothesis import given
 from thinc.api import get_width, Ragged, Padded
 from thinc.util import get_array_module, is_numpy_array, to_categorical
 from thinc.util import is_cupy_array
 from thinc.util import convert_recursive
+from thinc.util import smooth_one_hot
 from thinc.types import ArgsKwargs
+
 
 from . import strategies
 
@@ -143,6 +145,26 @@ def test_to_categorical(label_smoothing):
 
     with pytest.raises(ValueError, match=r"label_smoothing parameter"):
         to_categorical(numpy.asarray([0, 1, 2, 3, 4]), label_smoothing=0.88)
+
+
+@given(
+    n_classes=strategies.lengths(lo=2, hi=100),
+    n_samples=strategies.lengths(lo=1, hi=100),
+    label_smoothing=strategies.floats(min_value=0.0, max_value=1.0)
+)
+def test_smooth_one_hot(n_samples, n_classes, label_smoothing):
+    one_hot = numpy.zeros((n_samples, n_classes))
+    labels = numpy.random.randint(0, n_classes, (n_samples,))
+    one_hot[numpy.arange(n_samples), labels] = 1
+    max_smooth = (n_classes - 1) / n_classes
+    if label_smoothing >= max_smooth:
+        with pytest.raises(ValueError, match=r"label_smoothing parameter has to be less than"):
+            smooth_one_hot(one_hot, label_smoothing)
+    else:
+        smoothed = smooth_one_hot(one_hot, label_smoothing)
+        assert numpy.all(numpy.argmax(smoothed, axis=1) == labels)
+        assert smoothed.shape == one_hot.shape
+        assert numpy.allclose(smoothed.sum(1), 1.0)
 
 
 def test_convert_recursive():

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -257,12 +257,17 @@ def smooth_one_hot(X: Floats2d, label_smoothing: float) -> Floats2d:
     """
     Apply label-smoothing to one-hot array.
     """
+    n_classes = X.shape[1]
+    max_smooth = (n_classes - 1) / n_classes
     if label_smoothing < 0.0:
         raise ValueError(
             "Label-smoothing parameter has to be greater than or equal to 0"
         )
-    n_classes = X.shape[1]
-    max_smooth = (n_classes - 1) / n_classes
+    if not n_classes > 1:
+        raise ValueError(
+            "n_classes should be greater than 1 when label smoothing is enabled,"
+            f"but {n_classes} was provided."
+        )
     if label_smoothing >= max_smooth:
         raise ValueError(
             f"For {n_classes} classes "
@@ -637,6 +642,7 @@ __all__ = [
     "require_gpu",
     "copy_array",
     "to_categorical",
+    "smooth_one_hot",
     "get_width",
     "xp2torch",
     "torch2xp",

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -257,14 +257,20 @@ def smooth_one_hot(X: Floats2d, label_smoothing: float) -> Floats2d:
     """
     Apply label-smoothing to one-hot array.
     """
-    if not 0.0 <= label_smoothing < 0.5:
+    if label_smoothing < 0.0:
         raise ValueError(
-            "label_smoothing should be greater or "
-            "equal to 0.0 and less than 0.5, "
-            f"but {label_smoothing} was provided."
+            "Label-smoothing parameter has to be greater than or equal to 0"
+        )
+    n_classes = X.shape[1]
+    max_smooth = (n_classes - 1) / n_classes
+    if label_smoothing >= max_smooth:
+        raise ValueError(
+            f"For {n_classes} classes "
+            "label_smoothing parameter has to be less than "
+            f"{max_smooth}, but found {label_smoothing}."
         )
     X[X == 1] = 1 - label_smoothing
-    X[X == 0] = label_smoothing / (X.shape[1] - 1)
+    X[X == 0] = label_smoothing / (n_classes - 1)
     return X
 
 


### PR DESCRIPTION
The `smooth_one_hot` function in `thinc.util` is being called in the `CategoricalCrossentropy` to apply label smoothing. This PR fixes the check for valid label-smoothing parameter, which was fixed before for `to_categorical`, but not for `smooth_one_hot`. Also added a test for `smooth_one_hot` which was also missing.