### PR TITLE
Add support for building Windows ARM64 wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, windows-11-arm, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "*"
-skip = "pp* cp36* cp37* cp38*"
+skip = "pp* cp36* cp37* cp38* cp39-win_arm64 cp310-win_arm64"
 test-skip = ""
 free-threaded-support = false
 
@@ -59,6 +59,10 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.windows]
+
+[tool.cibuildwheel.windows.environment]
+CC = "cl.exe"
+CXX = "cl.exe"
 
 [tool.cibuildwheel.pyodide]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

* The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many Python wheels are still not available for this platform.
* GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.
* Currently, official thinc Python wheels are not provided for Windows ARM64 and thus users/developers were facing difficulties using popular thinc library natively.

Closes: https://github.com/explosion/thinc/issues/955

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

- This PR introduces support for building Google's re2 wheels on Windows ARM64, improving accessibility for developers and end users on this emerging platform.
- Currently, python 3.9 and 3.10 builds are skipped for Win-ARM64 since, these version of python binaries are not distributed in official download site.
- Also added env for CIBW windows to use MSVC compiler for building wheels.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

