### PR TITLE
replace old "mock" with newer "unittest.mock" from the standard library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ hypothesis>=3.27.0,<6.72.2
 pytest>=8.2.0
 pytest-cov>=2.7.0,<5.0.0
 coverage>=5.0.0,<8.0.0
-mock>=2.0.0,<3.0.0
 flake8>=3.5.0,<3.6.0
 mypy>=1.5.0,<1.6.0; platform_machine != "aarch64"
 types-mock>=0.1.1

--- a/thinc/tests/layers/test_linear.py
+++ b/thinc/tests/layers/test_linear.py
@@ -1,7 +1,8 @@
+from unittest.mock import MagicMock
+
 import numpy
 import pytest
 from hypothesis import given, settings
-from mock import MagicMock
 from numpy.testing import assert_allclose
 
 from thinc.api import SGD, Dropout, Linear, chain

--- a/thinc/tests/layers/test_with_debug.py
+++ b/thinc/tests/layers/test_with_debug.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from thinc.api import Linear, with_debug
 


### PR DESCRIPTION
Hi, 

After it's merging inside the standard library as `unittest.mock`,
the old external `mock`library is left to slowly bitrot.

---

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock

## Checklist

- [x ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
