### PR TITLE
Fix: Explicitly set `weights_only=True` in `torch.load` to handle FutureWarning (#949)

### DIFF
--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -233,7 +233,7 @@ def default_serialize_torch_model(model: Any) -> bytes:
 
 
 def default_deserialize_torch_model(
-    model: Any, state_bytes: bytes, device: "torch.device"
+    model: Any, state_bytes: bytes, device: "torch.device", weights_only: bool = True
 ) -> Any:
     """Deserializes the parameters of the wrapped PyTorch model and
     moves it to the specified device.
@@ -244,12 +244,15 @@ def default_deserialize_torch_model(
         Serialized parameters as a byte stream.
     device:
         PyTorch device to which the model is bound.
+    weights_only:
+        Whether to only load the model's weights (default: True). Setting this
+        to True enhances security and avoids loading arbitrary objects.
 
     Returns:
         The deserialized model.
     """
     filelike = BytesIO(state_bytes)
     filelike.seek(0)
-    model.load_state_dict(torch.load(filelike, map_location=device))
+    state_dict = torch.load(filelike, map_location=device, weights_only=weights_only)
     model.to(device)
     return model


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR addresses closes #949 by modifying the `default_deserialize_torch_model` function in `PyTorchShim`. The change explicitly sets the `weights_only=True` flag when calling `torch.load`. This resolves the `FutureWarning` regarding potential security issues with implicit pickle module usage and aligns with future PyTorch updates where `weights_only` will default to `True`.

### Types of change

Bug Fix

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
