### PR TITLE
Disable type validation in order to update to Pydantic2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,8 @@ install_requires =
     confection>=0.0.1,<1.0.0
     # Third-party dependencies
     setuptools
-    numpy>=1.19.0,<3.0.0; python_version < "3.9"
-    numpy>=1.19.0,<3.0.0; python_version >= "3.9"
-    pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
+    numpy>=2.0.0,<3.0.0
+    pydantic>=2.0.0,<3.0.0
     packaging>=20.0
     # Backports of modern Python features
     dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/thinc/layers/embed.py
+++ b/thinc/layers/embed.py
@@ -63,6 +63,7 @@ def forward(
         if drop_mask is not None:
             d_output *= drop_mask
         d_vectors = model.ops.alloc2f(*vectors.shape)
+        # Does a loop where we do d_vectors[i] += d_output[ids[i]]
         model.ops.scatter_add(d_vectors, ids, d_output)
         model.inc_grad("E", d_vectors)
         dX = model.ops.alloc1i(nN)

--- a/thinc/tests/model/test_validation.py
+++ b/thinc/tests/model/test_validation.py
@@ -13,6 +13,7 @@ from thinc.api import (
 from thinc.util import DataValidationError, data_validation
 
 
+@pytest.mark.xfail(reason="Validation currently disabled for Pydantic 2 changes0")
 def test_validation():
     model = chain(Relu(10), Relu(10), with_ragged(reduce_max()), Softmax())
     with data_validation(True):
@@ -24,6 +25,7 @@ def test_validation():
             model.initialize(X=[model.ops.alloc2f(1, 10)], Y=model.ops.alloc2f(1, 10))
 
 
+@pytest.mark.xfail(reason="Validation currently disabled for Pydantic 2 changes0")
 def test_validation_complex():
     good_model = chain(list2ragged(), reduce_sum(), Relu(12, dropout=0.5), Relu(1))
     X = [good_model.ops.xp.zeros((4, 75), dtype="f")]

--- a/thinc/tests/test_types.py
+++ b/thinc/tests/test_types.py
@@ -19,6 +19,7 @@ from thinc.types import (
 )
 
 
+@pytest.mark.xfail(reason="Validation currently disabled")
 @pytest.mark.parametrize(
     "arr,arr_type",
     [
@@ -38,6 +39,7 @@ def test_array_validation_valid(arr, arr_type):
     assert numpy.array_equal(arr, result.arr)
 
 
+@pytest.mark.xfail(reason="Validation currently disabled")
 @pytest.mark.parametrize(
     "arr,arr_type",
     [

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -21,8 +21,8 @@ from typing import (
 )
 
 import numpy
-from pydantic_core import core_schema
 from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
 
 from .compat import cupy, has_cupy
 
@@ -32,7 +32,6 @@ else:
     get_array_module = lambda obj: numpy
 
 from typing import Literal, Protocol  # noqa: F401
-
 
 # fmt: off
 XY_YZ_OutT = TypeVar("XY_YZ_OutT")

--- a/thinc/types.py
+++ b/thinc/types.py
@@ -21,6 +21,8 @@ from typing import (
 )
 
 import numpy
+from pydantic_core import core_schema
+from pydantic import GetCoreSchemaHandler
 
 from .compat import cupy, has_cupy
 
@@ -29,11 +31,7 @@ if has_cupy:
 else:
     get_array_module = lambda obj: numpy
 
-# Use typing_extensions for Python versions < 3.8
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal, Protocol
-else:
-    from typing import Literal, Protocol  # noqa: F401
+from typing import Literal, Protocol  # noqa: F401
 
 
 # fmt: off
@@ -132,9 +130,9 @@ _4I_ReduceResults = Union[int, "Ints1d", "Ints2d", "Ints3d", "Ints4d"]
 
 class _Array(Sized, Container):
     @classmethod
-    def __get_validators__(cls):
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler):
         """Runtime validation for pydantic."""
-        yield lambda v: validate_array(v)
+        return core_schema.no_info_after_validator_function(validate_array, handler(source_type))
 
     @property
     @abstractmethod
@@ -388,9 +386,9 @@ class _Array1d(_Array):
     """1-dimensional array."""
 
     @classmethod
-    def __get_validators__(cls):
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler):
         """Runtime validation for pydantic."""
-        yield lambda v: validate_array(v, ndim=1)
+        return core_schema.no_info_after_validator_function(lambda v: validate_array(v, ndim=1), handler(source_type))
 
     @property
     @abstractmethod
@@ -455,9 +453,10 @@ class Floats1d(_Array1d, _Floats):
     T: "Floats1d"
 
     @classmethod
-    def __get_validators__(cls):
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler):
         """Runtime validation for pydantic."""
-        yield lambda v: validate_array(v, ndim=1, dtype="f")
+        return core_schema.no_info_after_validator_function(lambda v: validate_array(v, ndim=1, dtype="f"), handler(source_type))
+
 
     @abstractmethod
     def __iter__(self) -> Iterator[float]: ...
@@ -505,9 +504,10 @@ class Ints1d(_Array1d, _Ints):
     T: "Ints1d"
 
     @classmethod
-    def __get_validators__(cls):
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler):
         """Runtime validation for pydantic."""
-        yield lambda v: validate_array(v, ndim=1, dtype="i")
+        return core_schema.no_info_after_validator_function(lambda v: validate_array(v, ndim=1, dtype="i"), handler(source_type))
+
 
     @abstractmethod
     def __iter__(self) -> Iterator[int]: ...
@@ -552,9 +552,10 @@ class Ints1d(_Array1d, _Ints):
 
 class _Array2d(_Array):
     @classmethod
-    def __get_validators__(cls):
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler):
         """Runtime validation for pydantic."""
-        yield lambda v: validate_array(v, ndim=2)
+        return core_schema.no_info_after_validator_function(lambda v: validate_array(v, ndim=2), handler(source_type))
+
 
     @property
     @abstractmethod
@@ -615,9 +616,9 @@ class Floats2d(_Array2d, _Floats):
     T: "Floats2d"
 
     @classmethod
-    def __get_validators__(cls):
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler):
         """Runtime validation for pydantic."""
