### PR TITLE
Fix PyTorch autocast/mixed-precision

### DIFF
--- a/thinc/shims/pytorch.py
+++ b/thinc/shims/pytorch.py
@@ -111,7 +111,7 @@ class PyTorchShim(Shim):
         """
         self._model.eval()
         with torch.no_grad():
-            with torch.amp.autocast("cuda", self._mixed_precision):
+            with torch.amp.autocast("cuda", enabled=self._mixed_precision):
                 outputs = self._model(*inputs.args, **inputs.kwargs)
         self._model.train()
         return outputs
@@ -125,7 +125,7 @@ class PyTorchShim(Shim):
         self._model.train()
 
         # Note: mixed-precision autocast must not be applied to backprop.
-        with torch.amp.autocast("cuda", self._mixed_precision):
+        with torch.amp.autocast("cuda", enabled=self._mixed_precision):
             output = self._model(*inputs.args, **inputs.kwargs)
 
         def backprop(grads):


### PR DESCRIPTION

## Description

PyTorch usage fails with

```
  File "thinc/model.py", line 310, in __call__
    return self._func(self, X, is_train=is_train)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "thinc/layers/chain.py", line 54, in forward
    Y, inc_layer_grad = layer(X, is_train=is_train)
                        ~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "thinc/model.py", line 310, in __call__
    return self._func(self, X, is_train=is_train)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "spacy_curated_transformers/models/with_strided_spans.py", line 108, in with_strided_spans_forward
    output, bp = transformer(cast(TorchTransformerInT, batch), is_train=is_train)
                 ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "thinc/model.py", line 310, in __call__
    return self._func(self, X, is_train=is_train)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "thinc/layers/pytorchwrapper.py", line 225, in forward
    Ytorch, torch_backprop = model.shims[0](Xtorch, is_train)
                             ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "thinc/shims/pytorch.py", line 97, in __call__
    return self.predict(inputs), lambda a: ...
           ~~~~~~~~~~~~^^^^^^^^
  File "thinc/shims/pytorch.py", line 114, in predict
    with torch.amp.autocast("cuda", self._mixed_precision):
         ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "torch/amp/autocast_mode.py", line 362, in __enter__
    torch.set_autocast_dtype(self.device, self.fast_dtype)  # type: ignore[arg-type]
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: set_autocast_dtype(): argument 'dtype' (position 2) must be torch.dtype, not bool
```

This is because `torch.amp.autocast()` method's 2nd parameter is `dtype`.
See https://pytorch.org/docs/stable/amp.html#torch.autocast

### Types of change

Use `enabled`  argument for `torch.amp.autocast()`

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
