### PR TITLE
Avoid h2d - d2h roundtrip when using `unflatten`

### DIFF
--- a/thinc/layers/concatenate.py
+++ b/thinc/layers/concatenate.py
@@ -1,11 +1,16 @@
 from typing import Any, List, Tuple, Callable, Optional
 from typing import TypeVar, cast, Dict, Union, Sequence
+
+from ..backends import NumpyOps
 from ..model import Model
 from ..config import registry
 from ..types import Array2d, Ragged
 from ..util import get_width
 from .noop import noop
 from ..types import XY_XY_OutT
+
+
+NUMPY_OPS = NumpyOps()
 
 
 InT = TypeVar("InT", bound=Any)
@@ -120,7 +125,7 @@ def _list_forward(
             start += width
         return dX
 
-    lengths = model.ops.asarray1i([len(x) for x in X])
+    lengths = NUMPY_OPS.asarray1i([len(x) for x in X])
     Ys = [model.ops.xp.concatenate(Y, axis=0) for Y in Ys]
     widths = [Y.shape[1] for Y in Ys]
     out_array = model.ops.xp.hstack(Ys)

--- a/thinc/layers/list2array.py
+++ b/thinc/layers/list2array.py
@@ -1,8 +1,12 @@
-from typing import Tuple, Callable, TypeVar, List, Union, cast
+from typing import Tuple, Callable, TypeVar, List
 
+from ..backends import NumpyOps
 from ..model import Model
 from ..config import registry
 from ..types import Array2d
+
+
+NUMPY_OPS = NumpyOps()
 
 
 OutT = TypeVar("OutT", bound=Array2d)
@@ -19,7 +23,7 @@ def list2array() -> Model[InT, OutT]:
 
 
 def forward(model: Model[InT, OutT], Xs: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    lengths = model.ops.asarray1i([len(x) for x in Xs])
+    lengths = NUMPY_OPS.asarray1i([len(x) for x in Xs])
 
     def backprop(dY: OutT) -> InT:
         return model.ops.unflatten(dY, lengths)

--- a/thinc/layers/with_array.py
+++ b/thinc/layers/with_array.py
@@ -1,8 +1,13 @@
 from typing import Tuple, Callable, Optional, TypeVar, Union, cast
 
+from ..backends import NumpyOps
 from ..model import Model
 from ..config import registry
 from ..types import Padded, Ragged, ArrayXd, Array3d, ListXd
+
+
+NUMPY_OPS = NumpyOps()
+
 
 ArrayTXd = TypeVar("ArrayTXd", bound=ArrayXd)
 SeqT = TypeVar("SeqT", bound=Union[Padded, Ragged, ListXd, ArrayXd])
@@ -68,7 +73,7 @@ def _list_forward(
 ) -> Tuple[ListXd, Callable]:
     layer: Model[ArrayXd, ArrayXd] = model.layers[0]
     pad = model.attrs["pad"]
-    lengths = layer.ops.asarray1i([len(seq) for seq in Xs])
+    lengths = NUMPY_OPS.asarray1i([len(seq) for seq in Xs])
     Xf = layer.ops.flatten(Xs, pad=pad)
     Yf, get_dXf = layer(Xf, is_train)
 

--- a/thinc/layers/with_array2d.py
+++ b/thinc/layers/with_array2d.py
@@ -1,8 +1,12 @@
 from typing import Tuple, Callable, Optional, TypeVar, cast, List, Union
 
+from ..backends import NumpyOps
 from ..model import Model
 from ..config import registry
 from ..types import Array2d, Floats2d, List2d, Padded, Ragged
+
+
+NUMPY_OPS = NumpyOps()
 
 
 ValT = TypeVar("ValT", bound=Array2d)
@@ -71,7 +75,7 @@ def _list_forward(
 ) -> Tuple[List2d, Callable]:
     layer: Model[Array2d, Array2d] = model.layers[0]
     pad = model.attrs["pad"]
-    lengths = layer.ops.asarray1i([len(seq) for seq in Xs])
+    lengths = NUMPY_OPS.asarray1i([len(seq) for seq in Xs])
     Xf = layer.ops.flatten(Xs, pad=pad)
     Yf, get_dXf = layer(Xf, is_train)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`unflatten` converts its `lengths` argument to a NumPy array, because CuPy's `split` function requires lengths to be in CPU memory. However, in various places in Thinc, we copy the lengths array to GPU memory when CupyOps is used. This results in an unnecessary roundtrip of the lengths array (host to device -> device to host). One of these roundtrips (array `list2array`) showed up in profiles of the biaffine parser.

This change fixes some length array allocations to avoid the round trip.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Performance improvement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
