### PR TITLE
Bump GH actions

### DIFF
--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -14,8 +14,8 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Install and run explosion-bot
         run: |
           pip install git+https://${{ secrets.EXPLOSIONBOT_TOKEN }}@github.com/explosion/explosion-bot

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,12 +44,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         python_version: ["3.12"]
         include:
           - os: windows-latest
             python_version: "3.9"
-          - os: macos-latest
+          - os: macos-13
             python_version: "3.10"
           - os: ubuntu-latest
             python_version: "3.11"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-          architecture: x64
 
       - name: black
         run: |
@@ -67,7 +66,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-          architecture: x64
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure Python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           architecture: x64
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure Python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ packaging>=20.0
 # Development dependencies
 cython>=0.25.0,<3.0
 hypothesis>=3.27.0,<6.72.2
-pytest>=5.2.0,!=7.1.0
+pytest>=8.2.0
 pytest-cov>=2.7.0,<5.0.0
 coverage>=5.0.0,<8.0.0
 mock>=2.0.0,<3.0.0

--- a/thinc/tests/test_examples.py
+++ b/thinc/tests/test_examples.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture
 def test_files(nb_file):
-    pytest.importorskip("nbconvert")
+    pytest.importorskip("nbconvert", exc_type=ImportError)
     pytest.importorskip("nbformat")
     import nbconvert
     import nbformat

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -32,7 +32,7 @@ except ImportError:
     from pydantic import ValidationError, create_model  # type: ignore
 
 import numpy
-from wasabi import table
+from wasabi import table  # type: ignore
 
 from . import types  # noqa: E402
 from .compat import (


### PR DESCRIPTION
## Description

- Bump GH actions
    - `checkout`: v3 -> v4
    - `setup-python` v4: -> v5
- Don't forcefully set `x64` but build for the native platform instead. 
- Update `pytest` to 8.2 and update test accordingly, cf https://docs.pytest.org/en/stable/deprecations.html#pytest-importorskip-default-behavior-regarding-importerror

### Types of change

Bump

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
