### PR TITLE
Upgrade from deprecated macos-13 to macos-15-intel in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,12 +44,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15-intel]
         python_version: ["3.12"]
         include:
           - os: windows-latest
             python_version: "3.10"
-          - os: macos-13
+          - os: macos-15-intel
             python_version: "3.10"
           - os: ubuntu-latest
             python_version: "3.11"
@@ -156,8 +156,8 @@ jobs:
           pip uninstall -y tensorflow
           pip install "thinc-apple-ops>=1.0.0,<2.0.0"
           python -m pytest --pyargs thinc_apple_ops
-        if: matrix.os == 'macos-13' && matrix.python_version == '3.10'
+        if: matrix.os == 'macos-15-intel' && matrix.python_version == '3.10'
 
       - name: Run tests with thinc-apple-ops
         run: python -m pytest --pyargs thinc
-        if: matrix.os == 'macos-13' && matrix.python_version == '3.10'
+        if: matrix.os == 'macos-15-intel' && matrix.python_version == '3.10'


### PR DESCRIPTION
Replace GitHub Actions runner image `macos-13` with `macos-15-intel` as recommended in:
* https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down
> The macOS 13 runner image will be retired by ___December 4th, 2025___.

The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |

<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
