### PR TITLE
Fix strings2array

### DIFF
--- a/thinc/layers/strings2arrays.py
+++ b/thinc/layers/strings2arrays.py
@@ -1,4 +1,5 @@
 from typing import Callable, List, Sequence, Tuple
+from ctypes import c_uint64
 
 from murmurhash import hash_unicode
 
@@ -17,9 +18,9 @@ def strings2arrays() -> Model[InT, OutT]:
 
 
 def forward(model: Model[InT, OutT], Xs: InT, is_train: bool) -> Tuple[OutT, Callable]:
-    hashes = model.ops.asarray2i(
-        [[hash_unicode(word) for word in X] for X in Xs], dtype="int32"
-    )
+    # Cast 32-bit (signed) integer to 64-bit unsigned, since such casting
+    # is deprecated in NumPy.
+    hashes = [[c_uint64(hash_unicode(word)).value for word in X] for X in Xs]
     hash_arrays = [model.ops.asarray1i(h, dtype="uint64") for h in hashes]
     arrays = [model.ops.reshape2i(array, -1, 1) for array in hash_arrays]
 

--- a/thinc/layers/strings2arrays.py
+++ b/thinc/layers/strings2arrays.py
@@ -1,5 +1,5 @@
-from typing import Callable, List, Sequence, Tuple
 from ctypes import c_uint64
+from typing import Callable, List, Sequence, Tuple
 
 from murmurhash import hash_unicode
 

--- a/thinc/tests/layers/test_basic_tagger.py
+++ b/thinc/tests/layers/test_basic_tagger.py
@@ -60,7 +60,6 @@ def get_shuffled_batches(Xs, Ys, batch_size):
         yield list(batch_X), list(batch_Y)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     ("depth", "width", "vector_width", "nb_epoch"), [(2, 32, 16, 5)]
 )


### PR DESCRIPTION

## Description

As noted by Daniel in https://github.com/explosion/thinc/pull/917, an error crept in the `forward` function of `strings2arrays`: it shouldn't use `asarray2i` as introduced by #897. The bug at the time wasn't noticed because the slow tests weren't run. For now, this PR also removes the `slow` marker on the basic tagger's `test_small_end_to_end` test, to ensure any regressions would be visible quickly.

### Types of change

bug fix

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
