### PR TITLE
Fix cython directive `language_level`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ COMPILE_OPTIONS = {
     "other": ["-O3", "-Wno-strict-prototypes", "-Wno-unused-function", "-std=c++11"],
 }
 COMPILER_DIRECTIVES = {
-    "language_level": -3,
+    "language_level": 3,
     "embedsignature": True,
     "annotation_typing": False,
 }


### PR DESCRIPTION
`-3` use as command line argument