### PR TITLE
Redesign cython profile defaults due to python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ MOD_NAMES = [
     "thinc.backends.numpy_ops",
     "thinc.extra.search",
     "thinc.layers.sparselinear",
-    "thinc.layers.premap_ids"
+    "thinc.layers.premap_ids",
 ]
 COMPILE_OPTIONS = {
     "msvc": ["/Ox", "/EHsc"],
@@ -31,6 +31,7 @@ COMPILER_DIRECTIVES = {
     "language_level": 3,
     "embedsignature": True,
     "annotation_typing": False,
+    "profile": sys.version_info < (3, 12),
 }
 LINK_OPTIONS = {"msvc": [], "other": []}
 
@@ -82,7 +83,9 @@ def setup_package():
         ext = Extension(name, [mod_path], language="c++", include_dirs=include_dirs)
         ext_modules.append(ext)
     print("Cythonizing sources")
-    ext_modules = cythonize(ext_modules, compiler_directives=COMPILER_DIRECTIVES, language_level=2)
+    ext_modules = cythonize(
+        ext_modules, compiler_directives=COMPILER_DIRECTIVES, language_level=2
+    )
 
     setup(
         name="thinc",

--- a/thinc/backends/cblas.pyx
+++ b/thinc/backends/cblas.pyx
@@ -1,3 +1,4 @@
+# cython: profile=False
 cimport blis.cy
 from cython.operator cimport dereference as deref
 from libcpp.memory cimport make_shared

--- a/thinc/backends/linalg.pyx
+++ b/thinc/backends/linalg.pyx
@@ -1,3 +1,4 @@
+# cython: profile=False
 try:
     import blis.py
 except ImportError:

--- a/thinc/backends/numpy_ops.pyx
+++ b/thinc/backends/numpy_ops.pyx
@@ -1,6 +1,5 @@
 # cython: cdivision=True
 # cython: infer_types=True
-# cython: profile=True
 from collections.abc import Sized
 from typing import Optional
 

--- a/thinc/extra/search.pyx
+++ b/thinc/extra/search.pyx
@@ -1,4 +1,4 @@
-# cython: profile=True, experimental_cpp_class_def=True, cdivision=True, infer_types=True
+# cython: experimental_cpp_class_def=True, cdivision=True, infer_types=True
 cimport cython
 from libc.math cimport exp, log
 from libc.string cimport memcpy, memset

--- a/thinc/extra/tests/c_test_search.pyx
+++ b/thinc/extra/tests/c_test_search.pyx
@@ -1,3 +1,4 @@
+# cython: profile=False
 from cymem.cymem cimport Pool
 
 from thinc.extra.search cimport Beam

--- a/thinc/layers/premap_ids.pyx
+++ b/thinc/layers/premap_ids.pyx
@@ -1,4 +1,4 @@
-# cython: binding=True, infer_types=True
+# cython: binding=True, infer_types=True, profile=False
 import numpy
 
 from preshed.maps cimport PreshMap

--- a/thinc/layers/sparselinear.pyx
+++ b/thinc/layers/sparselinear.pyx
@@ -1,4 +1,4 @@
-# cython: infer_types=True, cdivision=True, bounds_check=False, wraparound=False
+# cython: infer_types=True, cdivision=True, bounds_check=False, wraparound=False, profile=False
 cimport cython
 cimport numpy as np
 from libc.stdint cimport int32_t, uint32_t, uint64_t


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Profiling support for python 3.12 will not be available for cython 0.29, so toggle internal defaults to be able to disable profiling for python 3.12 completely in `setup.py`. The cython `profile` compiler directive in `setup.py` is then overridden by file-specific or function-specific settings.

* Swap file-specific `profile` settings to `False`
* In setup, set `profile` default to:
  * `True` for python < 3.12
  * `False` for python >= 3.12

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

?

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
