### PR TITLE
Update torch.cuda.amp to torch.amp in pytorch.py

### DIFF
--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -111,7 +111,7 @@ class PyTorchShim(Shim):
         """
         self._model.eval()
         with torch.no_grad():
-            with torch.cuda.amp.autocast(self._mixed_precision):
+            with torch.amp.autocast("cuda", self._mixed_precision):
                 outputs = self._model(*inputs.args, **inputs.kwargs)
         self._model.train()
         return outputs
@@ -125,7 +125,7 @@ class PyTorchShim(Shim):
         self._model.train()
 
         # Note: mixed-precision autocast must not be applied to backprop.
-        with torch.cuda.amp.autocast(self._mixed_precision):
+        with torch.amp.autocast("cuda", self._mixed_precision):
             output = self._model(*inputs.args, **inputs.kwargs)
 
         def backprop(grads):


### PR DESCRIPTION
update pytorch.py to get rid of torch.cuda.amp deprecated warning.

<!--- Provide a general summary of your changes in the title. -->

## Description

torch.cuda.amp is deprecated (Pytorch 2.4). This PR updates shims pytorch.py to use torch.amp.autocast instead of torch.cuda.amp.autocast.

### Types of change

replaced _torch.cuda.amp.autocast(self._mixed_precision)_ with _torch.amp.autocast("cuda", self._mixed_precision)_

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
