### PR TITLE
Convert Azure pipeline config to github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,7 @@ jobs:
   tests:
     name: Test
     strategy:
-      # TODO change me to false
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.11"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,11 @@ jobs:
           - os: windows-2019
             python_version: "3.6"
           - os: ubuntu-latest
-            python-version: "3.8"
+            python_version: "3.8"
           - os: macos-latest
-            python-version: ["3.7", "3.10"]
+            python_version: ["3.7", "3.10"]
           - os: windows-latest
-            python-version: "3.9"
+            python_version: "3.9"
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,9 @@ jobs:
           - os: ubuntu-latest
             python_version: "3.8"
           - os: macos-latest
-            python_version: ["3.7", "3.10"]
+            python_version: "3.7"
+          - os: macos-latest
+            python_version: "3.10"
           - os: windows-latest
             python_version: "3.9"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run mypy
         run: python -m mypy thinc --no-implicit-reexport
-        if: matrix.python_version != "3.6"
+        if: matrix.python_version != '3.6'
 
       - name: Delete source directory
         run: rm -rf thinc
@@ -102,8 +102,8 @@ jobs:
           pip uninstall -y tensorflow
           pip install thinc-apple-ops
           python -m pytest --pyargs thinc_apple_ops
-        if: matrix.os == "macos-latest" && matrix.python_version == "3.10"
+        if: matrix.os == 'macos-latest' && matrix.python_version == '3.10'
 
       - name: Run tests with thinc-apple-ops
         run: python -m pytest --pyargs thinc
-        if: matrix.os == "macos-latest" && matrix.python_version == "3.10"
+        if: matrix.os == 'macos-latest' && matrix.python_version == '3.10'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,19 @@ jobs:
     strategy:
       # TODO change me to false
       fail-fast: true
-      # TODO fix matrix
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.11"]
+        include:
+          - os: windows-2019
+            python_version: "3.6"
+          - os: ubuntu-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: ["3.7", "3.10"]
+          - os: windows-latest
+            python-version: "3.9"
+
     runs-on: ${{ matrix.os }}
     env:
       NOTEBOOK_KERNEL: "thinc-notebook-tests"
@@ -84,6 +93,9 @@ jobs:
       # 2. restrict to numpy<1.24.0 due to mxnet incompatibility
       # 3. keep restriction to torch<1.13.0 due to segfaults with numpy<1.24.0,
       # which skips torch for python 3.11
+      # Note: some of those pip install are currently failing. As requested by
+      # Adriane and Matt, removing -e from default bash flags to avoid CI failure.
+      # GHA docs for reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
       - name: Install extras for testing
         run: |
           pip install "protobuf~=3.20.0" "tensorflow~=2.5.0"
@@ -93,6 +105,7 @@ jobs:
           pip install "numpy<1.24.0"
           pip install -r requirements.txt
           pip uninstall -y mypy
+        shell: bash --noprofile --norc -o pipefail {0}
 
       - name: Run tests with extras
         run: python -m pytest --pyargs thinc --cov=thinc --cov-report=term

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,109 @@
+name: tests
+
+on:
+  push:
+    paths-ignore:
+      - "website/*"
+      - "*.md"
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths-ignore:
+      - "website/*"
+      - "*.md"
+
+jobs:
+  tests:
+    name: Test
+    strategy:
+      # TODO change me to false
+      fail-fast: true
+      # TODO fix matrix
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}
+    env:
+      NOTEBOOK_KERNEL: "thinc-notebook-tests"
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      - name: Configure Python version
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+          architecture: x64
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+
+      - name: Build sdist
+        run: |
+          python setup.py build_ext --inplace
+          python setup.py sdist --formats=gztar
+
+      - name: Run mypy
+        run: python -m mypy thinc --no-implicit-reexport
+        if: matrix.python_version != "3.6"
+
+      - name: Delete source directory
+        run: rm -rf thinc
+        shell: bash
+
+      - name: Uninstall all packages
+        run: |
+          python -m pip freeze
+          pip freeze --exclude pywin32 > installed.txt
+          pip uninstall -y -r installed.txt
+
+      - name: Install from sdist
+        run: |
+          SDIST=$(python -c "import os;print(os.listdir('./dist')[-1])" 2>&1)
+          PIP_CONSTRAINT="build-constraints.txt" pip install dist/$SDIST
+        shell: bash
+
+      - name: Test import
+        run: python -c "import thinc"
+
+      - name: Run tests without extras
+        run: |
+          pip install -r requirements.txt
+          pip install ipykernel pydot graphviz
+          python -m ipykernel install --name thinc-notebook-tests --user
+          python -m pytest --pyargs thinc --cov=thinc --cov-report=term
+
+      # Notes on numpy requirements hacks:
+      # 1. torch does not have a direct numpy requirement but is compiled
+      # against a newer version than the oldest supported numpy for windows and
+      # python 3.10; this version of numpy would not work with
+      # tensorflow~=2.5.0 as specified above, but there is no release for
+      # python 3.10 anyway
+      # 2. restrict to numpy<1.24.0 due to mxnet incompatibility
+      # 3. keep restriction to torch<1.13.0 due to segfaults with numpy<1.24.0,
+      # which skips torch for python 3.11
+      - name: Install extras for testing
+        run: |
+          pip install "protobuf~=3.20.0" "tensorflow~=2.5.0"
+          pip install "mxnet; sys_platform != 'win32'"
+          pip install "torch<1.13.0" --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install "numpy~=1.23.0; python_version=='3.10' and sys_platform=='win32'"
+          pip install "numpy<1.24.0"
+          pip install -r requirements.txt
+          pip uninstall -y mypy
+
+      - name: Run tests with extras
+        run: python -m pytest --pyargs thinc --cov=thinc --cov-report=term
+
+      - name: Run tests for thinc-apple-ops
+        run: |
+          pip uninstall -y tensorflow
+          pip install thinc-apple-ops
+          python -m pytest --pyargs thinc_apple_ops
+        if: matrix.os == "macos-latest" && matrix.python_version == "3.10"
+
+      - name: Run tests with thinc-apple-ops
+        run: python -m pytest --pyargs thinc
+        if: matrix.os == "macos-latest" && matrix.python_version == "3.10"


### PR DESCRIPTION
## Description

This PR converts the existing [Azure Pipeline config file](https://github.com/explosion/thinc/blob/248c32b5aa317c5ea0e7f05253292f8007175d76/azure-pipelines.yml) to GHA.

As requested, I removed `-e` from the default bash flags at the `Install extras for testing` step. This will prevent early pip install errors from failing CI. Once the underlying issue is fixed, you can remove `shell: bash --noprofile --norc -o pipefail {0}` to return to GHA default behavior. More details are available in [GHA docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell).

You can see the result of the [latest GHA run here](https://github.com/patjouk/thinc/actions/runs/4172701107). 

### Types of change

Add GHA based on the existing Azure pipeline configuration.

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
