### PR TITLE
make has_ predicated private

### DIFF
--- a/thinc/backends/_custom_kernels.py
+++ b/thinc/backends/_custom_kernels.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 import re
 from pathlib import Path
 from collections import defaultdict
-from ..compat import cupy, has_cupy_gpu
+from ..compat import cupy, _has_cupy_gpu
 
 
 PWD = Path(__file__).parent
@@ -57,7 +57,7 @@ KERNELS = (
     cupy.RawModule(
         code=KERNELS_SRC, options=("--std=c++11",), name_expressions=KERNELS_LIST
     )
-    if has_cupy_gpu
+    if _has_cupy_gpu
     else None
 )
 
@@ -72,7 +72,7 @@ def _get_kernel(name):
 
 
 def compile_mmh(src):
-    if not has_cupy_gpu:
+    if not _has_cupy_gpu:
         return None
     return cupy.RawKernel(src, "hash_data")
 
@@ -757,7 +757,7 @@ _values_within_range = (
         "true",
         "within_range",
     )
-    if has_cupy_gpu
+    if _has_cupy_gpu
     else None
 )
 

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -21,7 +21,7 @@ from ..util import copy_array, get_array_module
 from ..types import DeviceTypes, DTypes, Shape, ArrayXd
 from .cblas cimport CBlas, daxpy, saxpy, sgemm, dgemm, sscal
 from .ops import Ops, _split_weights, _transpose_weights, _untranspose_unsplit_weights
-from ..compat import has_blis
+from ..compat import _has_blis
 
 
 cdef extern from "math.h":
@@ -48,7 +48,7 @@ class NumpyOps(Ops):
         self.device_type = device_type
         self.device_id = device_id
         self.use_blis = use_blis
-        if self.use_blis and not has_blis:
+        if self.use_blis and not _has_blis:
             raise ValueError("BLIS support requires blis: pip install blis")
 
     def asarray(self, data, dtype=None):

--- a/thinc/compat.py
+++ b/thinc/compat.py
@@ -8,9 +8,9 @@ try:  # pragma: no cover
     cupy_version = Version(cupy.__version__)
     try:
         cupy.cuda.runtime.getDeviceCount()
-        has_cupy_gpu = True
+        _has_cupy_gpu = True
     except cupy.cuda.runtime.CUDARuntimeError:
-        has_cupy_gpu = False
+        _has_cupy_gpu = False
 
     if cupy_version.major >= 10:
         # fromDlpack was deprecated in v10.0.0.
@@ -23,54 +23,54 @@ except (ImportError, AttributeError):
     cupy_version = Version("0.0.0")
     has_cupy = False
     cupy_from_dlpack = None
-    has_cupy_gpu = False
+    _has_cupy_gpu = False
 
 
 try:  # pragma: no cover
     import torch.utils.dlpack
     import torch
 
