### PR TITLE
Fix required maximum version of typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy>=1.15.0
 packaging>=20.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"
-typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"
+typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
 contextvars>=2.4,<3; python_version < "3.7"
 # Development dependencies
 cython>=0.25.0,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy>=1.15.0
 packaging>=20.0
 # Backports of modern Python features
 dataclasses>=0.6,<1.0; python_version < "3.7"
-typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
+typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
 contextvars>=2.4,<3; python_version < "3.7"
 # Development dependencies
 cython>=0.25.0,<3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     packaging>=20.0
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"
-    typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"
+    typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
     contextvars>=2.4,<3; python_version < "3.7"
     
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     packaging>=20.0
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"
-    typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
+    typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
     contextvars>=2.4,<3; python_version < "3.7"
     
 [options.entry_points]


### PR DESCRIPTION
This PR fixes the required maximum version of typing-extensions.

Currently it is bounded to <4.2.0: `typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"`

This PR sets the upper bound to all compatible versions, until the next major release <5.0.0.

Required:
- [ ] https://github.com/explosion/confection/pull/20

See:
- https://github.com/explosion/spaCy/issues/12034

See issue in pydantic:
- https://github.com/pydantic/pydantic/issues/4885

See fixing PR in pydantic (`typing-extensions>=4.2.0`), which will be incompatible with your requirement `typing_extensions>=3.7.4,<4.2.0; python_version < "3.8"`:
- https://github.com/pydantic/pydantic/pull/4886