### PR TITLE
Implement `pad` as a CUDA kernel

### DIFF
--- a/thinc/backends/_custom_kernels.cu
+++ b/thinc/backends/_custom_kernels.cu
@@ -122,6 +122,25 @@ __global__ void seq2col(T* output, const T* X, const int* lengths,
 
 
 template <typename T>
+__global__ void pad(T* out, T const **seqs, int const *lengths, int stride, int N, int L)
+{
+    int _loop_start = blockIdx.x * blockDim.x + threadIdx.x;
+    int _loop_stride = blockDim.x * gridDim.x;
+
+    for (int i = _loop_start; i < L * stride; i += _loop_stride) {
+        for (int j = 0; j < N; ++j) {
+            T const *seq = seqs[j];
+            if (i < lengths[j] * stride) {
+                out[j * L * stride + i] = seq[i];
+            } else {
+                out[j * L * stride + i] = T();
+            }
+        }
+    }
+}
+
+
+template <typename T>
 __global__ void maxout(T* best, int* which, const T* cands, int B, int O, int P)
 {
     int _loop_start = blockIdx.x * blockDim.x + threadIdx.x;

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -165,7 +165,9 @@ def pad(seqs, round_to=1, *, threads_per_block=128, num_blocks=128):
 
     seq_lens = [len(seq) for seq in seqs]
     max_seq_len = max(seq_lens)
-    max_seq_len = (max_seq_len + (round_to - 1)) // round_to * round_to
+    # Round the length to nearest bucket -- helps on GPU, to make similar
+    # array sizes.
+    max_seq_len += -max_seq_len % round_to
     seq_lens = cupy.array(seq_lens, dtype="int32")
     final_shape = (len(seqs), max_seq_len) + seqs[0].shape[1:]
     out = cupy.empty(final_shape, dtype=seqs[0].dtype)

--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -158,6 +158,8 @@ def _alloc_like(array, zeros: bool = True):
 
 
 def pad(seqs, round_to=1, *, threads_per_block=128, num_blocks=128):
+    if round_to < 1:
+        raise ValueError(f"Rounding for padding must at least be 1, was: {round_to}")
     for seq in seqs:
         _is_float_or_int_array(seq)
 

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -358,6 +358,11 @@ class Ops:
         length, by taking the maximum dimension across each axis. This only
         works on non-empty sequences with the same `ndim` and `dtype`.
         """
+        if round_to < 1:
+            raise ValueError(
+                f"Rounding for padding must at least be 1, was: {round_to}"
+            )
+
         # TODO: This should be generalized to handle different ranks
         if not seqs:
             raise ValueError("Cannot pad empty sequence")

--- a/thinc/backends/ops.py
+++ b/thinc/backends/ops.py
@@ -373,11 +373,11 @@ class Ops:
         if len(set(seq.shape[1:] for seq in seqs)) != 1:
             raise ValueError("Cannot pad sequences that differ on other dimensions")
         # Find the maximum dimension along each axis. That's what we'll pad to.
-        length = max(len(seq) for seq in seqs)
+        max_seq_len = max(len(seq) for seq in seqs)
         # Round the length to nearest bucket -- helps on GPU, to make similar
         # array sizes.
-        length = (length + (round_to - 1)) // round_to * round_to
-        final_shape = (len(seqs), length) + seqs[0].shape[1:]
+        max_seq_len += -max_seq_len % round_to
+        final_shape = (len(seqs), max_seq_len) + seqs[0].shape[1:]
         output: Array3d = cast(Array3d, self.alloc(final_shape, dtype=seqs[0].dtype))
         for i, arr in enumerate(seqs):
             # It's difficult to convince this that the dtypes will match.

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -809,6 +809,9 @@ def test_pad(ops, dtype):
         ],
     )
 
+    with pytest.raises(ValueError, match=r"Rounding for padding must at least be 1"):
+        ops.pad(X, round_to=0)
+
 
 @pytest.mark.parametrize("ops", ALL_OPS)
 @pytest.mark.parametrize("dtype", FLOAT_TYPES)

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -32,6 +32,7 @@ if has_cupy_gpu:
 ALL_OPS = XP_OPS + [VANILLA_OPS]
 
 FLOAT_TYPES = ["float32", "float64"]
+INT_TYPES = ["int32", "int64"]
 
 
 def create_pytorch_funcs():
@@ -788,6 +789,25 @@ def test_flatten_unflatten_roundtrip(cpu_ops, X):
     assert len(flat2) > len(flat)
     unflat2 = cpu_ops.unflatten(flat2, [len(x) for x in X], pad=1)
     assert_allclose(X, unflat2)
+
+
+@pytest.mark.parametrize("ops", ALL_OPS)
+@pytest.mark.parametrize("dtype", FLOAT_TYPES + INT_TYPES)
+def test_pad(ops, dtype):
+    X = [ops.xp.arange(1, 3, dtype=dtype), ops.xp.arange(1, 5, dtype=dtype)]
+    ops.xp.testing.assert_allclose(ops.pad(X), [[1, 2, 0, 0], [1, 2, 3, 4]])
+
+    X = [
+        ops.xp.arange(1, 5, dtype=dtype).reshape(2, 2),
+        ops.xp.arange(1, 9, dtype=dtype).reshape(4, 2),
+    ]
+    ops.xp.testing.assert_allclose(
+        ops.pad(X),
+        [
+            [[1, 2], [3, 4], [0, 0], [0, 0]],
+            [[1, 2], [3, 4], [5, 6], [7, 8]],
+        ],
+    )
 
 
 @pytest.mark.parametrize("ops", ALL_OPS)

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -796,6 +796,9 @@ def test_flatten_unflatten_roundtrip(cpu_ops, X):
 def test_pad(ops, dtype):
     X = [ops.xp.arange(1, 3, dtype=dtype), ops.xp.arange(1, 5, dtype=dtype)]
     ops.xp.testing.assert_allclose(ops.pad(X), [[1, 2, 0, 0], [1, 2, 3, 4]])
+    ops.xp.testing.assert_allclose(
+        ops.pad(X, round_to=8), [[1, 2, 0, 0, 0, 0, 0, 0], [1, 2, 3, 4, 0, 0, 0, 0]]
+    )
 
     X = [
         ops.xp.arange(1, 5, dtype=dtype).reshape(2, 2),
@@ -806,6 +809,14 @@ def test_pad(ops, dtype):
         [
             [[1, 2], [3, 4], [0, 0], [0, 0]],
             [[1, 2], [3, 4], [5, 6], [7, 8]],
+        ],
+    )
+
+    ops.xp.testing.assert_allclose(
+        ops.pad(X, round_to=5),
+        [
+            [[1, 2], [3, 4], [0, 0], [0, 0], [0, 0]],
+            [[1, 2], [3, 4], [5, 6], [7, 8], [0, 0]],
         ],
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`Ops.pad` was a fairly slow operation on GPU. It iterates over all sequences and copies each sequence into the padded array. This results in a lot of kernel launches. In the biaffine parser, padding the inputs was more costly than applying the biaffine layers.

This change optimizes the `pad` op using a custom CUDA kernel. The kernel get an array of pointers to the CuPy arrays that are provided as a list. The output array is then filled, parallelizing over the 'time steps'. This should provides the largest amount of parallelism, since we usually have n_steps * hidden_size to parallelize over.

Before:

<img width="1192" alt="before-padding-change" src="https://user-images.githubusercontent.com/49398/224365739-2017a425-bf93-4070-96c6-e14da680f2c5.png">

After:

<img width="1371" alt="padding-after-change" src="https://user-images.githubusercontent.com/49398/224365784-4b9f6237-0592-4f38-9cc3-1fecb4c336c4.png">

~**Warning:** please do not review yet! There are still some todo items and I still want to be able to rebase the branch.~

- [x] Extend to int32 and int64, so that we can use this optimization in curated transformers as well.
- [x] Test by training in an actual model.
- [x] Rebase to Thinc `master`.
- [x] Clean up some redundancies in the `Ops.pad` code.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
