### PR TITLE
Fix(util): ensure seed is < 2**23 for np.random.seed()

### DIFF
--- a/thinc/util.py
+++ b/thinc/util.py
@@ -95,10 +95,16 @@ def fix_random_seed(seed: int = 0) -> None:  # pragma: no cover
     random.seed(seed)
     numpy.random.seed(seed % 2**32)
     if has_torch:
-        torch.manual_seed(seed)
+        # Must be within the inclusive range [-0x8000_0000_0000_0000, 0xffff_ffff_ffff_ffff]
+        # https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/random.py#L32-L41
+        torch.manual_seed(seed % 0xffff_ffff_ffff_ffff)
     if has_cupy_gpu:
+        # cupy has no documented range limit on seed as of 2026-01-15
+        # https://docs.cupy.dev/en/latest/reference/generated/cupy.random.seed.html
         cupy.random.seed(seed)
         if has_torch and has_torch_cuda_gpu:
+            # torch.cuda has no documented range limit on seed as of 2026-01-15
+            # https://docs.pytorch.org/docs/stable/generated/torch.cuda.manual_seed_all.html
             torch.cuda.manual_seed_all(seed)
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False

--- a/thinc/util.py
+++ b/thinc/util.py
@@ -93,7 +93,7 @@ def gpu_is_available():
 def fix_random_seed(seed: int = 0) -> None:  # pragma: no cover
     """Set the random seed across random, numpy.random and cupy.random."""
     random.seed(seed)
-    numpy.random.seed(seed)
+    numpy.random.seed(seed % 2**32)
     if has_torch:
         torch.manual_seed(seed)
     if has_cupy_gpu:


### PR DESCRIPTION
## Description

Fixes https://github.com/pytest-dev/pytest-randomly/issues/689 and https://github.com/explosion/thinc/issues/960

np.random.seed() only works with seeds in range 0 to (2**32)-1. However, in our util function, we accept an arbitrary python int, which could be larger than this. Now, we modulo the given seed to the acceptable range for numpy. 

torch says it needs a seed in the range [-0x8000_0000_0000_0000, 0xffff_ffff_ffff_ffff], so I fixed that as well.

The other backends, such as cupy and cuda, mention no range limits in their docs, so I will leave them as-is for now.

I ran into this when using this library with pytest-randomly, which calls `fix_random_seed(an int possibly larger than 2**32-1)` during test initialization using [the 'pytest_randomly.random_seeder' entry point](https://github.com/explosion/thinc/blob/ac9663f92f9285f31029ca3cdb72a49a6dbc621b/setup.cfg#L54-L56).  

### Types of change

Fix

## Checklist

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
