### PR TITLE
Improve exception when CuPy/PyTorch MPS is not installed

### DIFF
--- a/thinc/compat.py
+++ b/thinc/compat.py
@@ -32,6 +32,7 @@ try:  # pragma: no cover
 
     has_torch = True
     has_torch_cuda_gpu = torch.cuda.device_count() != 0
+    has_torch_mps = hasattr(torch, "has_mps") and torch.backends.mps.is_built()
     has_torch_mps_gpu = (
         hasattr(torch, "has_mps")
         and torch.has_mps  # type: ignore[attr-defined]
@@ -48,6 +49,7 @@ except ImportError:  # pragma: no cover
     has_torch = False
     has_torch_cuda_gpu = False
     has_torch_gpu = False
+    has_torch_mps = False
     has_torch_mps_gpu = False
     has_torch_amp = False
     torch_version = Version("0.0.0")

--- a/thinc/compat.py
+++ b/thinc/compat.py
@@ -32,12 +32,8 @@ try:  # pragma: no cover
 
     has_torch = True
     has_torch_cuda_gpu = torch.cuda.device_count() != 0
-    has_torch_mps = hasattr(torch, "has_mps") and torch.backends.mps.is_built()
-    has_torch_mps_gpu = (
-        hasattr(torch, "has_mps")
-        and torch.has_mps  # type: ignore[attr-defined]
-        and torch.backends.mps.is_available()  # type: ignore[attr-defined]
-    )
+    has_torch_mps = hasattr(torch.backends, "mps") and torch.backends.mps.is_built()
+    has_torch_mps_gpu = has_torch_mps and torch.backends.mps.is_available()
     has_torch_gpu = has_torch_cuda_gpu
     torch_version = Version(str(torch.__version__))
     has_torch_amp = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

`require_gpu` does not distinguish between different failure scenarios, which makes it harder to debug why GPU support is not working. See e.g.

https://github.com/explosion/spaCy/discussions/12410

Rather than raising a generic `No GPU devices can be detected` when CuPy or PyTorch with MPS isn't installed, this change adds more specific errors.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Enhancement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
