### PR TITLE
Allow different rate attribute names in Dropout

### DIFF
--- a/thinc/api.py
+++ b/thinc/api.py
@@ -22,9 +22,9 @@ from .backends import get_ops, set_current_ops, get_current_ops, use_ops
 from .backends import Ops, CupyOps, MPSOps, NumpyOps, set_gpu_allocator
 from .backends import use_pytorch_for_gpu_memory, use_tensorflow_for_gpu_memory
 
-from .layers import Dropout, Embed, expand_window, HashEmbed, LayerNorm, Linear
+from .layers import Dropout, Dropout_v2, Embed, expand_window, HashEmbed, LayerNorm
 from .layers import Maxout, Mish, MultiSoftmax, Relu, softmax_activation, Softmax, LSTM
-from .layers import CauchySimilarity, ParametricAttention, Logistic
+from .layers import CauchySimilarity, ParametricAttention, Linear, Logistic
 from .layers import resizable, sigmoid_activation, Sigmoid, SparseLinear
 from .layers import SparseLinear_v2, ClippedLinear, ReluK, HardTanh, HardSigmoid
 from .layers import Dish, HardSwish, HardSwishMobilenet, Swish, Gelu
@@ -84,7 +84,7 @@ __all__ = [
     "Ops", "CupyOps", "MPSOps", "NumpyOps", "set_gpu_allocator",
     "use_pytorch_for_gpu_memory", "use_tensorflow_for_gpu_memory",
     # .layers
-    "Dropout", "Embed", "expand_window", "HashEmbed", "LayerNorm", "Linear",
+    "Dropout", "Dropout_v2", "Embed", "expand_window", "HashEmbed", "LayerNorm", "Linear",
     "Maxout", "Mish", "MultiSoftmax", "Relu", "softmax_activation", "Softmax", "LSTM",
     "CauchySimilarity", "ParametricAttention", "Logistic",
     "resizable", "sigmoid_activation", "Sigmoid", "SparseLinear",

--- a/thinc/layers/__init__.py
+++ b/thinc/layers/__init__.py
@@ -1,7 +1,7 @@
 # Weights layers
 from .cauchysimilarity import CauchySimilarity
 from .dish import Dish
-from .dropout import Dropout
+from .dropout import Dropout, Dropout_v2
 from .embed import Embed
 from .expand_window import expand_window
 from .hashembed import HashEmbed
@@ -82,6 +82,7 @@ __all__ = [
     "CauchySimilarity",
     "Linear",
     "Dropout",
+    "Dropout_v2",
     "Embed",
     "expand_window",
     "HashEmbed",

--- a/thinc/layers/dropout.py
+++ b/thinc/layers/dropout.py
@@ -10,6 +10,24 @@ InT = TypeVar("InT", bound=Union[ArrayXd, Sequence[ArrayXd], Ragged, Padded])
 
 @registry.layers("Dropout.v1")
 def Dropout(
+    rate: float = 0.0
+) -> Model[InT, InT]:
+    """Help prevent overfitting by adding a random distortion to the input data
+    during training.  Specifically, cells of the input are zeroed with
+    probability determined by the `rate` argument.
+    """
+    return Model(
+        "dropout",
+        forward,
+        attrs={
+            "rate_attr_name": "dropout_rate",
+            "dropout_rate": rate,
+            "is_enabled": True,
+        },
+    )
+
+@registry.layers("Dropout.v2")
+def Dropout_v2(
     rate: float = 0.0, *, rate_attr_name: str = "dropout_rate"
 ) -> Model[InT, InT]:
     """Help prevent overfitting by adding a random distortion to the input data

--- a/thinc/layers/dropout.py
+++ b/thinc/layers/dropout.py
@@ -9,16 +9,33 @@ InT = TypeVar("InT", bound=Union[ArrayXd, Sequence[ArrayXd], Ragged, Padded])
 
 
 @registry.layers("Dropout.v1")
-def Dropout(rate: float = 0.0) -> Model[InT, InT]:
+def Dropout(
+    rate: float = 0.0, *, rate_attr_name: str = "dropout_rate"
+) -> Model[InT, InT]:
     """Help prevent overfitting by adding a random distortion to the input data
     during training.  Specifically, cells of the input are zeroed with
     probability determined by the `rate` argument.
+
+    rate: the probability of the dropout mask.
+    rate_attr_name: the name to use for the model attribute used to store *rate*. Different names
+        can be used to enable dropout layers to be sensitive to different calls to
+        *Model.set_dropout_rate()*. The default both here and in *Model.set_dropout_rate()* is
+        `dropout_rate`.
     """
-    return Model("dropout", forward, attrs={"dropout_rate": rate, "is_enabled": True})
+    return Model(
+        "dropout",
+        forward,
+        attrs={
+            "rate_attr_name": rate_attr_name,
+            rate_attr_name: rate,
+            "is_enabled": True,
+        },
+    )
 
 
 def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callable]:
-    rate = model.attrs["dropout_rate"]
+    rate_attr_name = model.attrs["rate_attr_name"]
+    rate = model.attrs[rate_attr_name]
     is_enabled = model.attrs["is_enabled"] and is_train
     if rate == 0 or not is_enabled:
         return X, lambda dY: dY
@@ -39,7 +56,8 @@ def forward(model: Model[InT, InT], X: InT, is_train: bool) -> Tuple[InT, Callab
 def _dropout_array(
     model: Model[InT, InT], X: ArrayXd, is_train: bool
 ) -> Tuple[ArrayXd, Callable]:
-    rate = model.attrs["dropout_rate"]
+    rate_attr_name = model.attrs["rate_attr_name"]
+    rate = model.attrs[rate_attr_name]
     mask = model.ops.get_dropout_mask(X.shape, rate)
 
     def backprop(dY: ArrayXd) -> ArrayXd:
@@ -52,7 +70,9 @@ def _dropout_padded(
     model: Model[InT, InT], Xp: Padded, is_train: bool
 ) -> Tuple[Padded, Callable]:
     X = Xp.data
-    mask = model.ops.get_dropout_mask(X.shape, model.attrs["dropout_rate"])
+    rate_attr_name = model.attrs["rate_attr_name"]
+    rate = model.attrs[rate_attr_name]
+    mask = model.ops.get_dropout_mask(X.shape, rate)
     Y = X * mask
 
     def backprop(dYp: Padded) -> Padded:
@@ -66,7 +86,9 @@ def _dropout_ragged(
 ) -> Tuple[Ragged, Callable]:
     X = Xr.data
     lengths = Xr.lengths
-    mask = model.ops.get_dropout_mask(X.shape, model.attrs["dropout_rate"])
+    rate_attr_name = model.attrs["rate_attr_name"]
+    rate = model.attrs[rate_attr_name]
+    mask = model.ops.get_dropout_mask(X.shape, rate)
     Y = X * mask
 
     def backprop(dYr: Ragged) -> Ragged:
@@ -78,7 +100,8 @@ def _dropout_ragged(
 def _dropout_lists(
     model: Model[InT, InT], Xs: Sequence[ArrayXd], is_train: bool
 ) -> Tuple[Sequence[ArrayXd], Callable]:
-    rate = model.attrs["dropout_rate"]
+    rate_attr_name = model.attrs["rate_attr_name"]
+    rate = model.attrs[rate_attr_name]
     masks = [model.ops.get_dropout_mask(X.shape, rate) for X in Xs]
     Ys = [X * mask for X, mask in zip(Xs, masks)]
 

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -224,7 +224,7 @@ def test_set_dropout_2(model_with_no_args):
 
 
 def test_set_dropout_specified_attr_name():
-    model = Dropout_v2(rate_attr_name="another_dropout_rate")
+    model = Dropout_v2(dropout_attr="another_dropout_rate")
     assert model.attrs["another_dropout_rate"] == 0.0
     set_dropout_rate(model, 0.2)
     assert model.attrs["another_dropout_rate"] == 0.0

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -4,7 +4,7 @@ import threading
 import time
 from thinc.api import Adam, CupyOps, Dropout, Linear, Model, Relu
 from thinc.api import Shim, Softmax, chain, change_attr_values
-from thinc.api import concatenate, set_dropout_rate
+from thinc.api import concatenate, set_dropout_rate, Dropout_v2
 from thinc.api import use_ops, with_debug, wrap_model_recursive
 from thinc.compat import has_cupy_gpu
 import numpy
@@ -224,7 +224,7 @@ def test_set_dropout_2(model_with_no_args):
 
 
 def test_set_dropout_specified_attr_name():
-    model = Dropout(rate_attr_name="another_dropout_rate")
+    model = Dropout_v2(rate_attr_name="another_dropout_rate")
     assert model.attrs["another_dropout_rate"] == 0.0
     set_dropout_rate(model, 0.2)
     assert model.attrs["another_dropout_rate"] == 0.0

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -223,6 +223,17 @@ def test_set_dropout_2(model_with_no_args):
     assert model.attrs["dropout_rate"] == 0.2
 
 
+def test_set_dropout_specified_attr_name():
+    model = Dropout(rate_attr_name="another_dropout_rate")
+    assert model.attrs["another_dropout_rate"] == 0.0
+    set_dropout_rate(model, 0.2)
+    assert model.attrs["another_dropout_rate"] == 0.0
+    set_dropout_rate(model, 0.2, attrs=["another_dropout_rate"])
+    assert model.attrs["another_dropout_rate"] == 0.2
+    set_dropout_rate(model, 0.3, attrs=["dropout_rate", "another_dropout_rate"])
+    assert model.attrs["another_dropout_rate"] == 0.3
+
+
 def test_bind_plus():
     with Model.define_operators({"+": lambda a, b: (a.name, b.name)}):
         m = create_model(name="a") + create_model(name="b")

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -106,10 +106,11 @@ for node in model.walk():
         node.attrs["dropout_rate"] = 0.5
 ```
 
-| Argument       | Type                 | Description                                                                                                                             |
-| -------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `dropout_rate` | <tt>float</tt>       | The probability of zeroing the activations (default: 0). Higher dropout rates mean more distortion. Values around `0.2` are often good. |
-| **RETURNS**    | <tt>Model[T, T]</tt> | The created dropout layer.                                                                                                              |
+| Argument         | Type                 | Description                                                                                                                                                                                                            |
+| ---------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rate`           | <tt>float</tt>       | The probability of zeroing the activations (default: 0). Higher dropout rates mean more distortion. Values around `0.2` are often good.                                                                                |
+| `rate_attr_name` | <tt>str</tt>         | The name of the attribute used within the model to store the value of `rate`. Different names can be set to make dropout layers sensitive to different calls to `Model.set_dropout_rate()` (default `"dropout_rate"`). |
+| **RETURNS**      | <tt>Model[T, T]</tt> | The created dropout layer.                                                                                                                                                                                             |
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/dropout.py
@@ -1003,7 +1004,7 @@ model, e.g. `chain(f, g)` computes `g(f(x))`.
 
 | Argument    | Type           | Description                       |
 | ----------- | -------------- | --------------------------------- |
-| `layer1 `   | <tt>Model</tt> | The first model to compose.       |
+| `layer1`    | <tt>Model</tt> | The first model to compose.       |
 | `layer2`    | <tt>Model</tt> | The second model to compose.      |
 | `*layers`   | <tt>Model</tt> | Any additional models to compose. |
 | **RETURNS** | <tt>Model</tt> | The composed feed-forward model.  |

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -106,6 +106,44 @@ for node in model.walk():
         node.attrs["dropout_rate"] = 0.5
 ```
 
+| Argument    | Type                 | Description                                                                                                                             |
+| ----------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `rate`      | <tt>float</tt>       | The probability of zeroing the activations (default: 0). Higher dropout rates mean more distortion. Values around `0.2` are often good. |
+| **RETURNS** | <tt>Model[T, T]</tt> | The created dropout layer.                                                                                                              |
+
+```python
+https://github.com/explosion/thinc/blob/master/thinc/layers/dropout.py
+```
+
+### Dropout_v2 {#dropout_v2 tag="function"}
+
+<inline-list>
+
+- **Input:** <ndarray>ArrayXd</ndarray> / <ndarray>Sequence[ArrayXd]</ndarray> /
+  <ndarray>Ragged</ndarray> / <ndarray>Padded</ndarray>
+- **Output:** <ndarray>ArrayXd</ndarray> / <ndarray>Sequence[ArrayXd]</ndarray>
+  / <ndarray>Ragged</ndarray> / <ndarray>Padded</ndarray>
+- **Attrs:** `dropout_rate` <tt>float</tt>
+
+</inline-list>
+
+Helps prevent overfitting by adding a random distortion to the input data during
+training. Specifically, cells of the input are zeroed with probability
+determined by the `dropout_rate` argument. Cells which are not zeroed are
+rescaled by `1-rate`. When not in training mode, the distortion is disabled (see
+[Hinton et al., 2012](https://arxiv.org/abs/1207.0580)).
+
+```python
+### Example
+from thinc.api import chain, Linear, Dropout
+model = chain(Linear(10, 2), Dropout(0.2))
+Y, backprop = model(X, is_train=True)
+# Configure dropout rate via the dropout_rate attribute.
+for node in model.walk():
+    if node.name == "dropout":
+        node.attrs["dropout_rate"] = 0.5
+```
+
 | Argument         | Type                 | Description                                                                                                                                                                                                            |
 | ---------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `rate`           | <tt>float</tt>       | The probability of zeroing the activations (default: 0). Higher dropout rates mean more distortion. Values around `0.2` are often good.                                                                                |

--- a/website/docs/api-layers.md
+++ b/website/docs/api-layers.md
@@ -144,11 +144,11 @@ for node in model.walk():
         node.attrs["dropout_rate"] = 0.5
 ```
 
-| Argument         | Type                 | Description                                                                                                                                                                                                            |
-| ---------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `rate`           | <tt>float</tt>       | The probability of zeroing the activations (default: 0). Higher dropout rates mean more distortion. Values around `0.2` are often good.                                                                                |
-| `rate_attr_name` | <tt>str</tt>         | The name of the attribute used within the model to store the value of `rate`. Different names can be set to make dropout layers sensitive to different calls to `Model.set_dropout_rate()` (default `"dropout_rate"`). |
-| **RETURNS**      | <tt>Model[T, T]</tt> | The created dropout layer.                                                                                                                                                                                             |
+| Argument       | Type                 | Description                                                                                                                                                                                                            |
+| -------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rate`         | <tt>float</tt>       | The probability of zeroing the activations (default: 0). Higher dropout rates mean more distortion. Values around `0.2` are often good.                                                                                |
+| `dropout_attr` | <tt>str</tt>         | The name of the attribute used within the model to store the value of `rate`. Different names can be set to make dropout layers sensitive to different calls to `Model.set_dropout_rate()` (default `"dropout_rate"`). |
+| **RETURNS**    | <tt>Model[T, T]</tt> | The created dropout layer.                                                                                                                                                                                             |
 
 ```python
 https://github.com/explosion/thinc/blob/master/thinc/layers/dropout.py


### PR DESCRIPTION
## Description

`Model.set_dropout_rate()` allows the specification of attribute names to set within models; the default is `dropout_rate`. However, in the pre-existing code there is no scope for using any value other than `dropout_rate` within a `Dropout` layer. This PR fixes this.

### Types of change

Enhancement/new feature

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