-        yield lambda v: validate_array(v, ndim=2, dtype="f")
+        return core_schema.no_info_after_validator_function(lambda v: validate_array(v, ndim=2, dtype="f"), handler(source_type))
 
     @abstractmethod
     def __iter__(self) -> Iterator[Floats1d]: ...
@@ -666,9 +667,9 @@ class Ints2d(_Array2d, _Ints):
     T: "Ints2d"
 
     @classmethod
-    def __get_validators__(cls):
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler):
         """Runtime validation for pydantic."""
-        yield lambda v: validate_array(v, ndim=2, dtype="i")
+        return core_schema.no_info_after_validator_function(lambda v: validate_array(v, ndim=2, dtype="i"), handler(source_type))
 
     @abstractmethod
     def __iter__(self) -> Iterator[Ints1d]: ...

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -25,10 +25,7 @@ from typing import (
 import numpy
 from packaging.version import Version
 
-try:
-    from pydantic.v1 import ValidationError, create_model
-except ImportError:
-    from pydantic import ValidationError, create_model  # type: ignore
+from pydantic import ValidationError, create_model, ConfigDict
 
 from wasabi import table  # type: ignore
 
@@ -549,11 +546,6 @@ class DataValidationError(ValueError):
         ValueError.__init__(self, "\n\n" + "\n".join(result))
 
 
-class _ArgModelConfig:
-    extra = "forbid"
-    arbitrary_types_allowed = True
-
-
 def validate_fwd_input_output(
     name: str, func: Callable[[Any, Any, bool], Any], X: Any, Y: Any
 ) -> None:
@@ -568,28 +560,34 @@ def validate_fwd_input_output(
         bad_params = f"{len(params)} ({', '.join([p.name for p in params])})"
         err = f"Invalid forward function. Expected 3 arguments (model, X , is_train), got {bad_params}"
         raise DataValidationError(name, X, Y, [{"msg": err}])
-    annot_x = params[1].annotation
-    annot_y = sig.return_annotation
-    sig_args: Dict[str, Any] = {"__config__": _ArgModelConfig}
-    args = {}
-    if X is not None and annot_x != empty:
-        if isinstance(X, list) and len(X) > 5:
-            X = X[:5]
-        sig_args["X"] = (annot_x, ...)
-        args["X"] = X
-    if Y is not None and annot_y != empty:
-        if isinstance(Y, list) and len(Y) > 5:
-            Y = Y[:5]
-        sig_args["Y"] = (annot_y, ...)
-        args["Y"] = (Y, lambda x: x)
-    ArgModel = create_model("ArgModel", **sig_args)
-    # Make sure the forward refs are resolved and the types used by them are
-    # available in the correct scope. See #494 for details.
-    ArgModel.update_forward_refs(**types.__dict__)
-    try:
-        ArgModel.parse_obj(args)
-    except ValidationError as e:
-        raise DataValidationError(name, X, Y, e.errors()) from None
+    # Unfortunately I can't get this to work for Pydantic v2 yet. The Floats2d etc types fail to validate
+    # against their duck-types numpy.ndarray etc. For now disable this validation while I check with
+    # the pydantic folks how I should do this.
+    # TODO: Uncomment when working
+    # annot_x = params[1].annotation
+    # annot_y = sig.return_annotation
+    # sig_args: Dict[str, Any] = {"__config__": {"extra": "forbid", "arbitrary_types_allowed": True}}
+    # args = {}
+    # if X is not None and annot_x != empty:
+    #     if isinstance(X, list) and len(X) > 5:
+    #         X = X[:5]
+    #     sig_args["X"] = (annot_x, ...)
+    #     args["X"] = X
+    # if Y is not None and annot_y != empty:
+    #     if isinstance(Y, list) and len(Y) > 5:
+    #         Y = Y[:5]
+    #     sig_args["Y"] = (annot_y, ...)
+    #     args["Y"] = (Y, lambda x: x)
+
+    # ArgModel = create_model("ArgModel", X=sig_args["X"], Y=sig_args["Y"], __config__=ConfigDict(extra="forbid", arbitrary_types_allowed=True))
+    # # Make sure the forward refs are resolved and the types used by them are
+    # # available in the correct scope. See #494 for details.
+    # ArgModel.model_rebuild()
+    # try:
+    #     ArgModel.model_validate(args)
+    # except ValidationError as e:
+    #     raise DataValidationError(name, X, Y, e.errors()) from None
+    return None
 
 
 @contextlib.contextmanager

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -24,9 +24,7 @@ from typing import (
 
 import numpy
 from packaging.version import Version
-
-from pydantic import ValidationError, create_model, ConfigDict
-
+from pydantic import ConfigDict, ValidationError, create_model
 from wasabi import table  # type: ignore
 
 from .compat import (


### PR DESCRIPTION
We need to update to Pydantic2 in order to update to Python3.13. The type validation approach we use here doesn't work in Pydantic 2, and I haven't yet figured out what we should do instead. As it's an optional feature, I've disabled this for now to unblock the release.
