### PR TITLE
Update cython to support 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
-    "cython>=0.25,<3.0",
+    "cython>=3.1.0,<3.2.0",
     "murmurhash>=1.0.2,<1.1.0",
     "cymem>=2.0.2,<2.1.0",
     "preshed>=3.0.2,<3.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
 numpy>=2.0.0,<3.0.0
 packaging>=20.0
 # Development dependencies
-cython>=0.25.0,<3.0
+cython>=3.1.0,<3.2.0
 hypothesis>=3.27.0,<6.72.2
 pytest>=8.2.0
 pytest-cov>=2.7.0,<5.0.0

--- a/thinc/backends/_accelerate.pxd
+++ b/thinc/backends/_accelerate.pxd
@@ -7,34 +7,34 @@ cdef extern from "Accelerate/Accelerate.h":
 
     # BLAS level 1 routines
 
-    void cblas_sswap(int M, float  *x, int incX, float  *y, int incY) nogil
-    void cblas_sscal(int N, float  alpha, float  *x, int incX) nogil
-    void cblas_scopy(int N, float  *x, int incX, float  *y, int incY) nogil
-    void cblas_saxpy(int N, float  alpha, float  *x, int incX, float  *y, int incY ) nogil
-    float cblas_sdot(int N, float  *x, int incX, float  *y, int incY ) nogil
-    float cblas_snrm2(int N, float  *x, int incX) nogil
-    float cblas_sasum(int N, float  *x, int incX) nogil
-    int cblas_isamax(int N, float  *x, int incX) nogil
+    void cblas_sswap(int M, float  *x, int incX, float  *y, int incY) noexcept nogil
+    void cblas_sscal(int N, float  alpha, float  *x, int incX) noexcept nogil
+    void cblas_scopy(int N, float  *x, int incX, float  *y, int incY) noexcept nogil
+    void cblas_saxpy(int N, float  alpha, float  *x, int incX, float  *y, int incY ) noexcept nogil
+    float cblas_sdot(int N, float  *x, int incX, float  *y, int incY ) noexcept nogil
+    float cblas_snrm2(int N, float  *x, int incX) noexcept nogil
+    float cblas_sasum(int N, float  *x, int incX) noexcept nogil
+    int cblas_isamax(int N, float  *x, int incX) noexcept nogil
 
     # BLAS level 2 routines
     void cblas_sgemv(CBLAS_ORDER Order, CBLAS_TRANSPOSE TransA, int M, int N,
                                  float  alpha, float  *A, int lda, float  *x, int incX,
-                                 float  beta, float  *y, int incY) nogil
+                                 float  beta, float  *y, int incY) noexcept nogil
 
     void cblas_sger(CBLAS_ORDER Order, int M, int N, float  alpha, float  *x,
-                                int incX, float  *y, int incY, float  *A, int lda) nogil
+                                int incX, float  *y, int incY, float  *A, int lda) noexcept nogil
 
     # BLAS level 3 routines
     void cblas_sgemm(CBLAS_ORDER Order, CBLAS_TRANSPOSE TransA,
                                  CBLAS_TRANSPOSE TransB, int M, int N, int K,
                                  float  alpha, float  *A, int lda, float  *B, int ldb,
-                                 float  beta, float  *C, int ldc) nogil
+                                 float  beta, float  *C, int ldc) noexcept nogil
 
 
 cdef void sgemm(bint TransA, bint TransB, int M, int N, int K,
                     float alpha, const float* A, int lda, const float *B,
-                    int ldb, float beta, float* C, int ldc) nogil
+                    int ldb, float beta, float* C, int ldc) noexcept nogil
 
 
 cdef void saxpy(int N, float alpha, const float* X, int incX,
-                float *Y, int incY) nogil
+                float *Y, int incY) noexcept nogil

--- a/thinc/backends/_accelerate.pyx
+++ b/thinc/backends/_accelerate.pyx
@@ -6,7 +6,7 @@ import numpy
 
 cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B,
                       bint trans1=False, bint trans2=False,
-                      np.ndarray out=None):
+                      np.ndarray out=None) noexcept:
     cdef int nM = A.shape[0] if not trans1 else A.shape[1]
     cdef int nK = A.shape[1] if not trans1 else A.shape[0]
     cdef int nK_b = B.shape[0] if not trans2 else B.shape[1]