-    has_torch = True
-    has_torch_cuda_gpu = torch.cuda.device_count() != 0
-    has_torch_mps_gpu = (
+    _has_torch = True
+    _has_torch_cuda_gpu = torch.cuda.device_count() != 0
+    _has_torch_mps_gpu = (
         hasattr(torch, "has_mps")
         and torch.has_mps  # type: ignore[attr-defined]
         and torch.backends.mps.is_available()  # type: ignore[attr-defined]
     )
-    has_torch_gpu = has_torch_cuda_gpu
+    _has_torch_gpu = _has_torch_cuda_gpu
     torch_version = Version(str(torch.__version__))
-    has_torch_amp = (
+    _has_torch_amp = (
         torch_version >= Version("1.9.0")
         and not torch.cuda.amp.common.amp_definitely_not_available()
     )
 except ImportError:  # pragma: no cover
     torch = None  # type: ignore
-    has_torch = False
-    has_torch_cuda_gpu = False
-    has_torch_gpu = False
-    has_torch_mps_gpu = False
-    has_torch_amp = False
+    _has_torch = False
+    _has_torch_cuda_gpu = False
+    _has_torch_gpu = False
+    _has_torch_mps_gpu = False
+    _has_torch_amp = False
     torch_version = Version("0.0.0")
 
 try:  # pragma: no cover
     import tensorflow.experimental.dlpack
     import tensorflow
 
-    has_tensorflow = True
-    has_tensorflow_gpu = len(tensorflow.config.get_visible_devices("GPU")) > 0
+    _has_tensorflow = True
+    _has_tensorflow_gpu = len(tensorflow.config.get_visible_devices("GPU")) > 0
 except ImportError:  # pragma: no cover
     tensorflow = None
-    has_tensorflow = False
-    has_tensorflow_gpu = False
+    _has_tensorflow = False
+    _has_tensorflow_gpu = False
 
 
 try:  # pragma: no cover
     import mxnet
 
-    has_mxnet = True
+    _has_mxnet = True
 except ImportError:  # pragma: no cover
     mxnet = None
-    has_mxnet = False
+    _has_mxnet = False
 
 try:
     import h5py
@@ -81,22 +81,22 @@ except ImportError:  # pragma: no cover
 try:  # pragma: no cover
     import os_signpost
 
-    has_os_signpost = True
+    _has_os_signpost = True
 except ImportError:
     os_signpost = None
-    has_os_signpost = False
+    _has_os_signpost = False
 
 
 try:  # pragma: no cover
     import blis
 
-    has_blis = True
+    _has_blis = True
 except ImportError:
     blis = None
-    has_blis = False
+    _has_blis = False
 
 
-has_gpu = has_cupy_gpu or has_torch_mps_gpu
+_has_gpu = _has_cupy_gpu or _has_torch_mps_gpu
 
 __all__ = [
     "cupy",

--- a/thinc/layers/with_signpost_interval.py
+++ b/thinc/layers/with_signpost_interval.py
@@ -1,6 +1,6 @@
 from typing import Optional, Callable, Any, Tuple, TypeVar
 
-from ..compat import has_os_signpost, os_signpost
+from ..compat import _has_os_signpost, os_signpost
 from ..model import Model
 
 
@@ -18,7 +18,7 @@ def with_signpost_interval(
     By default, the name of the layer is used as the name of the range,
     followed by the name of the pass.
     """
-    if not has_os_signpost:
+    if not _has_os_signpost:
         raise ValueError(
             "with_signpost_interval layer requires the 'os_signpost' package"
         )

--- a/thinc/shims/pytorch_grad_scaler.py
+++ b/thinc/shims/pytorch_grad_scaler.py
@@ -1,6 +1,6 @@
 from typing import Dict, Iterable, List, Union, cast
 
-from ..compat import has_torch_amp, torch
+from ..compat import _has_torch_amp, torch
 from ..util import is_torch_array
 
 
@@ -97,7 +97,7 @@ class PyTorchGradScaler:
         scale_per_device: Dict["torch.device", "torch.Tensor"],
         inplace: bool,
     ):
-        if not has_torch_amp:
+        if not _has_torch_amp:
             raise ValueError(
                 "Gradient scaling is not supported, requires capable GPU and torch>=1.9.0"
             )

--- a/thinc/tests/backends/test_ops.py
+++ b/thinc/tests/backends/test_ops.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 from thinc.api import NumpyOps, CupyOps, Ops, get_ops
 from thinc.api import get_current_ops, use_ops
 from thinc.util import torch2xp, xp2torch
-from thinc.compat import has_cupy_gpu, has_torch, torch_version
+from thinc.compat import _has_cupy_gpu, _has_torch, torch_version
 from thinc.api import fix_random_seed
 from thinc.api import LSTM
 from thinc.types import Floats2d
@@ -26,7 +26,7 @@ NUMPY_OPS = NumpyOps()
 BLIS_OPS = NumpyOps(use_blis=True)
 CPU_OPS = [NUMPY_OPS, VANILLA_OPS]
 XP_OPS = [NUMPY_OPS]
-if has_cupy_gpu:
+if _has_cupy_gpu:
     XP_OPS.append(CupyOps())
 ALL_OPS = XP_OPS + [VANILLA_OPS]
 
@@ -99,7 +99,7 @@ def create_pytorch_funcs():
     ]
 
 
-if has_torch:
+if _has_torch:
     TORCH_FUNCS = create_pytorch_funcs()
 else:
     TORCH_FUNCS = []
@@ -628,7 +628,7 @@ def test_backprop_seq2col_window_two(ops, dtype):
     ops.xp.testing.assert_allclose(seq, expected, atol=0.001, rtol=0.001)
 
 
-@pytest.mark.skipif(not has_cupy_gpu, reason="needs GPU/CuPy")
+@pytest.mark.skipif(not _has_cupy_gpu, reason="needs GPU/CuPy")
 @pytest.mark.parametrize("nW", [1, 2])
 def test_large_seq2col_gpu_against_cpu(nW):
     cupy_ops = CupyOps()
@@ -650,7 +650,7 @@ def test_large_seq2col_gpu_against_cpu(nW):
     assert_allclose(cols, cols_gpu.get())
 
 
-@pytest.mark.skipif(not has_cupy_gpu, reason="needs GPU/CuPy")
+@pytest.mark.skipif(not _has_cupy_gpu, reason="needs GPU/CuPy")
 @pytest.mark.parametrize("nW", [1, 2])
 def test_large_backprop_seq2col_gpu_against_cpu(nW):
     cupy_ops = CupyOps()
@@ -732,7 +732,7 @@ def torch_softmax_with_temperature(
     )
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize("ops", ALL_OPS)
 @pytest.mark.parametrize("temperature", [0.5, 1.0, 2.0])
 def test_softmax_temperature(ops, temperature):
@@ -1361,7 +1361,7 @@ def test_ngrams():
     assert len(ops.ngrams(arr1.shape[0] + 1, arr1)) == 0
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.skipif(torch_version < Version("1.9.0"), reason="needs PyTorch 1.9.0")
 @pytest.mark.parametrize("ops", ALL_OPS)
 @pytest.mark.parametrize("dtype", ["float32", "float64"])

--- a/thinc/tests/layers/test_layers_api.py
+++ b/thinc/tests/layers/test_layers_api.py
@@ -5,7 +5,7 @@ from thinc.api import registry, with_padded, Dropout, NumpyOps, Model
 from thinc.backends import NumpyOps
 from thinc.util import data_validation, get_width
 from thinc.types import Ragged, Padded, Array2d, Floats2d, FloatsXd, Shape
-from thinc.compat import has_torch
+from thinc.compat import _has_torch
 import numpy
 import pytest
 import srsly
@@ -99,7 +99,7 @@ TEST_CASES_SUMMABLE = [
     # fmt: off
     # List to list
     ("LSTM.v1", {"bi": False}, [array2d, array2d], [array2d, array2d]),
-    pytest.param("PyTorchLSTM.v1", {"bi": False, "nO": width, "nI": width}, [array2d, array2d], [array2d, array2d], marks=pytest.mark.skipif(not has_torch, reason="needs PyTorch")),
+    pytest.param("PyTorchLSTM.v1", {"bi": False, "nO": width, "nI": width}, [array2d, array2d], [array2d, array2d], marks=pytest.mark.skipif(not _has_torch, reason="needs PyTorch")),
     # fmt: on
 ]
 
@@ -110,7 +110,7 @@ TEST_CASES = [
         {"bi": True, "nO": width * 2, "nI": width},
         [array2d, array2d],
         [array2d, array2d],
-        marks=pytest.mark.skipif(not has_torch, reason="needs PyTorch"),
+        marks=pytest.mark.skipif(not _has_torch, reason="needs PyTorch"),
     ),
     ("LSTM.v1", {"bi": True}, [array2d, array2d], [array2d, array2d]),
     # Ragged to array

--- a/thinc/tests/layers/test_lstm.py
+++ b/thinc/tests/layers/test_lstm.py
@@ -2,7 +2,7 @@ import numpy
 import timeit
 from thinc.api import NumpyOps, LSTM, PyTorchLSTM, with_padded, fix_random_seed
 from thinc.api import Ops
-from thinc.compat import has_torch
+from thinc.compat import _has_torch
 import pytest
 
 
@@ -171,7 +171,7 @@ def test_lstm_init():
     model.initialize()
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 def test_pytorch_lstm_init():
     model = with_padded(PyTorchLSTM(2, 2, depth=0)).initialize()
     assert model.name == "with_padded(noop)"

--- a/thinc/tests/layers/test_mnist.py
+++ b/thinc/tests/layers/test_mnist.py
@@ -2,7 +2,7 @@ import pytest
 from thinc.api import Relu, Softmax, chain, clone, Adam
 from thinc.api import PyTorchWrapper, TensorFlowWrapper
 from thinc.api import get_current_ops
-from thinc.compat import has_torch, has_tensorflow
+from thinc.compat import _has_torch, _has_tensorflow
 
 
 @pytest.fixture(scope="module")
@@ -61,8 +61,8 @@ def create_wrapped_tensorflow(width, dropout, nI, nO):
     # fmt: off
     params=[
         create_relu_softmax,
-        pytest.param(create_wrapped_pytorch, marks=pytest.mark.skipif(not has_torch, reason="needs PyTorch")),
-        pytest.param(create_wrapped_tensorflow, marks=pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow"))
+        pytest.param(create_wrapped_pytorch, marks=pytest.mark.skipif(not _has_torch, reason="needs PyTorch")),
+        pytest.param(create_wrapped_tensorflow, marks=pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow"))
     ]
     # fmt: on
 )

--- a/thinc/tests/layers/test_mxnet_wrapper.py
+++ b/thinc/tests/layers/test_mxnet_wrapper.py
@@ -5,7 +5,7 @@ import pytest
 from thinc.api import Adam, ArgsKwargs, Model, Ops, MXNetWrapper
 from thinc.api import get_current_ops, mxnet2xp, xp2mxnet
 from thinc.types import Array2d, Array1d, IntsXd
-from thinc.compat import has_cupy_gpu, has_mxnet
+from thinc.compat import _has_cupy_gpu, _has_mxnet
 from thinc.util import to_categorical
 
 from ..util import check_input_converters, make_tempdir
@@ -67,7 +67,7 @@ def model(mx_model) -> Model[Array2d, Array2d]:
     return MXNetWrapper(mx_model)
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_roundtrip_conversion():
     import mxnet as mx
 
@@ -78,7 +78,7 @@ def test_mxnet_wrapper_roundtrip_conversion():
     assert numpy.array_equal(xp_tensor, new_xp_tensor)
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_gluon_sequential():
     import mxnet as mx
 
@@ -88,7 +88,7 @@ def test_mxnet_wrapper_gluon_sequential():
     assert isinstance(wrapped, Model)
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_built_model(
     model: Model[Array2d, Array2d], X: Array2d, Y: Array1d
 ):
@@ -98,12 +98,12 @@ def test_mxnet_wrapper_built_model(
     assert model.from_bytes(model.to_bytes()) is not None
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_predict(model: Model[Array2d, Array2d], X: Array2d):
     model.predict(X)
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_train_overfits(
     model: Model[Array2d, Array2d], X: Array2d, Y: Array1d, answer: int
 ):
@@ -117,14 +117,14 @@ def test_mxnet_wrapper_train_overfits(
     assert predicted == answer
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_can_copy_model(model: Model[Array2d, Array2d], X: Array2d):
     model.predict(X)
     copy: Model[Array2d, Array2d] = model.copy()
     assert copy is not None
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_to_bytes(model: Model[Array2d, Array2d], X: Array2d):
     model.predict(X)
     # And can be serialized
@@ -133,7 +133,7 @@ def test_mxnet_wrapper_to_bytes(model: Model[Array2d, Array2d], X: Array2d):
     model.from_bytes(model_bytes)
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_to_from_disk(model: Model[Array2d, Array2d], X: Array2d):
     model.predict(X)
     with make_tempdir() as tmp_path:
@@ -143,7 +143,7 @@ def test_mxnet_wrapper_to_from_disk(model: Model[Array2d, Array2d], X: Array2d):
         assert another_model is not None
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_from_bytes(model: Model[Array2d, Array2d], X: Array2d):
     model.predict(X)
     model_bytes = model.to_bytes()
@@ -151,21 +151,21 @@ def test_mxnet_wrapper_from_bytes(model: Model[Array2d, Array2d], X: Array2d):
     assert another_model is not None
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_to_cpu(mx_model, X: Array2d):
     model = MXNetWrapper(mx_model)
     model.predict(X)
     model.to_cpu()
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
-@pytest.mark.skipif(not has_cupy_gpu, reason="needs GPU/cupy")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_cupy_gpu, reason="needs GPU/cupy")
 def test_mxnet_wrapper_to_gpu(model: Model[Array2d, Array2d], X: Array2d):
     model.predict(X)
     model.to_gpu(0)
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 @pytest.mark.parametrize(
     "data,n_args,kwargs_keys",
     [
@@ -190,7 +190,7 @@ def test_mxnet_wrapper_convert_inputs(data, n_args, kwargs_keys):
     check_input_converters(Y, backprop, data, n_args, kwargs_keys, mx.nd.NDArray)
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_thinc_model_subclass(mx_model):
     class CustomModel(Model):
         def fn(self) -> int:
@@ -201,7 +201,7 @@ def test_mxnet_wrapper_thinc_model_subclass(mx_model):
     assert model.fn() == 1337
 
 
-@pytest.mark.skipif(not has_mxnet, reason="needs MXNet")
+@pytest.mark.skipif(not _has_mxnet, reason="needs MXNet")
 def test_mxnet_wrapper_thinc_set_model_name(mx_model):
     model = MXNetWrapper(mx_model, model_name="cool")
     assert model.name == "cool"

--- a/thinc/tests/layers/test_pytorch_wrapper.py
+++ b/thinc/tests/layers/test_pytorch_wrapper.py
@@ -7,8 +7,8 @@ from thinc.layers.pytorchwrapper import PyTorchWrapper_v3
 from thinc.shims.pytorch_grad_scaler import PyTorchGradScaler
 from thinc.shims.pytorch import default_deserialize_torch_model
 from thinc.shims.pytorch import default_serialize_torch_model
-from thinc.compat import has_torch, has_torch_amp
-from thinc.compat import has_cupy_gpu, has_torch_mps_gpu
+from thinc.compat import _has_torch, _has_torch_amp
+from thinc.compat import _has_cupy_gpu, _has_torch_mps_gpu
 import numpy
 import pytest
 from thinc.util import get_torch_default_device
@@ -17,13 +17,13 @@ from ..util import make_tempdir, check_input_converters
 
 
 XP_OPS = [NumpyOps()]
-if has_cupy_gpu:
+if _has_cupy_gpu:
     XP_OPS.append(CupyOps())
-if has_torch_mps_gpu:
+if _has_torch_mps_gpu:
     XP_OPS.append(MPSOps())
 
 
-if has_torch_amp:
+if _has_torch_amp:
     TORCH_MIXED_PRECISION = [False, True]
 else:
     TORCH_MIXED_PRECISION = [False]
@@ -51,7 +51,7 @@ def check_learns_zero_output(model, sgd, X, Y):
     assert total < prev
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
 def test_pytorch_unwrapped(nN, nI, nO):
     model = Linear(nO, nI).initialize()
@@ -62,7 +62,7 @@ def test_pytorch_unwrapped(nN, nI, nO):
     check_learns_zero_output(model, sgd, X, Y)
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
 def test_pytorch_wrapper(nN, nI, nO):
     import torch.nn
@@ -83,7 +83,7 @@ def test_pytorch_wrapper(nN, nI, nO):
     assert isinstance(model.predict(X), numpy.ndarray)
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize("ops_mixed", XP_OPS_MIXED)
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
 def test_pytorch_wrapper_thinc_input(ops_mixed, nN, nI, nO):
@@ -127,7 +127,7 @@ def test_pytorch_wrapper_thinc_input(ops_mixed, nN, nI, nO):
         assert isinstance(model.predict(X), ops.xp.ndarray)
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 def test_pytorch_roundtrip_conversion():
     import torch
 
@@ -138,7 +138,7 @@ def test_pytorch_roundtrip_conversion():
     assert numpy.array_equal(xp_tensor, new_xp_tensor)
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 def test_pytorch_wrapper_roundtrip():
     import torch.nn
 
@@ -152,7 +152,7 @@ def test_pytorch_wrapper_roundtrip():
         new_model.from_disk(model_path)
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize(
     "data,n_args,kwargs_keys",
     [
@@ -174,7 +174,7 @@ def test_pytorch_convert_inputs(data, n_args, kwargs_keys):
     check_input_converters(Y, backprop, data, n_args, kwargs_keys, torch.Tensor)
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 def test_pytorch_wrapper_custom_serde():
     import torch.nn
 

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -3,7 +3,7 @@ import pytest
 from thinc.api import Adam, ArgsKwargs, Linear, Model, TensorFlowWrapper
 from thinc.api import get_current_ops, keras_subclass, tensorflow2xp, xp2tensorflow
 from thinc.util import to_categorical
-from thinc.compat import has_cupy_gpu, has_tensorflow
+from thinc.compat import _has_cupy_gpu, _has_tensorflow
 
 from ..util import check_input_converters, make_tempdir
 
@@ -61,7 +61,7 @@ def model(tf_model):
     return TensorFlowWrapper(tf_model)
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_roundtrip_conversion():
     import tensorflow as tf
 
@@ -73,7 +73,7 @@ def test_tensorflow_wrapper_roundtrip_conversion():
     assert ops.xp.array_equal(xp_tensor, new_xp_tensor)
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_construction_requires_keras_model():
     import tensorflow as tf
 
@@ -83,7 +83,7 @@ def test_tensorflow_wrapper_construction_requires_keras_model():
         TensorFlowWrapper(Linear(2, 3))
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_built_model(model, X, Y):
     # built models are validated more and can perform useful operations:
     assert model.predict(X) is not None
@@ -93,12 +93,12 @@ def test_tensorflow_wrapper_built_model(model, X, Y):
     assert model.from_bytes(model.to_bytes()) is not None
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_predict(model, X):
     model.predict(X)
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_train_overfits(model, X, Y, answer):
     optimizer = Adam()
     ops = get_current_ops()
@@ -114,7 +114,7 @@ def test_tensorflow_wrapper_train_overfits(model, X, Y, answer):
     assert predicted == answer
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_accumulate_gradients(model, X, Y, answer):
     import tensorflow as tf
 
@@ -149,7 +149,7 @@ def test_tensorflow_wrapper_accumulate_gradients(model, X, Y, answer):
         assert found_diff is True
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_serialize_model_subclass(
     X, Y, input_size, n_classes, answer
 ):
@@ -199,7 +199,7 @@ def test_tensorflow_wrapper_serialize_model_subclass(
     assert model.predict(X).argmax() == answer
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_keras_subclass_decorator_compile_args():
     import tensorflow as tf
 
@@ -229,8 +229,8 @@ def test_tensorflow_wrapper_keras_subclass_decorator_compile_args():
     assert isinstance(model, Model)
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
-def test_tensorflow_wrapper_keras_subclass_decorator():
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
+def test_tensorflow_wrapaper_keras_subclass_decorator():
     import tensorflow as tf
 
     class UndecoratedModel(tf.keras.Model):
@@ -252,7 +252,7 @@ def test_tensorflow_wrapper_keras_subclass_decorator():
     assert isinstance(TensorFlowWrapper(TestModel()), Model)
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_keras_subclass_decorator_capture_args_kwargs(
     X, Y, input_size, n_classes, answer
 ):
@@ -290,13 +290,13 @@ def test_tensorflow_wrapper_keras_subclass_decorator_capture_args_kwargs(
     model = model.from_bytes(model.to_bytes())
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_can_copy_model(model):
     copy = model.copy()
     assert copy is not None
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_print_summary(model, X):
     summary = str(model.shims[0])
     # Summary includes the layers of our model
@@ -308,7 +308,7 @@ def test_tensorflow_wrapper_print_summary(model, X):
     assert "Non-trainable params" in summary
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_to_bytes(model, X):
     # And can be serialized
     model_bytes = model.to_bytes()
@@ -316,7 +316,7 @@ def test_tensorflow_wrapper_to_bytes(model, X):
     model.from_bytes(model_bytes)
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_to_from_disk(model, X, Y, answer):
     with make_tempdir() as tmp_path:
         model_file = tmp_path / "model.h5"
@@ -325,7 +325,7 @@ def test_tensorflow_wrapper_to_from_disk(model, X, Y, answer):
         assert another_model is not None
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_from_bytes(model, X):
     model.predict(X)
     model_bytes = model.to_bytes()
@@ -333,7 +333,7 @@ def test_tensorflow_wrapper_from_bytes(model, X):
     assert another_model is not None
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_use_params(model, X, Y, answer):
     optimizer = Adam()
     ops = get_current_ops()
@@ -352,19 +352,19 @@ def test_tensorflow_wrapper_use_params(model, X, Y, answer):
     assert predicted == answer
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_to_cpu(tf_model):
     model = TensorFlowWrapper(tf_model)
     model.to_cpu()
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
-@pytest.mark.skipif(not has_cupy_gpu, reason="needs GPU/cupy")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_cupy_gpu, reason="needs GPU/cupy")
 def test_tensorflow_wrapper_to_gpu(model, X):
     model.to_gpu(0)
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 @pytest.mark.parametrize(
     "data,n_args,kwargs_keys",
     [
@@ -387,7 +387,7 @@ def test_tensorflow_wrapper_convert_inputs(data, n_args, kwargs_keys):
     check_input_converters(Y, backprop, data, n_args, kwargs_keys, tf.Tensor)
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_thinc_model_subclass(tf_model):
     class CustomModel(Model):
         def fn(self):
@@ -398,7 +398,7 @@ def test_tensorflow_wrapper_thinc_model_subclass(tf_model):
     assert model.fn() == 1337
 
 
-@pytest.mark.skipif(not has_tensorflow, reason="needs TensorFlow")
+@pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
 def test_tensorflow_wrapper_thinc_set_model_name(tf_model):
     model = TensorFlowWrapper(tf_model, model_name="cool")
     assert model.name == "cool"

--- a/thinc/tests/layers/test_tensorflow_wrapper.py
+++ b/thinc/tests/layers/test_tensorflow_wrapper.py
@@ -230,7 +230,7 @@ def test_tensorflow_wrapper_keras_subclass_decorator_compile_args():
 
 
 @pytest.mark.skipif(not _has_tensorflow, reason="needs TensorFlow")
-def test_tensorflow_wrapaper_keras_subclass_decorator():
+def test_tensorflow_wrapper_keras_subclass_decorator():
     import tensorflow as tf
 
     class UndecoratedModel(tf.keras.Model):

--- a/thinc/tests/layers/test_torchscriptwrapper.py
+++ b/thinc/tests/layers/test_torchscriptwrapper.py
@@ -3,10 +3,10 @@ import numpy
 
 from thinc.api import PyTorchWrapper_v2, TorchScriptWrapper_v1
 from thinc.api import pytorch_to_torchscript_wrapper
-from thinc.compat import has_torch, torch
+from thinc.compat import _has_torch, torch
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
 def test_pytorch_script(nN, nI, nO):
 

--- a/thinc/tests/model/test_model.py
+++ b/thinc/tests/model/test_model.py
@@ -6,7 +6,7 @@ from thinc.api import Adam, CupyOps, Dropout, Linear, Model, Relu
 from thinc.api import Shim, Softmax, chain, change_attr_values
 from thinc.api import concatenate, set_dropout_rate
 from thinc.api import use_ops, with_debug, wrap_model_recursive
-from thinc.compat import has_cupy_gpu
+from thinc.compat import _has_cupy_gpu
 import numpy
 
 from ..util import make_tempdir
@@ -404,7 +404,7 @@ def test_unique_id_multithreading():
     assert len(list_of_ids) == len(list(set(list_of_ids)))
 
 
-@pytest.mark.skipif(not has_cupy_gpu, reason="needs CuPy GPU")
+@pytest.mark.skipif(not _has_cupy_gpu, reason="needs CuPy GPU")
 def test_model_gpu():
     pytest.importorskip("ml_datasets")
     import ml_datasets

--- a/thinc/tests/regression/test_issue564.py
+++ b/thinc/tests/regression/test_issue564.py
@@ -1,11 +1,11 @@
 import pytest
 
 from thinc.api import CupyOps
-from thinc.compat import has_torch, has_torch_cuda_gpu
+from thinc.compat import _has_torch, _has_torch_cuda_gpu
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
-@pytest.mark.skipif(not has_torch_cuda_gpu, reason="needs a GPU")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch_cuda_gpu, reason="needs a GPU")
 def test_issue564():
     import torch
 

--- a/thinc/tests/shims/test_pytorch_grad_scaler.py
+++ b/thinc/tests/shims/test_pytorch_grad_scaler.py
@@ -2,7 +2,7 @@ import pytest
 
 from hypothesis import given, settings
 from hypothesis.strategies import lists, one_of, tuples
-from thinc.compat import has_torch, has_torch_amp, has_torch_cuda_gpu, torch
+from thinc.compat import _has_torch, _has_torch_amp, _has_torch_cuda_gpu, torch
 from thinc.util import is_torch_array
 from thinc.api import PyTorchGradScaler
 
@@ -13,10 +13,10 @@ def tensors():
     return ndarrays().map(lambda a: torch.tensor(a).cuda())
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
-@pytest.mark.skipif(not has_torch_cuda_gpu, reason="needs a GPU")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch_cuda_gpu, reason="needs a GPU")
 @pytest.mark.skipif(
-    not has_torch_amp, reason="requires PyTorch with mixed-precision support"
+    not _has_torch_amp, reason="requires PyTorch with mixed-precision support"
 )
 @given(X=one_of(tensors(), lists(tensors()), tuples(tensors())))
 @settings(deadline=None)
@@ -36,10 +36,10 @@ def test_scale_random_inputs(X):
             assert torch.allclose(t1, t2)
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
-@pytest.mark.skipif(not has_torch_cuda_gpu, reason="needs a GPU")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch_cuda_gpu, reason="needs a GPU")
 @pytest.mark.skipif(
-    not has_torch_amp, reason="requires PyTorch with mixed-precision support"
+    not _has_torch_amp, reason="requires PyTorch with mixed-precision support"
 )
 def test_grad_scaler():
     import torch
@@ -83,9 +83,9 @@ def test_grad_scaler():
     ]
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.skipif(
-    has_torch_amp, reason="needs PyTorch without gradient scaling support"
+    _has_torch_amp, reason="needs PyTorch without gradient scaling support"
 )
 def test_raises_on_old_pytorch():
     import torch
@@ -95,9 +95,9 @@ def test_raises_on_old_pytorch():
         scaler.scale([torch.tensor([1.0], device="cpu")])
 
 
-@pytest.mark.skipif(not has_torch, reason="needs PyTorch")
+@pytest.mark.skipif(not _has_torch, reason="needs PyTorch")
 @pytest.mark.skipif(
-    not has_torch_amp, reason="needs PyTorch with gradient scaling support"
+    not _has_torch_amp, reason="needs PyTorch with gradient scaling support"
 )
 def test_raises_with_cpu_tensor():
     import torch


### PR DESCRIPTION
Make the `has_` predicates private according to the corresponding `v9` ticket.

## Description

Renames the `has_*` predicates `_has_*` to show that they are supposed to be private. The exceptions are `has_cupy` because that was exported in `thinc.api` before and `util.py` exports `_has_torch` as `has_torch` in `__all__`, because it used to do that before? Not sure about the second one.

### Types of change

Small technical debt mitigation.

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
