### PR TITLE
fix: remove setuptools runtime dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ install_requires =
     catalogue>=2.0.4,<2.1.0
     confection>=1.3.2,<2.0.0
     # Third-party dependencies
-    setuptools
     numpy>=1.21.0,<3.0.0
     pydantic>=2.0.0,<3.0.0
     packaging>=20.0


### PR DESCRIPTION
Fixes #971.

## What changed

Removed `setuptools` from `install_requires` in `setup.cfg`.

## Why

`setuptools` is a build-time dependency for Thinc and remains correctly declared in the PEP 517 `[build-system]` requirements in `pyproject.toml`. It is not imported by Thinc at runtime, so listing it in `install_requires` unnecessarily installs it into user environments as a runtime dependency.

## Validation

- parsed `setup.cfg` with Python `ConfigParser` and verified the runtime dependency list still contains 11 entries, includes NumPy, and no longer includes `setuptools`
- `git diff --check`

A full wheel build was not run because the local environment does not have the repository's Cython/NumPy build toolchain installed. The build-system declaration itself is unchanged.