@@ -51,7 +51,7 @@ cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B,
 
 cdef void sgemm(bint TransA, bint TransB, int M, int N, int K,
                     float alpha, const float* A, int lda, const float *B,
-                    int ldb, float beta, float* C, int ldc) nogil:
+                    int ldb, float beta, float* C, int ldc) noexcept nogil:
     cblas_sgemm(
         CblasRowMajor,
         CblasTrans if TransA else CblasNoTrans,
@@ -71,5 +71,5 @@ cdef void sgemm(bint TransA, bint TransB, int M, int N, int K,
 
 
 cdef void saxpy(int N, float alpha, const float* X, int incX,
-                float *Y, int incY) nogil:
+                float *Y, int incY) noexcept nogil:
     cblas_saxpy(N, alpha, X, incX, Y, incY)

--- a/thinc/backends/cblas.pxd
+++ b/thinc/backends/cblas.pxd
@@ -2,21 +2,21 @@ from libcpp.memory cimport shared_ptr
 
 ctypedef void (*sgemm_ptr)(bint transA, bint transB, int M, int N, int K,
                            float alpha, const float* A, int lda, const float* B,
-                           int ldb, float beta, float* C, int ldc) nogil
+                           int ldb, float beta, float* C, int ldc) noexcept nogil
 ctypedef void (*dgemm_ptr)(bint transA, bint transB, int M, int N, int K,
                            double alpha, const double* A, int lda, const double* B,
-                           int ldb, double beta, double* C, int ldc) nogil
+                           int ldb, double beta, double* C, int ldc) noexcept nogil
 
 
 ctypedef void (*saxpy_ptr)(int N, float alpha, const float* X, int incX,
-                           float *Y, int incY) nogil
+                           float *Y, int incY) noexcept nogil
 
 
 ctypedef void (*daxpy_ptr)(int N, double alpha, const double* X, int incX,
-                           double *Y, int incY) nogil
+                           double *Y, int incY) noexcept nogil
 
-ctypedef void (*sscal_ptr)(int N, float alpha, float* X, int incX) nogil
-ctypedef void (*dscal_ptr)(int N, double alpha, double* X, int incX) nogil
+ctypedef void (*sscal_ptr)(int N, float alpha, float* X, int incX) noexcept nogil
+ctypedef void (*dscal_ptr)(int N, double alpha, double* X, int incX) noexcept nogil
 
 # Forward-declaration of the BlasFuncs struct. This struct must be opaque, so
 # that consumers of the CBlas class cannot become dependent on its size or
@@ -34,15 +34,15 @@ cdef class CBlas:
 #
 # See https://github.com/explosion/thinc/pull/700 for more information.
 
-cdef daxpy_ptr daxpy(CBlas cblas) nogil
-cdef saxpy_ptr saxpy(CBlas cblas) nogil
-cdef sgemm_ptr sgemm(CBlas cblas) nogil
-cdef dgemm_ptr dgemm(CBlas cblas) nogil
-cdef sscal_ptr sscal(CBlas cblas) nogil
-cdef dscal_ptr dscal(CBlas cblas) nogil
-cdef void set_daxpy(CBlas cblas, daxpy_ptr daxpy) nogil
-cdef void set_saxpy(CBlas cblas, saxpy_ptr saxpy) nogil
-cdef void set_sgemm(CBlas cblas, sgemm_ptr sgemm) nogil
-cdef void set_dgemm(CBlas cblas, dgemm_ptr dgemm) nogil
-cdef void set_sscal(CBlas cblas, sscal_ptr sscal) nogil
-cdef void set_dscal(CBlas cblas, dscal_ptr dscal) nogil
+cdef daxpy_ptr daxpy(CBlas cblas) noexcept nogil
+cdef saxpy_ptr saxpy(CBlas cblas) noexcept nogil
+cdef sgemm_ptr sgemm(CBlas cblas) noexcept nogil
+cdef dgemm_ptr dgemm(CBlas cblas) noexcept nogil
+cdef sscal_ptr sscal(CBlas cblas) noexcept nogil
+cdef dscal_ptr dscal(CBlas cblas) noexcept nogil
+cdef void set_daxpy(CBlas cblas, daxpy_ptr daxpy) noexcept nogil
+cdef void set_saxpy(CBlas cblas, saxpy_ptr saxpy) noexcept nogil
+cdef void set_sgemm(CBlas cblas, sgemm_ptr sgemm) noexcept nogil
+cdef void set_dgemm(CBlas cblas, dgemm_ptr dgemm) noexcept nogil
+cdef void set_sscal(CBlas cblas, sscal_ptr sscal) noexcept nogil
+cdef void set_dscal(CBlas cblas, dscal_ptr dscal) noexcept nogil

--- a/thinc/backends/cblas.pyx
+++ b/thinc/backends/cblas.pyx
@@ -5,10 +5,10 @@ from libcpp.memory cimport make_shared
 
 
 # Single- and double-precision wrappers for `blis.cy.scalv`
-cdef void blis_sscal(int N, float alpha, float* X, int incX) nogil:
+cdef void blis_sscal(int N, float alpha, float* X, int incX) noexcept nogil:
     blis.cy.scalv(blis.cy.NO_CONJUGATE, N, alpha, X, incX)
 
-cdef void blis_dscal(int N, double alpha, double* X, int incX) nogil:
+cdef void blis_dscal(int N, double alpha, double* X, int incX) noexcept nogil:
     blis.cy.scalv(blis.cy.NO_CONJUGATE, N, alpha, X, incX)
 
 
