### PR TITLE
Allow NumPy v1 in installation requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     confection>=0.0.1,<1.0.0
     # Third-party dependencies
     setuptools
-    numpy>=2.0.0,<3.0.0
+    numpy>=1.19.0,<3.0.0
     pydantic>=2.0.0,<3.0.0
     packaging>=20.0
     # Backports of modern Python features


### PR DESCRIPTION
## Description

Similar to https://github.com/explosion/spacy-pkuseg/pull/18, this PR updates the version pin to allow `thinc` to be used with `NumPy` v1 to ease compatibility issues with other 3rd-party packages requiring `NumPy` 1.x.

### Types of change

Dependency change.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