@@ -36,38 +36,38 @@ cdef class CBlas:
         funcs.dscal = blis_dscal
         self.ptr = make_shared[BlasFuncs](funcs)
 
-cdef daxpy_ptr daxpy(CBlas cblas) nogil:
+cdef daxpy_ptr daxpy(CBlas cblas) noexcept nogil:
     return deref(cblas.ptr).daxpy
 
-cdef saxpy_ptr saxpy(CBlas cblas) nogil:
+cdef saxpy_ptr saxpy(CBlas cblas) noexcept nogil:
     return deref(cblas.ptr).saxpy
 
-cdef sgemm_ptr sgemm(CBlas cblas) nogil:
+cdef sgemm_ptr sgemm(CBlas cblas) noexcept nogil:
     return deref(cblas.ptr).sgemm
 
-cdef dgemm_ptr dgemm(CBlas cblas) nogil:
+cdef dgemm_ptr dgemm(CBlas cblas) noexcept nogil:
     return deref(cblas.ptr).dgemm
 
-cdef sscal_ptr sscal(CBlas cblas) nogil:
+cdef sscal_ptr sscal(CBlas cblas) noexcept nogil:
     return deref(cblas.ptr).sscal
 
-cdef dscal_ptr dscal(CBlas cblas) nogil:
+cdef dscal_ptr dscal(CBlas cblas) noexcept nogil:
     return deref(cblas.ptr).dscal
 
-cdef void set_daxpy(CBlas cblas, daxpy_ptr daxpy) nogil:
+cdef void set_daxpy(CBlas cblas, daxpy_ptr daxpy) noexcept nogil:
     deref(cblas.ptr).daxpy = daxpy
 
-cdef void set_saxpy(CBlas cblas, saxpy_ptr saxpy) nogil:
+cdef void set_saxpy(CBlas cblas, saxpy_ptr saxpy) noexcept nogil:
     deref(cblas.ptr).saxpy = saxpy
 
-cdef void set_sgemm(CBlas cblas, sgemm_ptr sgemm) nogil:
+cdef void set_sgemm(CBlas cblas, sgemm_ptr sgemm) noexcept nogil:
     deref(cblas.ptr).sgemm = sgemm
 
-cdef void set_dgemm(CBlas cblas, dgemm_ptr dgemm) nogil:
+cdef void set_dgemm(CBlas cblas, dgemm_ptr dgemm) noexcept nogil:
     deref(cblas.ptr).dgemm = dgemm
 
-cdef void set_sscal(CBlas cblas, sscal_ptr sscal) nogil:
+cdef void set_sscal(CBlas cblas, sscal_ptr sscal) noexcept nogil:
     deref(cblas.ptr).sscal = sscal
 
-cdef void set_dscal(CBlas cblas, dscal_ptr dscal) nogil:
+cdef void set_dscal(CBlas cblas, dscal_ptr dscal) noexcept nogil:
     deref(cblas.ptr).dscal = dscal


### PR DESCRIPTION
Update cython dependency to support python 3.13

## Description

1. Update cython dependency
2. It failed build, so I added `noexcept` annotation

not all deprecations and other warnings fixed, it only runs on 3.13

### Types of change

bug fix? for compatibility

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

tests failed on local but seems not related / is deprecation
```
============================================== short test summary info ===============================================
FAILED thinc/tests/backends/test_ops.py::test_ops_consistency[NumpyOps] - AssertionError: alloc
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func0-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func0-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func0-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func0-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func1-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func1-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func1-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func1-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func2-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func2-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func2-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func2-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func3-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func3-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func3-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func3-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func4-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func4-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func4-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func4-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func5-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func5-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func5-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func5-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func6-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func6-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func6-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func6-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func7-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func7-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func7-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func7-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func8-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func8-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func8-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func8-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func9-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func9-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func9-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func9-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func10-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func10-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func10-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func10-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func11-float32-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func11-float32-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func11-float64-ops0] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/backends/test_ops.py::test_compare_activations_to_torch[torch_func11-float64-ops1] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ens...
FAILED thinc/tests/layers/test_layers_api.py::test_layers_from_config[SparseLinear.v1-kwargs55-in_data55-out_data55] - NameError: name 'InT' is not defined
FAILED thinc/tests/layers/test_layers_api.py::test_layers_from_config[SparseLinear.v2-kwargs56-in_data56-out_data56] - NameError: name 'InT' is not defined
FAILED thinc/tests/layers/test_layers_api.py::test_layers_from_config[premap_ids.v1-kwargs59-in_data59-out_data59] - NameError: name 'InT' is not defined
FAILED thinc/tests/layers/test_layers_api.py::test_dropout[data2] - thinc.util.DataValidationError: 
FAILED thinc/tests/layers/test_layers_api.py::test_layers_batching_all[premap_ids.v1-kwargs59-in_data59-out_data59] - NameError: name 'InT' is not defined
=============================== 54 failed, 1252 passed, 86 skipped in 71.37s (0:01:11) ===============================
```